### PR TITLE
Improve dbCAN mapping and CAZy overview plots

### DIFF
--- a/R/Output_combiner.R
+++ b/R/Output_combiner.R
@@ -585,6 +585,18 @@ dnmb_module_block_columns <- function(genbank_table, prefix) {
     dbCAN = c(
       "dbcan_hit",
       "family_id",
+      "dbcan_all_families",
+      "dbcan_primary_family",
+      "dbcan_domain_architecture",
+      "dbcan_hmm_domain_architecture",
+      "dbcan_hmm_domain_count",
+      "dbcan_evidence_tier",
+      "dbcan_evidence_sources",
+      "dbcan_tool_count",
+      "dbcan_consensus",
+      "dbcan_ec",
+      "substrate_label",
+      "dbcan_substrate_source",
       "support",
       "profile_id",
       "evalue",
@@ -596,6 +608,7 @@ dnmb_module_block_columns <- function(genbank_table, prefix) {
       "gene_start",
       "gene_end",
       "dbcan_cgc_id",
+      "dbcan_contig_key",
       "dbcan_cgc_gene_type",
       "dbcan_cgc_protein_family",
       "dbcan_pul_id",
@@ -1206,12 +1219,15 @@ dnmb_module_details_dbcan <- function(genbank_table, base_cols) {
   out$primary_call <- if ("dbCAN_dbcan_hit" %in% names(genbank_table)) as.character(genbank_table$dbCAN_dbcan_hit[keep]) else as.character(genbank_table$dbCAN_family_id[keep])
   out$reference_id <- dnmb_detail_join(
     if ("dbCAN_profile_id" %in% names(genbank_table)) paste0("profile=", as.character(genbank_table$dbCAN_profile_id[keep])) else NA_character_,
-    if ("dbCAN_family_id" %in% names(genbank_table)) paste0("family=", as.character(genbank_table$dbCAN_family_id[keep])) else NA_character_
+    if ("dbCAN_family_id" %in% names(genbank_table)) paste0("family=", as.character(genbank_table$dbCAN_family_id[keep])) else NA_character_,
+    if ("dbCAN_dbcan_domain_architecture" %in% names(genbank_table)) paste0("domains=", as.character(genbank_table$dbCAN_dbcan_domain_architecture[keep])) else NA_character_
   )
   out$significance <- dnmb_detail_key_value("evalue", if ("dbCAN_evalue" %in% names(genbank_table)) genbank_table$dbCAN_evalue[keep] else NA, digits = 3)
   out$score_summary <- dnmb_detail_join(
     dnmb_detail_key_value("coverage", if ("dbCAN_coverage" %in% names(genbank_table)) genbank_table$dbCAN_coverage[keep] else NA, digits = 3),
-    if ("dbCAN_support" %in% names(genbank_table)) paste0("support=", as.character(genbank_table$dbCAN_support[keep])) else NA_character_
+    if ("dbCAN_support" %in% names(genbank_table)) paste0("support=", as.character(genbank_table$dbCAN_support[keep])) else NA_character_,
+    if ("dbCAN_dbcan_evidence_tier" %in% names(genbank_table)) paste0("tier=", as.character(genbank_table$dbCAN_dbcan_evidence_tier[keep])) else NA_character_,
+    if ("dbCAN_dbcan_tool_count" %in% names(genbank_table)) paste0("tools=", as.character(genbank_table$dbCAN_dbcan_tool_count[keep])) else NA_character_
   )
   out$alignment_summary <- dnmb_detail_join(
     dnmb_detail_span("profile", if ("dbCAN_profile_start" %in% names(genbank_table)) genbank_table$dbCAN_profile_start[keep] else NA, if ("dbCAN_profile_end" %in% names(genbank_table)) genbank_table$dbCAN_profile_end[keep] else NA, if ("dbCAN_profile_length" %in% names(genbank_table)) genbank_table$dbCAN_profile_length[keep] else NA),
@@ -1226,7 +1242,9 @@ dnmb_module_details_dbcan <- function(genbank_table, base_cols) {
     dnmb_detail_key_value("pul_bitscore", if ("dbCAN_dbcan_pul_bitscore" %in% names(genbank_table)) genbank_table$dbCAN_dbcan_pul_bitscore[keep] else NA, digits = 3),
     if ("dbCAN_dbcan_pul_signature_pairs" %in% names(genbank_table)) paste0("signature=", as.character(genbank_table$dbCAN_dbcan_pul_signature_pairs[keep])) else NA_character_,
     if ("dbCAN_dbcan_sub_substrate" %in% names(genbank_table)) paste0("dbcan_sub=", as.character(genbank_table$dbCAN_dbcan_sub_substrate[keep])) else NA_character_,
-    if ("dbCAN_dbcan_sub_score" %in% names(genbank_table)) paste0("dbcan_sub_score=", as.character(genbank_table$dbCAN_dbcan_sub_score[keep])) else NA_character_
+    if ("dbCAN_dbcan_sub_score" %in% names(genbank_table)) paste0("dbcan_sub_score=", as.character(genbank_table$dbCAN_dbcan_sub_score[keep])) else NA_character_,
+    if ("dbCAN_substrate_label" %in% names(genbank_table)) paste0("substrate=", as.character(genbank_table$dbCAN_substrate_label[keep])) else NA_character_,
+    if ("dbCAN_dbcan_substrate_source" %in% names(genbank_table)) paste0("substrate_source=", as.character(genbank_table$dbCAN_dbcan_substrate_source[keep])) else NA_character_
   )
   out
 }

--- a/R/comparative_dbcan.R
+++ b/R/comparative_dbcan.R
@@ -135,24 +135,20 @@ dnmb_plot_comparative_dbcan_family <- function(
 # ---- dbCAN-specific collector ----
 
 .dnmb_comparative_dbcan_token <- function(call, level = c("class", "family")) {
-  # Calls look like "GH13_3", "GT2", "CE1(24-257)", "GH18_e66|CBM5_e25",
-  # "CBM50_e705|CBM50_e699|GH18_e157". Take the first "|"-separated token,
-  # strip any "(...)" positional suffix, then either collapse to the
-  # leading alphabetic prefix (class) or to the alpha+digit head (family,
-  # with the "_subfamily" suffix dropped so GH13_3 rolls into GH13).
+  # A dbCAN call may contain several domains. Count each unique gene-family
+  # pair instead of silently keeping only the first token.
   level <- match.arg(level)
   x <- as.character(call)
-  x[is.na(x) | x == "-" | !nzchar(x)] <- NA_character_
-  first <- vapply(strsplit(x, "[|+]"), function(v) if (length(v)) v[[1]] else NA_character_,
-                  character(1))
-  first <- sub("\\(.*$", "", first)
-  if (level == "class") {
-    out <- sub("^([A-Za-z]+).*$", "\\1", first)
-  } else {
-    out <- sub("^([A-Za-z]+\\d+).*$", "\\1", first)
-  }
-  out[!nzchar(out)] <- NA_character_
-  out
+  token_list <- lapply(x, function(value) {
+    families <- .dnmb_dbcan_family_tokens(value)
+    if (!length(families)) return(character())
+    if (level == "class") {
+      unique(sub("^([A-Za-z]+).*$", "\\1", families))
+    } else {
+      unique(sub("^([A-Za-z]+[0-9]+).*$", "\\1", families))
+    }
+  })
+  unname(unlist(token_list, use.names = FALSE))
 }
 
 .dnmb_comparative_collect_dbcan <- function(data_root, marker_rel,
@@ -177,25 +173,12 @@ dnmb_plot_comparative_dbcan_family <- function(
       if (verbose) message("  ", genome_id, " — 0 CAZymes (not analyzed)")
       next
     }
-    tab <- tryCatch(
-      utils::read.delim(marker_path, header = TRUE, stringsAsFactors = FALSE,
-                        na.strings = c("", "NA", "-"), check.names = FALSE,
-                        quote = "", comment.char = ""),
-      error = function(e) NULL
-    )
+    tab <- tryCatch(dnmb_dbcan_parse_overview(marker_path), error = function(e) NULL)
     if (is.null(tab) || !nrow(tab)) {
       if (verbose) message("  ", genome_id, " — 0 CAZymes (analyzed, empty)")
       next
     }
-    # Prefer Recommend Results, then dbCAN_sub, then dbCAN_hmm, then DIAMOND.
-    pick <- rep(NA_character_, nrow(tab))
-    for (col in c("Recommend Results", "dbCAN_sub", "dbCAN_hmm", "DIAMOND")) {
-      if (!col %in% names(tab)) next
-      val <- as.character(tab[[col]])
-      take <- is.na(pick) & !is.na(val) & nzchar(val) & val != "-"
-      pick[take] <- val[take]
-    }
-    tokens <- .dnmb_comparative_dbcan_token(pick, level = level)
+    tokens <- .dnmb_comparative_dbcan_token(tab$dbcan_all_families, level = level)
     tokens <- tokens[!is.na(tokens) & nzchar(tokens)]
     if (!length(tokens)) {
       if (verbose) message("  ", genome_id, " — 0 CAZymes (analyzed, empty)")

--- a/R/db_module_dbcan.R
+++ b/R/db_module_dbcan.R
@@ -10,6 +10,10 @@
   "5.2.9"
 }
 
+.dnmb_dbcan_pipeline_contract_version <- function() {
+  2L
+}
+
 .dnmb_dbcan_default_base_url <- function() {
   "https://pro.unl.edu/dbCAN2/download/Databases"
 }
@@ -344,6 +348,445 @@
   clean
 }
 
+.dnmb_dbcan_clean_query_id <- function(x) {
+  x <- trimws(as.character(x))
+  x <- sub("^>", "", x)
+  x <- sub("[[:space:]].*$", "", x)
+  x <- gsub("^gnl\\|", "", x)
+  x <- gsub("\\|", ":", x)
+  x <- gsub(
+    "^lcl:(AC|NC|BG|NT|NW|NZ)_([A-Za-z]+)?[0-9]+\\.[0-9]+_prot_",
+    "",
+    x
+  )
+  x <- gsub("^extdb:", "", x)
+  x[nchar(x) == 0L] <- NA_character_
+  x
+}
+
+.dnmb_dbcan_missing_value <- function(x) {
+  x <- trimws(as.character(x))
+  is.na(x) | !nzchar(x) | tolower(x) %in% c("-", "na", "n/a", "none", "null")
+}
+
+.dnmb_dbcan_contig_keys <- function(genes) {
+  n <- nrow(genes)
+  display <- if ("contig" %in% names(genes)) as.character(genes$contig) else rep(NA_character_, n)
+  key <- rep(NA_character_, n)
+
+  if ("contig_number" %in% names(genes)) {
+    number <- suppressWarnings(as.integer(genes$contig_number))
+    use <- !is.na(number)
+    key[use] <- sprintf("replicon_%04d", number[use])
+  }
+
+  accession_columns <- c("record_accession", "contig_accession", "accession", "sequence_id")
+  for (column_name in accession_columns[accession_columns %in% names(genes)]) {
+    value <- .dnmb_dbcan_clean_query_id(genes[[column_name]])
+    use <- is.na(key) & !is.na(value) & nzchar(value)
+    key[use] <- value[use]
+  }
+
+  fallback <- gsub("[^A-Za-z0-9_.-]+", "_", display)
+  fallback[is.na(fallback) | !nzchar(fallback)] <- "unknown_replicon"
+  key[is.na(key)] <- fallback[is.na(key)]
+  list(key = key, display = display)
+}
+
+.dnmb_dbcan_build_gene_map <- function(genes) {
+  if (!is.data.frame(genes)) {
+    stop("`genes` must be a data frame.", call. = FALSE)
+  }
+  n <- nrow(genes)
+  value_or_na <- function(column_name) {
+    if (column_name %in% names(genes)) as.character(genes[[column_name]]) else rep(NA_character_, n)
+  }
+
+  locus_tag <- .dnmb_dbcan_clean_query_id(value_or_na("locus_tag"))
+  protein_id <- .dnmb_dbcan_clean_query_id(value_or_na("protein_id"))
+  translation <- if ("translation" %in% names(genes)) {
+    .dnmb_normalize_translation(genes$translation)
+  } else {
+    rep(NA_character_, n)
+  }
+  contigs <- .dnmb_dbcan_contig_keys(genes)
+  start <- suppressWarnings(as.numeric(value_or_na("start")))
+  end <- suppressWarnings(as.numeric(value_or_na("end")))
+  direction <- value_or_na("direction")
+
+  mapping_source <- ifelse(!is.na(locus_tag), "locus_tag", ifelse(!is.na(protein_id), "protein_id", "coordinate"))
+  coordinate_id <- paste0(
+    contigs$key,
+    ":",
+    ifelse(is.finite(start), format(start, scientific = FALSE, trim = TRUE), "NA"),
+    "-",
+    ifelse(is.finite(end), format(end, scientific = FALSE, trim = TRUE), "NA"),
+    ":",
+    ifelse(is.na(direction) | !nzchar(direction), ".", direction)
+  )
+  mapping_id <- ifelse(!is.na(locus_tag), locus_tag, ifelse(!is.na(protein_id), protein_id, coordinate_id))
+
+  out <- tibble::tibble(
+    dbcan_gene_row = seq_len(n),
+    dbcan_query_id = sprintf("DNMBCAZY_%07d", seq_len(n)),
+    mapping_id = mapping_id,
+    mapping_source = mapping_source,
+    locus_tag = locus_tag,
+    protein_id = protein_id,
+    dbcan_contig_key = contigs$key,
+    contig = contigs$display,
+    start = start,
+    end = end,
+    direction = direction,
+    translation = translation
+  )
+  out
+}
+
+.dnmb_dbcan_write_gene_map <- function(id_map, path) {
+  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+  columns <- setdiff(names(id_map), "translation")
+  utils::write.table(
+    as.data.frame(id_map[, columns, drop = FALSE], stringsAsFactors = FALSE),
+    file = path,
+    sep = "\t",
+    row.names = FALSE,
+    col.names = TRUE,
+    quote = FALSE,
+    na = ""
+  )
+  invisible(path)
+}
+
+.dnmb_dbcan_write_mapped_query_fasta <- function(id_map, path) {
+  id_map <- id_map[!is.na(id_map$translation) & nzchar(id_map$translation), , drop = FALSE]
+  fasta <- tibble::tibble(
+    protein_label = id_map$dbcan_query_id,
+    protein_seq = id_map$translation
+  )
+  .dnmb_write_protein_fasta(fasta, path)
+  list(path = path, proteins = id_map, n = nrow(id_map))
+}
+
+.dnmb_dbcan_restore_query_map <- function(tbl, id_map) {
+  if (is.null(tbl) || !is.data.frame(tbl) || !nrow(tbl) ||
+      is.null(id_map) || !is.data.frame(id_map) || !nrow(id_map) ||
+      !"query" %in% names(tbl)) {
+    return(tbl)
+  }
+  out <- as.data.frame(tbl, stringsAsFactors = FALSE)
+  query_id <- .dnmb_dbcan_clean_query_id(out$query)
+  idx <- match(query_id, id_map$dbcan_query_id)
+  out$dbcan_query_id <- query_id
+  out$dbcan_gene_row <- id_map$dbcan_gene_row[idx]
+  out$dbcan_mapping_source <- id_map$mapping_source[idx]
+  out$dbcan_contig_key <- id_map$dbcan_contig_key[idx]
+  mapped <- !is.na(idx)
+  out$query[mapped] <- id_map$mapping_id[idx[mapped]]
+  out$query[!mapped] <- query_id[!mapped]
+  tibble::as_tibble(out)
+}
+
+.dnmb_dbcan_raw_domain_tokens <- function(call) {
+  x <- trimws(as.character(call)[1])
+  if (.dnmb_dbcan_missing_value(x)) return(character())
+  tokens <- trimws(unlist(strsplit(x, "[|+;]", perl = TRUE), use.names = FALSE))
+  tokens <- sub("\\([^)]*\\)$", "", tokens)
+  tokens <- tokens[! .dnmb_dbcan_missing_value(tokens)]
+  tokens
+}
+
+.dnmb_dbcan_family_tokens <- function(call) {
+  tokens <- .dnmb_dbcan_raw_domain_tokens(call)
+  if (!length(tokens)) return(character())
+  tokens <- sub("\\.hmm$", "", tokens, ignore.case = TRUE)
+  tokens <- sub("_e[0-9]+$", "", tokens, ignore.case = TRUE)
+  family <- sub(
+    "^((?:AA|CBM|CE|GH|GT|PL)[0-9]+(?:_[0-9]+)?).*$",
+    "\\1",
+    tokens,
+    perl = TRUE,
+    ignore.case = TRUE
+  )
+  valid <- grepl("^(AA|CBM|CE|GH|GT|PL)[0-9]+(?:_[0-9]+)?$", family, perl = TRUE, ignore.case = TRUE)
+  unique(toupper(family[valid]))
+}
+
+.dnmb_dbcan_primary_family <- function(families) {
+  families <- as.character(families)
+  families <- families[!is.na(families) & nzchar(families)]
+  if (!length(families)) return(NA_character_)
+  catalytic <- families[grepl("^(AA|CE|GH|GT|PL)", families)]
+  if (length(catalytic)) catalytic[[1]] else families[[1]]
+}
+
+.dnmb_dbcan_normalize_substrate <- function(x) {
+  x <- trimws(as.character(x)[1])
+  if (.dnmb_dbcan_missing_value(x)) return(NA_character_)
+  values <- trimws(unlist(strsplit(x, "[;,]", perl = TRUE), use.names = FALSE))
+  values <- values[! .dnmb_dbcan_missing_value(values)]
+  values <- gsub("^hostglycan$", "host glycan", values, ignore.case = TRUE)
+  values <- unique(values)
+  if (!length(values)) NA_character_ else paste(values, collapse = "; ")
+}
+
+.dnmb_dbcan_empty_overview <- function() {
+  tibble::tibble(
+    query = character(),
+    dbcan_ec = character(),
+    dbcan_hmm_call = character(),
+    dbcan_subfamily_call = character(),
+    dbcan_diamond_call = character(),
+    dbcan_tool_count = integer(),
+    dbcan_recommended = character(),
+    dbcan_overview_substrate = character(),
+    dbcan_evidence_sources = character(),
+    dbcan_evidence_tier = character(),
+    dbcan_consensus = logical(),
+    dbcan_domain_architecture = character(),
+    dbcan_all_families = character(),
+    dbcan_primary_family = character(),
+    dbcan_family_count = integer()
+  )
+}
+
+dnmb_dbcan_parse_overview <- function(path, id_map = NULL) {
+  if (!file.exists(path) || !isTRUE(file.info(path)$size > 0)) {
+    return(.dnmb_dbcan_empty_overview())
+  }
+  tbl <- tryCatch(
+    utils::read.delim(
+      path,
+      sep = "\t",
+      header = TRUE,
+      stringsAsFactors = FALSE,
+      fill = TRUE,
+      check.names = FALSE,
+      quote = "",
+      comment.char = ""
+    ),
+    error = function(e) NULL
+  )
+  if (is.null(tbl) || !nrow(tbl)) return(.dnmb_dbcan_empty_overview())
+
+  column <- function(candidates, default = NA_character_) {
+    found <- candidates[candidates %in% names(tbl)]
+    if (length(found)) as.character(tbl[[found[[1]]]]) else rep(default, nrow(tbl))
+  }
+  query <- .dnmb_dbcan_clean_query_id(column(c("Gene ID", "Gene.ID", "query", "Protein ID")))
+  ec <- column(c("EC#", "EC", "EC number"))
+  hmm <- column(c("dbCAN_hmm", "HMMER"))
+  subfamily <- column(c("dbCAN_sub", "dbCAN-sub"))
+  diamond <- column(c("DIAMOND", "diamond"))
+  recommended <- column(c("Recommend Results", "Recommended Results", "Recommend.Results"))
+  substrate <- column(c("Substrate", "substrate"))
+  tool_count <- suppressWarnings(as.integer(column(c("#ofTools", "ofTools", "Tools"))))
+
+  has_hmm <- !.dnmb_dbcan_missing_value(hmm)
+  has_sub <- !.dnmb_dbcan_missing_value(subfamily)
+  has_diamond <- !.dnmb_dbcan_missing_value(diamond)
+  inferred_count <- as.integer(has_hmm) + as.integer(has_sub) + as.integer(has_diamond)
+  tool_count[is.na(tool_count)] <- inferred_count[is.na(tool_count)]
+
+  chosen <- recommended
+  for (candidate in list(subfamily, hmm, diamond)) {
+    take <- .dnmb_dbcan_missing_value(chosen) & !.dnmb_dbcan_missing_value(candidate)
+    chosen[take] <- candidate[take]
+  }
+  family_list <- lapply(chosen, .dnmb_dbcan_family_tokens)
+  domain_list <- lapply(chosen, .dnmb_dbcan_raw_domain_tokens)
+  all_families <- vapply(
+    family_list,
+    function(x) if (length(x)) paste(x, collapse = "; ") else NA_character_,
+    character(1)
+  )
+  architecture <- vapply(
+    domain_list,
+    function(x) if (length(x)) paste(x, collapse = " | ") else NA_character_,
+    character(1)
+  )
+  primary <- vapply(family_list, .dnmb_dbcan_primary_family, character(1))
+  family_count <- vapply(family_list, length, integer(1))
+  sources <- vapply(seq_len(nrow(tbl)), function(i) {
+    source <- c("HMM", "dbCAN-sub", "DIAMOND")[c(has_hmm[[i]], has_sub[[i]], has_diamond[[i]])]
+    if (length(source)) paste(source, collapse = "+") else NA_character_
+  }, character(1))
+  consensus <- tool_count >= 2L & !.dnmb_dbcan_missing_value(recommended)
+  tier <- ifelse(
+    tool_count >= 3L & consensus,
+    "very_high",
+    ifelse(
+      consensus,
+      "high",
+      ifelse(has_hmm, "medium", ifelse(has_sub, "low", "audit"))
+    )
+  )
+
+  out <- tibble::tibble(
+    query = query,
+    dbcan_ec = vapply(ec, function(x) {
+      value <- trimws(as.character(x))
+      if (.dnmb_dbcan_missing_value(value)) NA_character_ else value
+    }, character(1)),
+    dbcan_hmm_call = ifelse(has_hmm, hmm, NA_character_),
+    dbcan_subfamily_call = ifelse(has_sub, subfamily, NA_character_),
+    dbcan_diamond_call = ifelse(has_diamond, diamond, NA_character_),
+    dbcan_tool_count = tool_count,
+    dbcan_recommended = ifelse(.dnmb_dbcan_missing_value(recommended), NA_character_, recommended),
+    dbcan_overview_substrate = vapply(substrate, .dnmb_dbcan_normalize_substrate, character(1)),
+    dbcan_evidence_sources = sources,
+    dbcan_evidence_tier = tier,
+    dbcan_consensus = consensus,
+    dbcan_domain_architecture = architecture,
+    dbcan_all_families = all_families,
+    dbcan_primary_family = primary,
+    dbcan_family_count = family_count
+  )
+  out <- out[!is.na(out$query) & nzchar(out$query) & !is.na(out$dbcan_all_families), , drop = FALSE]
+  .dnmb_dbcan_restore_query_map(out, id_map)
+}
+
+.dnmb_dbcan_family_substrate_map <- function(path) {
+  empty <- tibble::tibble(
+    family = character(),
+    dbcan_family_substrate_prior = character()
+  )
+  if (is.null(path) || !file.exists(path) || !isTRUE(file.info(path)$size > 0)) return(empty)
+  tbl <- tryCatch(
+    utils::read.delim(
+      path,
+      sep = "\t",
+      header = TRUE,
+      stringsAsFactors = FALSE,
+      fill = TRUE,
+      check.names = FALSE,
+      comment.char = "#",
+      quote = "\""
+    ),
+    error = function(e) NULL
+  )
+  if (is.null(tbl) || !nrow(tbl)) return(empty)
+  names(tbl) <- trimws(names(tbl))
+  required <- c("Family", "Substrate_high_level")
+  if (!all(required %in% names(tbl))) return(empty)
+  removed <- if ("type" %in% names(tbl)) toupper(trimws(as.character(tbl$type))) == "REMOVED" else rep(FALSE, nrow(tbl))
+  preferred <- if ("new_Substrate_high_level" %in% names(tbl)) as.character(tbl$new_Substrate_high_level) else rep(NA_character_, nrow(tbl))
+  original <- as.character(tbl$Substrate_high_level)
+  substrate <- ifelse(!.dnmb_dbcan_missing_value(preferred), preferred, original)
+  family <- toupper(trimws(as.character(tbl$Family)))
+  keep <- !removed & !.dnmb_dbcan_missing_value(family) & !.dnmb_dbcan_missing_value(substrate)
+  if (!any(keep)) return(empty)
+  data.frame(family = family[keep], substrate = substrate[keep], stringsAsFactors = FALSE) |>
+    dplyr::group_by(.data$family) |>
+    dplyr::summarise(
+      dbcan_family_substrate_prior = paste(sort(unique(.data$substrate)), collapse = "; "),
+      .groups = "drop"
+    )
+}
+
+.dnmb_dbcan_add_family_substrate_prior <- function(overview, mapping_path) {
+  if (is.null(overview) || !is.data.frame(overview) || !nrow(overview)) return(overview)
+  mapping <- .dnmb_dbcan_family_substrate_map(mapping_path)
+  out <- as.data.frame(overview, stringsAsFactors = FALSE)
+  out$dbcan_family_substrate_prior <- NA_character_
+  if (!nrow(mapping)) return(tibble::as_tibble(out))
+  prior_map <- stats::setNames(mapping$dbcan_family_substrate_prior, mapping$family)
+  out$dbcan_family_substrate_prior <- vapply(out$dbcan_all_families, function(value) {
+    families <- .dnmb_dbcan_family_tokens(value)
+    if (!length(families)) return(NA_character_)
+    substrates <- unname(prior_map[families])
+    missing <- is.na(substrates) | !nzchar(substrates)
+    if (any(missing)) {
+      parent <- sub("^([A-Z]+[0-9]+).*$", "\\1", families[missing])
+      substrates[missing] <- unname(prior_map[parent])
+    }
+    substrates <- unlist(strsplit(substrates[!is.na(substrates) & nzchar(substrates)], ";\\s*", perl = TRUE), use.names = FALSE)
+    substrates <- sort(unique(trimws(substrates[nzchar(trimws(substrates))])))
+    if (length(substrates)) paste(substrates, collapse = "; ") else NA_character_
+  }, character(1))
+  tibble::as_tibble(out)
+}
+
+.dnmb_dbcan_merge_overview_hits <- function(hits, overview) {
+  if (is.null(overview) || !is.data.frame(overview) || !nrow(overview)) return(hits)
+  hits <- as.data.frame(hits, stringsAsFactors = FALSE)
+  overview <- as.data.frame(overview, stringsAsFactors = FALSE)
+
+  hit_idx <- if (nrow(hits) && "dbcan_gene_row" %in% names(hits) && "dbcan_gene_row" %in% names(overview)) {
+    match(hits$dbcan_gene_row, overview$dbcan_gene_row)
+  } else if (nrow(hits)) {
+    match(.dnmb_dbcan_clean_query_id(hits$query), .dnmb_dbcan_clean_query_id(overview$query))
+  } else integer()
+  if (nrow(hits)) {
+    metadata_columns <- c(
+      "dbcan_tool_count", "dbcan_evidence_sources", "dbcan_evidence_tier",
+      "dbcan_consensus", "dbcan_all_families", "dbcan_primary_family",
+      "dbcan_domain_architecture", "dbcan_ec", "dbcan_overview_substrate",
+      "dbcan_family_substrate_prior"
+    )
+    for (column_name in metadata_columns[metadata_columns %in% names(overview)]) {
+      hits[[column_name]] <- overview[[column_name]][hit_idx]
+    }
+    direct_substrate <- if ("dbcan_overview_substrate" %in% names(overview)) overview$dbcan_overview_substrate[hit_idx] else NA_character_
+    hits$substrate_label <- ifelse(!is.na(direct_substrate) & nzchar(direct_substrate), direct_substrate, hits$substrate_label)
+    tier <- if ("dbcan_evidence_tier" %in% names(hits)) hits$dbcan_evidence_tier else NA_character_
+    hits$typing_eligible <- tier %in% c("very_high", "high", "medium")
+  }
+
+  represented <- if (nrow(hits) && "dbcan_gene_row" %in% names(hits)) {
+    unique(hits$dbcan_gene_row[!is.na(hits$dbcan_gene_row)])
+  } else if (nrow(hits)) {
+    unique(.dnmb_dbcan_clean_query_id(hits$query))
+  } else {
+    integer()
+  }
+  missing <- if ("dbcan_gene_row" %in% names(overview) && length(represented) && is.numeric(represented)) {
+    !overview$dbcan_gene_row %in% represented
+  } else if ("dbcan_gene_row" %in% names(overview) && !length(represented)) {
+    rep(TRUE, nrow(overview))
+  } else {
+    !.dnmb_dbcan_clean_query_id(overview$query) %in% represented
+  }
+
+  synthetic <- lapply(which(missing), function(i) {
+    families <- .dnmb_dbcan_family_tokens(overview$dbcan_all_families[[i]])
+    if (!length(families)) return(NULL)
+    substrate <- overview$dbcan_overview_substrate[[i]]
+    if (is.na(substrate) || !nzchar(substrate)) substrate <- overview$dbcan_family_substrate_prior[[i]] %||% NA_character_
+    data.frame(
+      query = rep(overview$query[[i]], length(families)),
+      source = rep("dbcan_overview", length(families)),
+      family_system = rep("dbCAN", length(families)),
+      family_id = families,
+      hit_label = families,
+      enzyme_role = rep("CAZyme", length(families)),
+      evidence_mode = rep(if (isTRUE(overview$dbcan_consensus[[i]])) "consensus" else "single_tool", length(families)),
+      substrate_label = rep(substrate, length(families)),
+      support = rep(paste0(
+        "tools=", overview$dbcan_tool_count[[i]],
+        "; tier=", overview$dbcan_evidence_tier[[i]],
+        "; sources=", overview$dbcan_evidence_sources[[i]]
+      ), length(families)),
+      typing_eligible = rep(overview$dbcan_evidence_tier[[i]] %in% c("very_high", "high", "medium"), length(families)),
+      dbcan_query_id = rep(overview$dbcan_query_id[[i]] %||% NA_character_, length(families)),
+      dbcan_gene_row = rep(overview$dbcan_gene_row[[i]] %||% NA_integer_, length(families)),
+      dbcan_mapping_source = rep(overview$dbcan_mapping_source[[i]] %||% NA_character_, length(families)),
+      dbcan_contig_key = rep(overview$dbcan_contig_key[[i]] %||% NA_character_, length(families)),
+      dbcan_tool_count = rep(overview$dbcan_tool_count[[i]], length(families)),
+      dbcan_evidence_sources = rep(overview$dbcan_evidence_sources[[i]], length(families)),
+      dbcan_evidence_tier = rep(overview$dbcan_evidence_tier[[i]], length(families)),
+      dbcan_consensus = rep(overview$dbcan_consensus[[i]], length(families)),
+      dbcan_all_families = rep(overview$dbcan_all_families[[i]], length(families)),
+      dbcan_primary_family = rep(overview$dbcan_primary_family[[i]], length(families)),
+      dbcan_domain_architecture = rep(overview$dbcan_domain_architecture[[i]], length(families)),
+      dbcan_ec = rep(overview$dbcan_ec[[i]], length(families)),
+      dbcan_overview_substrate = rep(overview$dbcan_overview_substrate[[i]], length(families)),
+      stringsAsFactors = FALSE
+    )
+  })
+  tibble::as_tibble(dplyr::bind_rows(hits, dplyr::bind_rows(synthetic)))
+}
+
 .dnmb_dbcan_empty_hits <- function() {
   tibble::tibble(
     query = character(),
@@ -376,18 +819,24 @@
 
     i <- 1L
     while (i < nrow(tbl)) {
-      len1 <- tbl$gene_end[[i]] - tbl$gene_start[[i]]
-      len2 <- tbl$gene_end[[i + 1L]] - tbl$gene_start[[i + 1L]]
-      overlap <- tbl$gene_end[[i]] - tbl$gene_start[[i + 1L]]
+      len1 <- tbl$gene_end[[i]] - tbl$gene_start[[i]] + 1L
+      len2 <- tbl$gene_end[[i + 1L]] - tbl$gene_start[[i + 1L]] + 1L
+      overlap <- min(tbl$gene_end[[i]], tbl$gene_end[[i + 1L]]) -
+        max(tbl$gene_start[[i]], tbl$gene_start[[i + 1L]]) + 1L
       if (!is.na(overlap) && overlap > 0 && (
         (!is.na(len1) && len1 > 0 && overlap / len1 > 0.5) ||
           (!is.na(len2) && len2 > 0 && overlap / len2 > 0.5)
       )) {
-        drop_index <- if (!is.na(tbl$evalue[[i]]) && !is.na(tbl$evalue[[i + 1L]]) && tbl$evalue[[i]] < tbl$evalue[[i + 1L]]) {
-          i + 1L
-        } else {
-          i
-        }
+        score_i <- c(
+          ifelse(is.na(tbl$evalue[[i]]), Inf, tbl$evalue[[i]]),
+          -ifelse(is.na(tbl$coverage[[i]]), -Inf, tbl$coverage[[i]])
+        )
+        score_j <- c(
+          ifelse(is.na(tbl$evalue[[i + 1L]]), Inf, tbl$evalue[[i + 1L]]),
+          -ifelse(is.na(tbl$coverage[[i + 1L]]), -Inf, tbl$coverage[[i + 1L]])
+        )
+        drop_index <- if (score_i[[1]] < score_j[[1]] ||
+          (identical(score_i[[1]], score_j[[1]]) && score_i[[2]] <= score_j[[2]])) i + 1L else i
         tbl <- tbl[-drop_index, , drop = FALSE]
         if (i > 1L) {
           i <- i - 1L
@@ -433,12 +882,12 @@ dnmb_dbcan_parse_domtblout <- function(path,
     coverage <- if (is.na(profile_length) || profile_length <= 0L || is.na(profile_start) || is.na(profile_end)) {
       NA_real_
     } else {
-      (profile_end - profile_start) / profile_length
+      (profile_end - profile_start + 1L) / profile_length
     }
     family_id <- .dnmb_dbcan_profile_family(profile_id)
 
     tibble::tibble(
-      query = .dnmb_module_clean_annotation_key(gene_id),
+      query = .dnmb_dbcan_clean_query_id(gene_id),
       profile_id = profile_id,
       profile_length = profile_length,
       gene_length = gene_length,
@@ -459,8 +908,8 @@ dnmb_dbcan_parse_domtblout <- function(path,
     return(.dnmb_dbcan_empty_hits())
   }
 
-  hits <- .dnmb_dbcan_filter_overlaps(hits)
   hits <- hits[!is.na(hits$evalue) & hits$evalue <= evalue_threshold & !is.na(hits$coverage) & hits$coverage >= coverage_threshold, , drop = FALSE]
+  hits <- .dnmb_dbcan_filter_overlaps(hits)
   rownames(hits) <- NULL
   if (!nrow(hits)) {
     return(.dnmb_dbcan_empty_hits())
@@ -493,7 +942,7 @@ dnmb_dbcan_normalize_hits <- function(hits) {
   )
 
   out <- data.frame(
-    query = .dnmb_module_clean_annotation_key(hits$query),
+    query = .dnmb_dbcan_clean_query_id(hits$query),
     source = rep("dbcan", nrow(hits)),
     family_system = rep("dbCAN", nrow(hits)),
     family_id = as.character(hits$family_id),
@@ -514,6 +963,13 @@ dnmb_dbcan_normalize_hits <- function(hits) {
     typing_eligible = rep(TRUE, nrow(hits)),
     stringsAsFactors = FALSE
   )
+  mapping_columns <- intersect(
+    c("dbcan_query_id", "dbcan_gene_row", "dbcan_mapping_source", "dbcan_contig_key"),
+    names(hits)
+  )
+  for (column_name in mapping_columns) {
+    out[[column_name]] <- hits[[column_name]]
+  }
   out <- out[, c(.dnmb_module_optional_long_columns(), setdiff(names(out), .dnmb_module_optional_long_columns())), drop = FALSE]
   hit_order <- order(out$query, hits$evalue, -hits$coverage)
   out <- out[hit_order, , drop = FALSE]
@@ -521,24 +977,113 @@ dnmb_dbcan_normalize_hits <- function(hits) {
   out
 }
 
-.dnmb_dbcan_output_table <- function(genes, hits, cgc_genes = NULL, substrate = NULL) {
-  out <- .dnmb_module_output_table(genes = genes, hits = hits)
-  out$dbcan_hit <- out$family_id
-  if (!is.null(cgc_genes) && is.data.frame(cgc_genes) && nrow(cgc_genes)) {
-    cgc_genes <- as.data.frame(cgc_genes, stringsAsFactors = FALSE)
-    cgc_genes$query <- .dnmb_module_clean_annotation_key(cgc_genes$query)
-    join_cols <- setdiff(names(cgc_genes), "query")
-    match_rows <- match(out$locus_tag, cgc_genes$query)
-    include <- !is.na(match_rows)
-    for (column_name in join_cols) {
-      if (!column_name %in% names(out)) {
-        out[[column_name]] <- .dnmb_na_vector_like(cgc_genes[[column_name]], nrow(out))
-      }
-      out[[column_name]][include] <- cgc_genes[[column_name]][match_rows[include]]
-    }
+.dnmb_dbcan_domain_summary <- function(hits) {
+  if (is.null(hits) || !is.data.frame(hits) || !nrow(hits)) return(tibble::tibble())
+  hits <- as.data.frame(hits, stringsAsFactors = FALSE)
+  if ("source" %in% names(hits)) {
+    hits <- hits[hits$source == "dbcan", , drop = FALSE]
   }
+  required <- c("family_id", "gene_start", "gene_end", "evalue", "coverage")
+  if (!nrow(hits) || !all(required %in% names(hits))) return(tibble::tibble())
+  key <- if ("dbcan_gene_row" %in% names(hits) && any(!is.na(hits$dbcan_gene_row))) {
+    paste0("row:", hits$dbcan_gene_row)
+  } else {
+    paste0("query:", .dnmb_dbcan_clean_query_id(hits$query))
+  }
+  groups <- split(seq_len(nrow(hits)), key)
+  rows <- lapply(groups, function(idx) {
+    tbl <- hits[idx, , drop = FALSE]
+    tbl <- tbl[order(tbl$gene_start, tbl$gene_end, tbl$evalue, na.last = TRUE), , drop = FALSE]
+    families <- as.character(tbl$family_id)
+    families <- families[!is.na(families) & nzchar(families)]
+    architecture <- if (length(families)) {
+      paste0(
+        as.character(tbl$family_id),
+        "@",
+        as.character(tbl$gene_start),
+        "-",
+        as.character(tbl$gene_end)
+      )
+    } else {
+      character()
+    }
+    best_order <- order(tbl$evalue, -tbl$coverage, na.last = TRUE)
+    best <- tbl[best_order[[1]], , drop = FALSE]
+    out <- data.frame(
+      query = as.character(best$query[[1]]),
+      dbcan_gene_row = if ("dbcan_gene_row" %in% names(best)) suppressWarnings(as.integer(best$dbcan_gene_row[[1]])) else NA_integer_,
+      dbcan_hmm_families = if (length(families)) paste(unique(families), collapse = "; ") else NA_character_,
+      dbcan_hmm_domain_architecture = if (length(architecture)) paste(architecture, collapse = " | ") else NA_character_,
+      dbcan_hmm_domain_count = length(families),
+      stringsAsFactors = FALSE
+    )
+    best_columns <- intersect(
+      c("profile_id", "evalue", "coverage", "profile_length", "gene_length", "profile_start", "profile_end", "gene_start", "gene_end", "support"),
+      names(best)
+    )
+    for (column_name in best_columns) out[[column_name]] <- best[[column_name]][[1]]
+    out
+  })
+  tibble::as_tibble(dplyr::bind_rows(rows))
+}
+
+.dnmb_dbcan_output_table <- function(genes, hits, cgc_genes = NULL,
+                                      substrate = NULL, overview = NULL,
+                                      id_map = NULL) {
+  out <- .dnmb_module_output_table(
+    genes = genes,
+    hits = hits,
+    key_normalizer = .dnmb_dbcan_clean_query_id
+  )
+  out$dbcan_gene_row <- seq_len(nrow(out))
+
+  attach_rows <- function(target, source, exclude = character()) {
+    if (is.null(source) || !is.data.frame(source) || !nrow(source)) return(target)
+    source <- as.data.frame(source, stringsAsFactors = FALSE)
+    idx <- rep(NA_integer_, nrow(target))
+    if ("dbcan_gene_row" %in% names(source) && any(!is.na(source$dbcan_gene_row))) {
+      idx <- match(target$dbcan_gene_row, suppressWarnings(as.integer(source$dbcan_gene_row)))
+    }
+    unresolved <- is.na(idx)
+    if (any(unresolved) && "query" %in% names(source)) {
+      query <- .dnmb_dbcan_clean_query_id(source$query)
+      locus <- .dnmb_dbcan_clean_query_id(target$locus_tag)
+      idx[unresolved] <- match(locus[unresolved], query)
+      unresolved <- is.na(idx)
+      if (any(unresolved) && "protein_id" %in% names(target)) {
+        protein <- .dnmb_dbcan_clean_query_id(target$protein_id)
+        idx[unresolved] <- match(protein[unresolved], query)
+      }
+    }
+    include <- !is.na(idx)
+    join_cols <- setdiff(names(source), c("query", "dbcan_gene_row", exclude))
+    for (column_name in join_cols) {
+      if (!column_name %in% names(target)) {
+        target[[column_name]] <- .dnmb_na_vector_like(source[[column_name]], nrow(target))
+      }
+      target[[column_name]][include] <- source[[column_name]][idx[include]]
+    }
+    target
+  }
+
+  if (!is.null(id_map) && is.data.frame(id_map) && nrow(id_map)) {
+    map_columns <- intersect(
+      c("dbcan_gene_row", "dbcan_query_id", "mapping_source", "dbcan_contig_key"),
+      names(id_map)
+    )
+    map <- id_map[, map_columns, drop = FALSE]
+    if ("mapping_source" %in% names(map)) names(map)[names(map) == "mapping_source"] <- "dbcan_mapping_source"
+    out <- attach_rows(out, map)
+  }
+
+  domain_summary <- .dnmb_dbcan_domain_summary(hits)
+  out <- attach_rows(out, domain_summary)
+  out <- attach_rows(out, overview)
+  out <- attach_rows(out, cgc_genes)
+
   if (!is.null(substrate) && is.data.frame(substrate) && nrow(substrate) && "dbcan_cgc_id" %in% names(out)) {
     substrate <- as.data.frame(substrate, stringsAsFactors = FALSE)
+    substrate <- substrate[!duplicated(substrate$dbcan_cgc_id), , drop = FALSE]
     match_rows <- match(out$dbcan_cgc_id, substrate$dbcan_cgc_id)
     include <- !is.na(match_rows)
     join_cols <- setdiff(names(substrate), "dbcan_cgc_id")
@@ -549,22 +1094,61 @@ dnmb_dbcan_normalize_hits <- function(hits) {
       out[[column_name]][include] <- substrate[[column_name]][match_rows[include]]
     }
   }
-  drop_cols <- intersect(
-    c(
-      "hit_label",
-      "enzyme_role",
-      "evidence_mode",
-      "substrate_label",
-      "typing_eligible"
-    ),
-    names(out)
-  )
-  if (length(drop_cols)) {
-    out[drop_cols] <- NULL
+
+  prefer_text <- function(...) {
+    values <- list(...)
+    result <- rep(NA_character_, nrow(out))
+    for (value in values) {
+      if (is.null(value)) next
+      value <- as.character(value)
+      take <- (is.na(result) | !nzchar(result)) & !is.na(value) & nzchar(value) & value != "-"
+      result[take] <- value[take]
+    }
+    result
   }
 
+  overview_primary <- if ("dbcan_primary_family" %in% names(out)) out$dbcan_primary_family else NULL
+  hmm_primary <- if ("dbcan_hmm_families" %in% names(out)) {
+    vapply(
+      out$dbcan_hmm_families,
+      function(value) .dnmb_dbcan_primary_family(.dnmb_dbcan_family_tokens(value)),
+      character(1)
+    )
+  } else {
+    NULL
+  }
+  out$family_id <- prefer_text(overview_primary, hmm_primary, out$family_id)
+  all_families <- if ("dbcan_all_families" %in% names(out)) out$dbcan_all_families else NULL
+  hmm_families <- if ("dbcan_hmm_families" %in% names(out)) out$dbcan_hmm_families else NULL
+  out$dbcan_hit <- prefer_text(all_families, hmm_families, out$family_id)
+
+  pul_substrate <- if ("dbcan_pul_substrate" %in% names(out)) out$dbcan_pul_substrate else rep(NA_character_, nrow(out))
+  sub_substrate <- if ("dbcan_sub_substrate" %in% names(out)) out$dbcan_sub_substrate else rep(NA_character_, nrow(out))
+  overview_substrate <- if ("dbcan_overview_substrate" %in% names(out)) out$dbcan_overview_substrate else rep(NA_character_, nrow(out))
+  family_prior <- if ("dbcan_family_substrate_prior" %in% names(out)) out$dbcan_family_substrate_prior else rep(NA_character_, nrow(out))
+  out$substrate_label <- prefer_text(pul_substrate, sub_substrate, overview_substrate, family_prior)
+  out$dbcan_substrate_source <- ifelse(
+    !is.na(pul_substrate) & nzchar(pul_substrate),
+    "dbCAN-PUL",
+    ifelse(
+      !is.na(sub_substrate) & nzchar(sub_substrate),
+      "dbCAN-sub",
+      ifelse(
+        !is.na(overview_substrate) & nzchar(overview_substrate),
+        "overview",
+        ifelse(!is.na(family_prior) & nzchar(family_prior), "family_prior", NA_character_)
+      )
+    )
+  )
+
+  drop_cols <- intersect(
+    c("hit_label", "enzyme_role", "evidence_mode", "typing_eligible"),
+    names(out)
+  )
+  if (length(drop_cols)) out[drop_cols] <- NULL
+
   base_cols <- intersect(dnmb_backbone_columns(), names(out))
-  dbcan_cols <- c("dbcan_hit", setdiff(names(out), c(base_cols, "dbcan_hit")))
+  dbcan_cols <- c("dbcan_hit", "family_id", setdiff(names(out), c(base_cols, "dbcan_hit", "family_id")))
   out[, c(base_cols, dbcan_cols), drop = FALSE]
 }
 
@@ -609,10 +1193,12 @@ dnmb_dbcan_normalize_hits <- function(hits) {
     paste0(paths$stp_hmm, c(".h3f", ".h3i", ".h3m", ".h3p")),
     paste0(paths$tf_hmm, c(".h3f", ".h3i", ".h3m", ".h3p")),
     paths$cazy_dmnd,
+    paths$peptidase_dmnd,
+    paths$sulfatlas_dmnd,
     paths$dbcan_sub_hmm,
     paste0(paths$dbcan_sub_hmm, c(".h3f", ".h3i", ".h3m", ".h3p"))
   )
-  all(file.exists(required))
+  all(file.exists(required)) && dir.exists(paths$pul_dir)
 }
 
 .dnmb_dbcan_stage_hmm_for_standalone <- function(module_dir, bundle_dir) {
@@ -714,12 +1300,17 @@ dnmb_dbcan_normalize_hits <- function(hits) {
 }
 
 .dnmb_dbcan_can_run_standalone <- function(genes) {
-  required <- c("locus_tag", "contig", "start", "end", "direction")
-  all(required %in% names(genes))
+  required <- c("start", "end", "direction")
+  if (!is.data.frame(genes) || !all(required %in% names(genes))) return(FALSE)
+  has_replicon <- any(c("contig_number", "record_accession", "contig_accession", "accession", "sequence_id", "contig") %in% names(genes))
+  start <- suppressWarnings(as.numeric(genes$start))
+  end <- suppressWarnings(as.numeric(genes$end))
+  has_replicon && any(is.finite(start) & is.finite(end) & start <= end)
 }
 
 .dnmb_dbcan_safe_contig_map <- function(genes) {
-  contigs <- unique(as.character(genes$contig))
+  keys <- .dnmb_dbcan_contig_keys(as.data.frame(genes, stringsAsFactors = FALSE))
+  contigs <- unique(keys$key)
   contigs <- contigs[!is.na(contigs) & nzchar(contigs)]
   tibble::tibble(
     contig = contigs,
@@ -730,41 +1321,54 @@ dnmb_dbcan_normalize_hits <- function(hits) {
 .dnmb_dbcan_write_cluster_tsv <- function(genes, path) {
   dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
   out <- as.data.frame(genes, stringsAsFactors = FALSE)
-  out$locus_tag <- .dnmb_module_clean_annotation_key(out$locus_tag)
+  out$locus_tag <- .dnmb_dbcan_clean_query_id(out$locus_tag)
   out <- out[!is.na(out$locus_tag) & nzchar(out$locus_tag), c("contig", "locus_tag", "start", "end", "direction"), drop = FALSE]
   mapping <- .dnmb_dbcan_safe_contig_map(out)
-  out$contig <- mapping$safe_contig[match(out$contig, mapping$contig)]
+  contig_key <- .dnmb_dbcan_contig_keys(out)$key
+  out$contig <- mapping$safe_contig[match(contig_key, mapping$contig)]
   utils::write.table(out, file = path, sep = "\t", row.names = FALSE, col.names = FALSE, quote = FALSE)
   list(path = path, contig_map = mapping)
 }
 
-.dnmb_dbcan_write_query_gff <- function(genes, path) {
+.dnmb_dbcan_write_query_gff <- function(genes, path, id_map = NULL) {
   dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
-  out <- as.data.frame(genes, stringsAsFactors = FALSE)
-  out$locus_tag <- .dnmb_module_clean_annotation_key(out$locus_tag)
-  out <- out[!is.na(out$locus_tag) & nzchar(out$locus_tag) &
-             !is.na(out$contig) & !is.na(out$start) & !is.na(out$end), ]
+  if (is.null(id_map)) id_map <- .dnmb_dbcan_build_gene_map(genes)
+  out <- as.data.frame(id_map, stringsAsFactors = FALSE)
+  out <- out[!is.na(out$dbcan_query_id) & nzchar(out$dbcan_query_id) &
+             !is.na(out$dbcan_contig_key) & nzchar(out$dbcan_contig_key) &
+             is.finite(out$start) & is.finite(out$end) & out$start <= out$end, , drop = FALSE]
 
-  # Sanitize contig names (no spaces/special chars that break GFF parsing)
-  mapping <- .dnmb_dbcan_safe_contig_map(out)
-  out$safe_contig <- mapping$safe_contig[match(out$contig, mapping$contig)]
+  mapping <- tibble::tibble(
+    contig = unique(out$dbcan_contig_key),
+    safe_contig = paste0("ctg", seq_along(unique(out$dbcan_contig_key)))
+  )
+  out$safe_contig <- mapping$safe_contig[match(out$dbcan_contig_key, mapping$contig)]
 
-  # Numeric sort by position
   out$start <- as.numeric(out$start)
   out$end <- as.numeric(out$end)
   out <- out[order(out$safe_contig, out$start), ]
 
-  # Write GFF3
-  lines <- c("##gff-version 3")
-  for (i in seq_len(nrow(out))) {
-    strand <- if (is.na(out$direction[i]) || out$direction[i] == "+") "+" else "-"
-    attrs <- paste0("ID=", out$locus_tag[i], ";Name=", out$locus_tag[i])
-    lines <- c(lines, paste(out$safe_contig[i], "DNMB", "CDS",
-      as.integer(out$start[i]), as.integer(out$end[i]),
-      ".", strand, "0", attrs, sep = "\t"))
-  }
+  strand <- ifelse(
+    grepl("complement|minus|^-|^-1$", as.character(out$direction), ignore.case = TRUE),
+    "-",
+    "+"
+  )
+  attrs <- paste0("ID=", out$dbcan_query_id, ";Name=", out$dbcan_query_id)
+  body <- paste(
+    out$safe_contig,
+    "DNMB",
+    "CDS",
+    as.integer(out$start),
+    as.integer(out$end),
+    ".",
+    strand,
+    "0",
+    attrs,
+    sep = "\t"
+  )
+  lines <- c("##gff-version 3", body)
   writeLines(lines, path)
-  list(path = path, contig_map = mapping, n = nrow(out))
+  list(path = path, contig_map = mapping, id_map = id_map, n = nrow(out))
 }
 
 .dnmb_dbcan_restore_cgc_ids <- function(tbl, contig_map) {
@@ -773,10 +1377,15 @@ dnmb_dbcan_normalize_hits <- function(hits) {
   }
   out <- as.data.frame(tbl, stringsAsFactors = FALSE)
   out$dbcan_cgc_id <- as.character(out$dbcan_cgc_id)
-  for (i in seq_len(nrow(contig_map))) {
-    safe <- paste0("^", gsub("([][{}()+*^$.|\\\\?])", "\\\\\\1", contig_map$safe_contig[[i]]), "\\|")
-    repl <- paste0(contig_map$contig[[i]], "|")
-    out$dbcan_cgc_id <- sub(safe, repl, out$dbcan_cgc_id, perl = TRUE)
+  safe_contig <- sub("\\|.*$", "", out$dbcan_cgc_id)
+  suffix <- sub("^[^|]+", "", out$dbcan_cgc_id)
+  idx <- match(safe_contig, contig_map$safe_contig)
+  mapped <- !is.na(idx)
+  out$dbcan_cgc_id[mapped] <- paste0(contig_map$contig[idx[mapped]], suffix[mapped])
+  if ("dbcan_contig_key" %in% names(out)) {
+    contig_idx <- match(out$dbcan_contig_key, contig_map$safe_contig)
+    keep <- !is.na(contig_idx)
+    out$dbcan_contig_key[keep] <- contig_map$contig[contig_idx[keep]]
   }
   out
 }
@@ -838,6 +1447,12 @@ dnmb_dbcan_normalize_hits <- function(hits) {
   )
 }
 
+.dnmb_dbcan_synteny_output_dir <- function(run_dbcan_dir) {
+  candidates <- file.path(run_dbcan_dir, c("synteny_pdf", "synteny.pdf"))
+  existing <- candidates[dir.exists(candidates)]
+  if (length(existing)) existing[[1]] else candidates[[1]]
+}
+
 .dnmb_dbcan_run_syntenic_plot <- function(run_dbcan_dir, bundle_dir, trace_log = NULL) {
   required_files <- c(
     file.path(run_dbcan_dir, "PUL_blast.out"),
@@ -866,7 +1481,7 @@ dnmb_dbcan_normalize_hits <- function(hits) {
     .dnmb_dbcan_trace(trace_log, sprintf("[%s] syntenic_plot args=%s", Sys.time(), .dnmb_format_command("syntenic_plot", args)))
   }
   command <- dnmb_run_external("syntenic_plot", args = args, wd = run_dbcan_dir, required = FALSE)
-  synteny_dir <- file.path(run_dbcan_dir, "synteny.pdf")
+  synteny_dir <- .dnmb_dbcan_synteny_output_dir(run_dbcan_dir)
   ok <- isTRUE(command$ok) && dir.exists(synteny_dir)
   status <- .dnmb_dbcan_status_row(
     "dbcan_synteny",
@@ -897,7 +1512,7 @@ dnmb_dbcan_parse_hmmer_table <- function(path) {
       return(NULL)
     }
     tibble::tibble(
-      query = .dnmb_module_clean_annotation_key(fields[[3]]),
+      query = .dnmb_dbcan_clean_query_id(fields[[3]]),
       profile_id = fields[[1]],
       profile_length = suppressWarnings(as.integer(fields[[2]])),
       gene_length = suppressWarnings(as.integer(fields[[4]])),
@@ -923,7 +1538,8 @@ dnmb_dbcan_parse_hmmer_table <- function(path) {
 dnmb_dbcan_parse_cgc_standard <- function(path) {
   empty <- tibble::tibble(
     query = character(), dbcan_cgc_id = character(),
-    dbcan_cgc_gene_type = character(), dbcan_cgc_protein_family = character()
+    dbcan_contig_key = character(), dbcan_cgc_gene_type = character(),
+    dbcan_cgc_protein_family = character()
   )
   if (!file.exists(path) || !isTRUE(file.info(path)$size > 0)) return(empty)
 
@@ -951,16 +1567,18 @@ dnmb_dbcan_parse_cgc_standard <- function(path) {
   # Build dbcan_cgc_id from contig + CGC#
   if ("contig_id" %in% names(tbl) && "cgc_num" %in% names(tbl)) {
     tbl$dbcan_cgc_id <- paste(tbl$contig_id, tbl$cgc_num, sep = "|")
+    tbl$dbcan_contig_key <- as.character(tbl$contig_id)
   } else {
     tbl$dbcan_cgc_id <- NA_character_
+    tbl$dbcan_contig_key <- NA_character_
   }
 
   # Clean query
   if ("query" %in% names(tbl)) {
-    tbl$query <- .dnmb_module_clean_annotation_key(tbl$query)
+    tbl$query <- .dnmb_dbcan_clean_query_id(tbl$query)
   }
 
-  result <- tbl[, intersect(c("query", "dbcan_cgc_id", "dbcan_cgc_gene_type", "dbcan_cgc_protein_family"), names(tbl)), drop = FALSE]
+  result <- tbl[, intersect(c("query", "dbcan_cgc_id", "dbcan_contig_key", "dbcan_cgc_gene_type", "dbcan_cgc_protein_family"), names(tbl)), drop = FALSE]
   tibble::as_tibble(result)
 }
 
@@ -1028,7 +1646,8 @@ dnmb_dbcan_run_standalone <- function(query_fasta,
                                       cache_root = NULL,
                                       cpu = 1L,
                                       install = FALSE,
-                                      base_url = .dnmb_dbcan_default_base_url()) {
+                                      base_url = .dnmb_dbcan_default_base_url(),
+                                      id_map = NULL) {
   dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
   status <- .dnmb_dbcan_empty_status()
   trace_log <- file.path(output_dir, "dbcan_trace.log")
@@ -1076,10 +1695,17 @@ dnmb_dbcan_run_standalone <- function(query_fasta,
     ))
   }
 
-  # Write query GFF for the new run_dbcan 5.x CLI (replaces cluster.tsv)
-  gff_info <- .dnmb_dbcan_write_query_gff(genes, file.path(output_dir, "dbcan_query.gff"))
+  if (is.null(id_map)) id_map <- .dnmb_dbcan_build_gene_map(genes)
+  gff_info <- .dnmb_dbcan_write_query_gff(
+    genes,
+    file.path(output_dir, "dbcan_query.gff"),
+    id_map = id_map
+  )
 
   run_dbcan_output <- file.path(output_dir, "run_dbcan")
+  if (dir.exists(run_dbcan_output)) {
+    unlink(run_dbcan_output, recursive = TRUE, force = TRUE)
+  }
   dir.create(run_dbcan_output, recursive = TRUE, showWarnings = FALSE)
 
   # Stage: symlink db_dir for run_dbcan
@@ -1105,7 +1731,8 @@ dnmb_dbcan_run_standalone <- function(query_fasta,
     "--additional_genes", "STP",
     "--additional_logic", "any",
     "--num_null_gene", "2",
-    "--use_null_genes"
+    "--use_null_genes",
+    "--threads", as.character(max(1L, as.integer(cpu)[1]))
   )
   .dnmb_dbcan_trace(trace_log, sprintf("[%s] run_dbcan args=%s", Sys.time(), .dnmb_format_command("run_dbcan", args)))
   command <- dnmb_run_external("run_dbcan", args = args, required = FALSE)
@@ -1115,23 +1742,46 @@ dnmb_dbcan_run_standalone <- function(query_fasta,
   cgc_standard_path <- file.path(run_dbcan_output, "cgc_standard_out.tsv")
   substrate_path <- file.path(run_dbcan_output, "substrate_prediction.tsv")
 
-  raw_hits <- dnmb_dbcan_parse_hmmer_table(hmmer_path)
+  raw_hits <- .dnmb_dbcan_restore_query_map(
+    dnmb_dbcan_parse_hmmer_table(hmmer_path),
+    id_map
+  )
+  overview <- dnmb_dbcan_parse_overview(overview_path, id_map = id_map)
   cgc_genes <- .dnmb_dbcan_restore_cgc_ids(
     dnmb_dbcan_parse_cgc_standard(cgc_standard_path),
     contig_map = gff_info$contig_map
   )
+  cgc_genes <- .dnmb_dbcan_restore_query_map(cgc_genes, id_map)
   substrate <- .dnmb_dbcan_restore_cgc_ids(
     dnmb_dbcan_parse_substrate_table(substrate_path),
     contig_map = gff_info$contig_map
   )
-  hits <- dnmb_dbcan_normalize_hits(.dnmb_dbcan_augment_hits_with_standalone(raw_hits, cgc_genes = cgc_genes, substrate = substrate))
+  hits <- dnmb_dbcan_normalize_hits(raw_hits)
+  mapped_domains_path <- file.path(run_dbcan_output, "dnmb_mapped_domains.tsv")
+  gene_summary_path <- file.path(run_dbcan_output, "dnmb_cazy_gene_summary.tsv")
+  utils::write.table(
+    as.data.frame(hits, stringsAsFactors = FALSE),
+    file = mapped_domains_path,
+    sep = "\t",
+    row.names = FALSE,
+    quote = FALSE,
+    na = ""
+  )
+  utils::write.table(
+    as.data.frame(overview, stringsAsFactors = FALSE),
+    file = gene_summary_path,
+    sep = "\t",
+    row.names = FALSE,
+    quote = FALSE,
+    na = ""
+  )
   synteny <- .dnmb_dbcan_run_syntenic_plot(
     run_dbcan_dir = run_dbcan_output,
     bundle_dir = bundle_dir,
     trace_log = trace_log
   )
 
-  ok <- file.exists(overview_path) && file.exists(cgc_standard_path)
+  ok <- isTRUE(command$ok) && file.exists(overview_path)
   status <- dplyr::bind_rows(
     status,
     .dnmb_dbcan_status_row("run_dbcan", if (ok) "ok" else if (isTRUE(command$ok)) "partial" else "failed", run_dbcan_output),
@@ -1142,7 +1792,7 @@ dnmb_dbcan_run_standalone <- function(query_fasta,
   )
 
   list(
-    ok = ok || (isTRUE(command$ok) && file.exists(overview_path)),
+    ok = ok,
     status = status,
     files = c(
       list(
@@ -1153,6 +1803,8 @@ dnmb_dbcan_run_standalone <- function(query_fasta,
         overview = overview_path,
         cgc_standard = cgc_standard_path,
         substrate = substrate_path,
+        mapped_domains = mapped_domains_path,
+        gene_summary = gene_summary_path,
         trace_log = trace_log
       ),
       synteny$files,
@@ -1161,6 +1813,7 @@ dnmb_dbcan_run_standalone <- function(query_fasta,
     command = command,
     raw_hits = raw_hits,
     hits = hits,
+    overview = overview,
     cgc_genes = cgc_genes,
     substrate = substrate,
     manifest = module$manifest
@@ -1405,7 +2058,8 @@ dnmb_dbcan_run_hmmsearch <- function(query_fasta,
                                      base_url = .dnmb_dbcan_default_base_url(),
                                      asset_urls = NULL,
                                      evalue_threshold = 1e-15,
-                                     coverage_threshold = 0.35) {
+                                     coverage_threshold = 0.35,
+                                     id_map = NULL) {
   dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
   status <- .dnmb_dbcan_empty_status()
   trace_log <- file.path(output_dir, "dbcan_trace.log")
@@ -1472,6 +2126,7 @@ dnmb_dbcan_run_hmmsearch <- function(query_fasta,
     evalue_threshold = evalue_threshold,
     coverage_threshold = coverage_threshold
   )
+  raw_hits <- .dnmb_dbcan_restore_query_map(raw_hits, id_map)
   hits <- dnmb_dbcan_normalize_hits(raw_hits)
   status <- dplyr::bind_rows(
     status,
@@ -1513,31 +2168,37 @@ dnmb_run_dbcan_module <- function(genes,
                                   cpu = 1L,
                                   genbank = NULL) {
   dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+  standalone_output <- file.path(output_dir, "run_dbcan")
+  if (dir.exists(standalone_output)) {
+    unlink(standalone_output, recursive = TRUE, force = TRUE)
+  }
   trace_log <- file.path(output_dir, "dbcan_module_trace.log")
   fasta_path <- file.path(output_dir, "dbcan_query_proteins.faa")
-  existing_faa <- dnmb_resolve_query_faa(genbank = genbank, output_dir = output_dir, fallback_filename = basename(fasta_path))
-  if (!is.null(existing_faa) && .dnmb_can_reuse_query_fasta(existing_faa, genes)) {
-    proteins <- .dnmb_prepare_query_proteins(genes)
-    fasta <- list(path = existing_faa, n = nrow(proteins), proteins = proteins)
-    fasta_path <- existing_faa
-  } else {
-    fasta <- .dnmb_write_query_fasta(genes, fasta_path)
-  }
+  id_map <- .dnmb_dbcan_build_gene_map(genes)
+  id_map_path <- file.path(output_dir, "dbcan_gene_id_map.tsv")
+  .dnmb_dbcan_write_gene_map(id_map, id_map_path)
+  fasta <- .dnmb_dbcan_write_mapped_query_fasta(id_map, fasta_path)
   status <- .dnmb_dbcan_status_row(
     "dbcan_query_fasta",
     if (fasta$n) "ok" else "empty",
     paste0("proteins=", fasta$n)
   )
-  .dnmb_dbcan_trace(trace_log, sprintf("[%s] query_faa=%s existing=%s proteins=%s", Sys.time(), fasta_path, !is.null(existing_faa), fasta$n))
+  .dnmb_dbcan_trace(trace_log, sprintf("[%s] query_faa=%s synthetic_ids=true proteins=%s", Sys.time(), fasta_path, fasta$n))
 
   if (!fasta$n) {
     return(list(
       ok = TRUE,
       status = status,
-      files = list(query_fasta = fasta_path, trace_log = trace_log),
+      files = list(query_fasta = fasta_path, gene_id_map = id_map_path, trace_log = trace_log),
       manifest = NULL,
       raw_hits = .dnmb_dbcan_empty_hits(),
       hits = .dnmb_module_empty_optional_long_table(),
+      overview = .dnmb_dbcan_empty_overview(),
+      output_table = .dnmb_dbcan_output_table(
+        genes = genes,
+        hits = .dnmb_module_empty_optional_long_table(),
+        id_map = id_map
+      ),
       query_proteins = fasta$proteins
     ))
   }
@@ -1554,10 +2215,38 @@ dnmb_run_dbcan_module <- function(genes,
       cache_root = cache_root,
       cpu = cpu,
       install = install,
-      base_url = base_url
+      base_url = base_url,
+      id_map = id_map
     )
+    if (!isTRUE(search$ok)) {
+      standalone_status <- search$status
+      if (dir.exists(standalone_output)) {
+        unlink(standalone_output, recursive = TRUE, force = TRUE)
+      }
+      fallback <- dnmb_dbcan_run_hmmsearch(
+        query_fasta = fasta_path,
+        output_dir = output_dir,
+        version = version,
+        cache_root = cache_root,
+        cpu = cpu,
+        install = install,
+        base_url = base_url,
+        asset_urls = asset_urls,
+        id_map = id_map
+      )
+      fallback$status <- dplyr::bind_rows(
+        standalone_status,
+        .dnmb_dbcan_status_row(
+          "run_dbcan_fallback",
+          if (isTRUE(fallback$ok)) "ok" else "failed",
+          "standalone dbCAN failed; retried with HMMER"
+        ),
+        fallback$status
+      )
+      search <- fallback
+    }
   } else {
-    missing_cols <- setdiff(c("locus_tag", "contig", "start", "end", "direction"), names(genes))
+    missing_cols <- setdiff(c("start", "end", "direction"), names(genes))
     skip_detail <- if (!standalone_inputs_ok) {
       paste0("missing required GenBank columns for CGC mode: ", paste(missing_cols, collapse = ", "))
     } else {
@@ -1571,7 +2260,8 @@ dnmb_run_dbcan_module <- function(genes,
       cpu = cpu,
       install = install,
       base_url = base_url,
-      asset_urls = asset_urls
+      asset_urls = asset_urls,
+      id_map = id_map
     )
     search$status <- dplyr::bind_rows(
       .dnmb_dbcan_status_row("run_dbcan", "skipped", skip_detail),
@@ -1579,20 +2269,46 @@ dnmb_run_dbcan_module <- function(genes,
     )
   }
 
+  mapping_path <- search$files$mapping_path %||% NULL
+  if (!is.null(mapping_path) && length(mapping_path)) {
+    search$overview <- .dnmb_dbcan_add_family_substrate_prior(
+      search$overview %||% .dnmb_dbcan_empty_overview(),
+      as.character(mapping_path[[1]])
+    )
+    gene_summary_path <- file.path(output_dir, "run_dbcan", "dnmb_cazy_gene_summary.tsv")
+    if (dir.exists(dirname(gene_summary_path))) {
+      utils::write.table(
+        as.data.frame(search$overview, stringsAsFactors = FALSE),
+        file = gene_summary_path,
+        sep = "\t",
+        row.names = FALSE,
+        quote = FALSE,
+        na = ""
+      )
+    }
+  }
+  search$hits <- .dnmb_dbcan_merge_overview_hits(
+    search$hits,
+    search$overview %||% .dnmb_dbcan_empty_overview()
+  )
+
   list(
     ok = isTRUE(search$ok),
     status = dplyr::bind_rows(status, search$status),
-    files = c(search$files, list(module_trace_log = trace_log)),
+    files = c(search$files, list(gene_id_map = id_map_path, module_trace_log = trace_log)),
     manifest = search$manifest,
     raw_hits = search$raw_hits,
     hits = search$hits,
+    overview = search$overview %||% .dnmb_dbcan_empty_overview(),
     cgc_genes = search$cgc_genes %||% tibble::tibble(),
     substrate = search$substrate %||% tibble::tibble(),
     output_table = .dnmb_dbcan_output_table(
       genes = genes,
       hits = search$hits,
       cgc_genes = search$cgc_genes %||% NULL,
-      substrate = search$substrate %||% NULL
+      substrate = search$substrate %||% NULL,
+      overview = search$overview %||% NULL,
+      id_map = id_map
     ),
     query_proteins = fasta$proteins
   )

--- a/R/module_api.R
+++ b/R/module_api.R
@@ -100,9 +100,67 @@ append_module_results <- function(main_table, ..., merged_module_table = NULL) {
 
   matched_rows <- match(main_table$locus_tag, merged_module_table$locus_tag)
   appended_columns <- merged_module_table[matched_rows, module_columns, drop = FALSE]
+
+  dbcan_row_column <- grep(
+    "(^|_)dbcan_gene_row$",
+    names(merged_module_table),
+    value = TRUE,
+    ignore.case = TRUE
+  )
+  dbcan_columns <- grep("^dbCAN_", module_columns, value = TRUE, ignore.case = TRUE)
+  if (length(dbcan_row_column) && length(dbcan_columns)) {
+    dbcan_rows <- suppressWarnings(as.integer(merged_module_table[[dbcan_row_column[[1]]]]))
+    row_matched <- match(seq_len(nrow(main_table)), dbcan_rows)
+    if (!dnmb_append_row_mapping_is_compatible(main_table, merged_module_table, row_matched)) {
+      row_matched <- dnmb_stable_row_match(main_table, merged_module_table)
+    }
+    unresolved <- is.na(row_matched)
+    contig_column <- grep(
+      "^dbCAN_dbcan_contig_key$",
+      names(merged_module_table),
+      value = TRUE,
+      ignore.case = TRUE
+    )
+    if (any(unresolved) && length(contig_column) &&
+        all(c("start", "end", "direction") %in% names(main_table)) &&
+        all(c("start", "end", "direction") %in% names(merged_module_table))) {
+      main_contigs <- .dnmb_dbcan_contig_keys(main_table)$key
+      module_contigs <- as.character(merged_module_table[[contig_column[[1]]]])
+      main_key <- paste(main_contigs, main_table$start, main_table$end, main_table$direction, sep = "|")
+      module_key <- paste(module_contigs, merged_module_table$start, merged_module_table$end, merged_module_table$direction, sep = "|")
+      coordinate_match <- dnmb_unique_value_match(main_key, module_key)
+      row_matched[unresolved] <- coordinate_match[unresolved]
+    }
+    include <- !is.na(row_matched)
+    for (column_name in dbcan_columns) {
+      value <- .dnmb_na_vector_like(merged_module_table[[column_name]], nrow(main_table))
+      value[include] <- merged_module_table[[column_name]][row_matched[include]]
+      appended_columns[[column_name]] <- value
+    }
+  }
   rownames(appended_columns) <- NULL
 
   cbind(main_table, appended_columns, stringsAsFactors = FALSE)
+}
+
+dnmb_append_row_mapping_is_compatible <- function(main_table, module_table, matched_rows) {
+  mapped <- !is.na(matched_rows)
+  if (!any(mapped)) return(FALSE)
+  shared <- intersect(names(main_table), names(module_table))
+  compare_field <- function(column_name) {
+    left <- as.character(main_table[[column_name]][mapped])
+    right <- as.character(module_table[[column_name]][matched_rows[mapped]])
+    comparable <- !is.na(left) & nzchar(left) & !is.na(right) & nzchar(right)
+    list(n = sum(comparable), same = !any(left[comparable] != right[comparable]))
+  }
+  stable_fields <- intersect(c("protein_id", "contig", "start", "end", "direction"), shared)
+  if (length(stable_fields) >= 2L) {
+    status <- lapply(stable_fields, compare_field)
+    comparable <- sum(vapply(status, `[[`, integer(1), "n"))
+    if (comparable > 0L) return(all(vapply(status, `[[`, logical(1), "same")))
+  }
+  if ("locus_tag" %in% shared) return(compare_field("locus_tag")$same)
+  !length(shared)
 }
 
 dnmb_validate_append_main_table <- function(main_table) {
@@ -116,13 +174,24 @@ dnmb_validate_append_main_table <- function(main_table) {
 }
 
 dnmb_merge_two_module_tables <- function(primary_table, secondary_table) {
-  combined_locus_tags <- c(
-    primary_table$locus_tag,
-    secondary_table$locus_tag[!secondary_table$locus_tag %in% primary_table$locus_tag]
-  )
-
-  primary_aligned <- dnmb_align_module_table(primary_table, combined_locus_tags)
-  secondary_aligned <- dnmb_align_module_table(secondary_table, combined_locus_tags)
+  if (dnmb_module_rows_are_aligned(primary_table, secondary_table)) {
+    primary_aligned <- primary_table
+    secondary_aligned <- secondary_table
+  } else {
+    stable_rows <- dnmb_stable_row_match(primary_table, secondary_table)
+    if (nrow(primary_table) == nrow(secondary_table) && all(!is.na(stable_rows))) {
+      primary_aligned <- primary_table
+      secondary_aligned <- secondary_table[stable_rows, , drop = FALSE]
+      rownames(secondary_aligned) <- NULL
+    } else {
+      combined_locus_tags <- c(
+        primary_table$locus_tag,
+        secondary_table$locus_tag[!secondary_table$locus_tag %in% primary_table$locus_tag]
+      )
+      primary_aligned <- dnmb_align_module_table(primary_table, combined_locus_tags)
+      secondary_aligned <- dnmb_align_module_table(secondary_table, combined_locus_tags)
+    }
+  }
   backbone_columns <- setdiff(dnmb_backbone_columns(), "locus_tag")
 
   for (column_name in backbone_columns) {
@@ -148,6 +217,71 @@ dnmb_merge_two_module_tables <- function(primary_table, secondary_table) {
   }
 
   primary_aligned
+}
+
+dnmb_module_rows_are_aligned <- function(primary_table, secondary_table) {
+  if (nrow(primary_table) != nrow(secondary_table) || !nrow(primary_table)) {
+    return(FALSE)
+  }
+  shared <- intersect(
+    dnmb_backbone_columns(),
+    intersect(names(primary_table), names(secondary_table))
+  )
+  if (!length(shared)) return(FALSE)
+  same_column <- function(column_name) {
+    identical(
+      as.character(primary_table[[column_name]]),
+      as.character(secondary_table[[column_name]])
+    )
+  }
+  stable_fields <- intersect(
+    c("protein_id", "contig", "start", "end", "direction"),
+    shared
+  )
+  if (length(stable_fields) >= 2L) {
+    return(all(vapply(stable_fields, same_column, logical(1))))
+  }
+  "locus_tag" %in% shared && same_column("locus_tag")
+}
+
+dnmb_unique_value_match <- function(target, source) {
+  target <- as.character(target)
+  source <- as.character(source)
+  target_missing <- is.na(target) | !nzchar(target)
+  source_missing <- is.na(source) | !nzchar(source)
+  target_unique <- !duplicated(target) & !duplicated(target, fromLast = TRUE) & !target_missing
+  source_unique <- !duplicated(source) & !duplicated(source, fromLast = TRUE) & !source_missing
+  out <- match(target, ifelse(source_unique, source, NA_character_))
+  out[!target_unique] <- NA_integer_
+  out
+}
+
+dnmb_stable_row_match <- function(target_table, source_table) {
+  out <- rep(NA_integer_, nrow(target_table))
+  if (!nrow(target_table) || !nrow(source_table)) return(out)
+
+  if ("protein_id" %in% names(target_table) && "protein_id" %in% names(source_table)) {
+    out <- dnmb_unique_value_match(target_table$protein_id, source_table$protein_id)
+  }
+
+  coordinate_fields <- intersect(
+    c("contig", "start", "end", "direction"),
+    intersect(names(target_table), names(source_table))
+  )
+  if (all(c("start", "end") %in% coordinate_fields)) {
+    target_key <- do.call(paste, c(target_table[coordinate_fields], sep = "|"))
+    source_key <- do.call(paste, c(source_table[coordinate_fields], sep = "|"))
+    coordinate_match <- dnmb_unique_value_match(target_key, source_key)
+    unresolved <- is.na(out)
+    out[unresolved] <- coordinate_match[unresolved]
+  }
+
+  if ("locus_tag" %in% names(target_table) && "locus_tag" %in% names(source_table)) {
+    locus_match <- dnmb_unique_value_match(target_table$locus_tag, source_table$locus_tag)
+    unresolved <- is.na(out)
+    out[unresolved] <- locus_match[unresolved]
+  }
+  out
 }
 
 dnmb_align_module_table <- function(module_table, locus_tags) {

--- a/R/module_plotting.R
+++ b/R/module_plotting.R
@@ -5,7 +5,8 @@
 }
 
 .dnmb_module_plot_save <- function(plot, pdf_path, width = 12, height = 6,
-                                   min_dim = 4, max_dim = 45) {
+                                   min_dim = 4, max_dim = 45,
+                                   device = NULL) {
   ar <- width / height
   width  <- max(min_dim, min(max_dim, width))
   height <- max(min_dim, min(max_dim, height))
@@ -17,7 +18,12 @@
       width <- min(max_dim, max(min_dim, height * ar))
     }
   }
-  ggplot2::ggsave(pdf_path, plot, width = width, height = height, bg = "white")
+  save_args <- list(
+    filename = pdf_path, plot = plot,
+    width = width, height = height, bg = "white"
+  )
+  if (!is.null(device)) save_args$device <- device
+  do.call(ggplot2::ggsave, save_args)
 }
 
 .dnmb_module_plot_save_multi <- function(plots, pdf_path, labels = "AUTO", ncol = 1, rel_heights = NULL, width = 12, height = 8) {
@@ -358,7 +364,11 @@ dnmb_render_module_plots <- function(genbank_table, output_dir = getwd(), cache_
   }
 
   run_plot("GapMindAA",        function() .dnmb_plot_gapmind_aa_pathway_map(genbank_table, output_dir = output_dir))
-  run_plot("CAZyTransport",    function() .dnmb_plot_cazy_carbon_transport_map(genbank_table, output_dir = output_dir))
+  run_plot("CAZyTransport", function() .dnmb_plot_cazy_carbon_transport_map(
+    genbank_table,
+    output_dir = output_dir,
+    file_stub = "CAZy_overview"
+  ))
   run_plot("DefenseFinder",    function() .dnmb_plot_defensefinder_module(genbank_table, output_dir = output_dir))
   run_plot("dbAPIS",           function() .dnmb_plot_dbapis_module(genbank_table, output_dir = output_dir))
   run_plot("AcrFinder",        function() .dnmb_plot_acrfinder_module(genbank_table, output_dir = output_dir))

--- a/R/module_runner.R
+++ b/R/module_runner.R
@@ -105,7 +105,9 @@
   x
 }
 
-.dnmb_prepare_query_proteins <- function(genes) {
+.dnmb_prepare_query_proteins <- function(
+    genes,
+    key_normalizer = .dnmb_module_clean_annotation_key) {
   if (!is.data.frame(genes)) {
     stop("`genes` must be a data frame.", call. = FALSE)
   }
@@ -122,7 +124,7 @@
   }
 
   proteins <- tibble::as_tibble(genes)
-  proteins$locus_tag <- .dnmb_module_clean_annotation_key(proteins$locus_tag)
+  proteins$locus_tag <- key_normalizer(proteins$locus_tag)
   proteins$translation <- .dnmb_normalize_translation(proteins$translation)
   proteins <- proteins[!is.na(proteins$locus_tag) & nzchar(proteins$locus_tag) & !is.na(proteins$translation), , drop = FALSE]
   proteins <- proteins[!duplicated(proteins$locus_tag), , drop = FALSE]
@@ -130,8 +132,14 @@
   proteins
 }
 
-.dnmb_write_query_fasta <- function(genes, path) {
-  proteins <- .dnmb_prepare_query_proteins(genes)
+.dnmb_write_query_fasta <- function(
+    genes,
+    path,
+    key_normalizer = .dnmb_module_clean_annotation_key) {
+  proteins <- .dnmb_prepare_query_proteins(
+    genes,
+    key_normalizer = key_normalizer
+  )
   if (!nrow(proteins)) {
     writeLines(character(), con = path)
     return(list(path = path, proteins = proteins, n = 0L))
@@ -158,8 +166,14 @@
   headers
 }
 
-.dnmb_can_reuse_query_fasta <- function(path, genes) {
-  proteins <- .dnmb_prepare_query_proteins(genes)
+.dnmb_can_reuse_query_fasta <- function(
+    path,
+    genes,
+    key_normalizer = .dnmb_module_clean_annotation_key) {
+  proteins <- .dnmb_prepare_query_proteins(
+    genes,
+    key_normalizer = key_normalizer
+  )
   headers <- .dnmb_fasta_headers(path)
   if (!length(headers) || length(headers) != nrow(proteins)) {
     return(FALSE)
@@ -168,7 +182,9 @@
   identical(headers, proteins$locus_tag)
 }
 
-.dnmb_best_module_hits <- function(hits) {
+.dnmb_best_module_hits <- function(
+    hits,
+    key_normalizer = .dnmb_module_clean_annotation_key) {
   if (is.null(hits) || !is.data.frame(hits) || !nrow(hits)) {
     return(.dnmb_module_empty_optional_long_table())
   }
@@ -181,7 +197,7 @@
   }
 
   hits <- as.data.frame(hits, stringsAsFactors = FALSE)
-  hits$query <- .dnmb_module_clean_annotation_key(hits$query)
+  hits$query <- key_normalizer(hits$query)
   ordered_columns <- c(required, extra_columns)
   hits <- hits[!is.na(hits$query), ordered_columns, drop = FALSE]
   if (!nrow(hits)) {
@@ -212,9 +228,12 @@
   rep(NA_character_, n)
 }
 
-.dnmb_module_output_table <- function(genes, hits) {
+.dnmb_module_output_table <- function(
+    genes,
+    hits,
+    key_normalizer = .dnmb_module_clean_annotation_key) {
   genes <- as.data.frame(genes, stringsAsFactors = FALSE)
-  genes$locus_tag <- .dnmb_module_clean_annotation_key(genes$locus_tag)
+  genes$locus_tag <- key_normalizer(genes$locus_tag)
   base_cols <- intersect(
     c("locus_tag", "gene", "product", "protein_id", "contig", "start", "end", "direction"),
     names(genes)
@@ -228,7 +247,10 @@
   out$support <- NA_character_
   out$typing_eligible <- NA
 
-  best_hits <- .dnmb_best_module_hits(hits)
+  best_hits <- .dnmb_best_module_hits(
+    hits,
+    key_normalizer = key_normalizer
+  )
   if (!nrow(best_hits)) {
     return(out)
   }

--- a/R/plot_cazy_carbon.R
+++ b/R/plot_cazy_carbon.R
@@ -2138,7 +2138,8 @@
     NAG = "glcnac", Glucosamine = "glcnac", Fructose = "fructose",
     Sucrose = "fructose", Mannitol = "mannose", Glycerol = "glycerol",
     Xylose = "xylose", Arabinose = "arabinose", Ribose = "ribose",
-    Fucose = "fucose", Rhamnose = "rhamnose", Gluconate = "glca"
+    Deoxyribose = "deoxyribose", Fucose = "fucose",
+    Rhamnose = "rhamnose", Gluconate = "glca"
   )
   cs_ids <- names(cs_xs)
   rows <- lapply(cs_ids, function(id) {
@@ -2191,8 +2192,12 @@
  }
  
 # ---------------------------------------------------------------------------
-# SNFG polygon-based symbol rendering (ggplot2-only, no ggstar dependency)
+# SNFG symbol rendering (native circles + polygons, no ggstar dependency)
 # ---------------------------------------------------------------------------
+
+# One residue has one map footprint in every zone. Composite carbohydrates
+# grow horizontally by residue count; their individual units are not shrunk.
+.dnmb_cct_sugar_icon_radius <- function() 0.10
 
 #' Return polygon vertex coordinates for an SNFG shape
 #' @param shape_type One of "circle", "square", "diamond", "triangle", "star"
@@ -2200,52 +2205,54 @@
 #' @param size Radius / half-width of the symbol (plot units)
 #' @return data.frame with columns \code{x}, \code{y}
 #' @keywords internal
-.dnmb_snfg_polygon_coords_v2 <- function(shape_type, x = 0, y = 0, size = 0.075) {
+.dnmb_snfg_polygon_coords_v2 <- function(
+    shape_type, x = 0, y = 0,
+    size = .dnmb_cct_sugar_icon_radius()) {
+  normalize_bbox <- function(unit_x, unit_y) {
+    x_range <- range(unit_x)
+    y_range <- range(unit_y)
+    scale <- 2 * size / max(diff(x_range), diff(y_range))
+    data.frame(
+      x = x + (unit_x - mean(x_range)) * scale,
+      y = y + (unit_y - mean(y_range)) * scale
+    )
+  }
 
   switch(shape_type,
     circle = {
       # 20-gon approximation
       theta <- seq(0, 2 * pi, length.out = 21L)[-21L]
-      data.frame(x = x + size * cos(theta),
-                 y = y + size * sin(theta))
+      normalize_bbox(cos(theta), sin(theta))
     },
     square = {
       # axis-aligned square
-      hs <- size  # half-side
-      data.frame(x = x + c(-hs, hs, hs, -hs),
-                 y = y + c(-hs, -hs, hs, hs))
+      normalize_bbox(c(-1, 1, 1, -1), c(-1, -1, 1, 1))
     },
     diamond = {
       # 45-degree rotated square
-      data.frame(x = x + size * c(0, 1, 0, -1),
-                 y = y + size * c(1, 0, -1, 0))
+      normalize_bbox(c(0, 1, 0, -1), c(1, 0, -1, 0))
     },
     triangle = {
-      # equilateral, pointing up
+      # Equilateral, pointing up. Bbox normalization preserves the shape while
+      # giving it the same maximum footprint as circles and squares.
       angles <- c(pi / 2, pi / 2 + 2 * pi / 3, pi / 2 + 4 * pi / 3)
-      data.frame(x = x + size * cos(angles),
-                 y = y + size * sin(angles))
+      normalize_bbox(cos(angles), sin(angles))
     },
     star = {
       # 5-pointed star: 10 vertices, alternating outer / inner radius
-      outer_r <- size
-      inner_r <- size * 0.38  # classic pentagram ratio
       angles  <- seq(pi / 2, pi / 2 + 2 * pi, length.out = 11L)[-11L]
-      radii   <- rep(c(outer_r, inner_r), 5L)
-      data.frame(x = x + radii * cos(angles),
-                 y = y + radii * sin(angles))
+      radii   <- rep(c(1, 0.38), 5L)
+      normalize_bbox(radii * cos(angles), radii * sin(angles))
     },
     pentagon = {
       # regular pentagon, point up
       angles <- seq(pi / 2, pi / 2 + 2 * pi, length.out = 6L)[-6L]
-      data.frame(x = x + size * cos(angles),
-                 y = y + size * sin(angles))
+      normalize_bbox(cos(angles), sin(angles))
     },
     # fallback: small circle
     {
       theta <- seq(0, 2 * pi, length.out = 21L)[-21L]
-      data.frame(x = x + size * cos(theta),
-                 y = y + size * sin(theta))
+      normalize_bbox(cos(theta), sin(theta))
     }
   )
 }
@@ -2274,6 +2281,7 @@
     glca         = list(shape = "diamond",  fill = "#0072BC", color = "#004A7C", half_fill = TRUE),
     gala         = list(shape = "diamond",  fill = "#FFD400", color = "#CCA800", half_fill = TRUE),
     ribose       = list(shape = "star",     fill = "#F69EA1", color = "#C47078"),
+    deoxyribose  = list(shape = "star",     fill = "#D7A1C4", color = "#8A5879"),
     glycerol     = list(shape = "circle",   fill = "#3182BD", color = "#1B5A8A"),
     glucosamine  = list(shape = "square",   fill = "#0072BC", color = "#004A7C", crossed = TRUE),
     trehalose    = list(shape = "circle",   fill = "#0072BC", color = "#004A7C"),
@@ -2297,6 +2305,28 @@
   sp
 }
 
+.dnmb_native_circle_layer_v2 <- function(x, y, radius, fill, color = NA,
+                                         linewidth = 0, alpha = 1) {
+  radius <- max(0, as.numeric(radius)[1])
+  ggplot2::annotation_custom(
+    grob = grid::circleGrob(
+      x = grid::unit(0.5, "npc"),
+      y = grid::unit(0.5, "npc"),
+      r = grid::unit(0.5, "npc"),
+      gp = grid::gpar(
+        fill = fill,
+        col = color,
+        lwd = as.numeric(linewidth)[1] * 72.27 / 25.4,
+        alpha = as.numeric(alpha)[1]
+      )
+    ),
+    xmin = x - radius,
+    xmax = x + radius,
+    ymin = y - radius,
+    ymax = y + radius
+  )
+}
+
 #' Build ggplot2 layers for a single SNFG symbol (polygon + optional badge)
 #'
 #' For half-filled diamonds (GlcA / GalA) a smaller white diamond is drawn
@@ -2307,51 +2337,75 @@
 #' @param size Radius of the symbol
 #' @return A list of ggplot2 layers
 #' @keywords internal
-.dnmb_snfg_symbol_layers_v2 <- function(x, y, sugar_type, size = 0.075, label = NULL) {
+.dnmb_snfg_symbol_layers_v2 <- function(
+    x, y, sugar_type, size = .dnmb_cct_sugar_icon_radius(),
+    label = NULL, alpha = 1) {
 
-  sp    <- .dnmb_snfg_sugar_spec_v2(sugar_type)
-  verts <- .dnmb_snfg_polygon_coords_v2(sp$shape, x, y, size)
-  halo_verts <- .dnmb_snfg_polygon_coords_v2(sp$shape, x, y, size * 1.18)
+  sp <- .dnmb_snfg_sugar_spec_v2(sugar_type)
 
-  layers <- list(
-    ggplot2::geom_polygon(
-      data    = halo_verts,
-      mapping = ggplot2::aes(x = .data[["x"]], y = .data[["y"]]),
-      fill    = "#FFFFFF",
-      color   = NA,
-      alpha   = 0.92,
-      inherit.aes = FALSE
-    )
-  )
-
-  shape_layers <- if (isTRUE(sp$half_fill) && identical(sp$shape, "diamond")) {
-    .dnmb_snfg_split_diamond_layers(
-      cx = x, cy = y, r = size,
-      fill_color = sp$fill, border_color = sp$color, border_lw = 0.3
+  if (identical(sp$shape, "circle")) {
+    layers <- list(
+      .dnmb_native_circle_layer_v2(
+        x, y, radius = size * 1.18,
+        fill = "#FFFFFF", color = NA, linewidth = 0, alpha = 0.92 * alpha
+      ),
+      .dnmb_native_circle_layer_v2(
+        x, y, radius = size,
+        fill = sp$fill, color = sp$color, linewidth = 0.30, alpha = alpha
+      )
     )
   } else {
-    list(
+    verts <- .dnmb_snfg_polygon_coords_v2(sp$shape, x, y, size)
+    halo_verts <- .dnmb_snfg_polygon_coords_v2(sp$shape, x, y, size * 1.18)
+    layers <- list(
       ggplot2::geom_polygon(
-        data    = verts,
+        data = halo_verts,
         mapping = ggplot2::aes(x = .data[["x"]], y = .data[["y"]]),
-        fill    = sp$fill,
-        color   = sp$color,
-        linewidth = 0.3,
+        fill = "#FFFFFF", color = NA, alpha = 0.92 * alpha,
         inherit.aes = FALSE
       )
     )
+    shape_layers <- if (isTRUE(sp$half_fill) && identical(sp$shape, "diamond")) {
+      .dnmb_snfg_split_diamond_layers(
+        cx = x, cy = y, r = size,
+        fill_color = sp$fill, border_color = sp$color, border_lw = 0.3,
+        alpha = alpha
+      )
+    } else {
+      list(
+        ggplot2::geom_polygon(
+          data = verts,
+          mapping = ggplot2::aes(x = .data[["x"]], y = .data[["y"]]),
+          fill = sp$fill, color = sp$color, linewidth = 0.3, alpha = alpha,
+          inherit.aes = FALSE
+        )
+      )
+    }
+    layers <- c(layers, shape_layers)
   }
-  layers <- c(layers, shape_layers)
 
   # Abbreviation label inside the symbol
   if (!is.null(label) && nzchar(label)) {
     # White text for dark fills, black for light fills
     txt_col <- if (mean(grDevices::col2rgb(sp$fill)) < 180) "white" else "#333333"
+    label_lines <- strsplit(as.character(label), "\n", fixed = TRUE)[[1]]
+    max_chars <- max(nchar(label_lines))
+    text_scale <- if (max_chars <= 3L) {
+      11.0
+    } else if (max_chars <= 5L) {
+      9.5
+    } else if (max_chars <= 7L) {
+      7.8
+    } else {
+      6.6
+    }
     lbl_df <- data.frame(x = x, y = y, label = label)
     layers[[length(layers) + 1L]] <- ggplot2::geom_text(
       data = lbl_df,
       mapping = ggplot2::aes(x = .data[["x"]], y = .data[["y"]], label = .data[["label"]]),
-      size = size * 10, fontface = "bold", color = txt_col, inherit.aes = FALSE)
+      size = size * text_scale, fontface = "bold", color = txt_col, alpha = alpha,
+      lineheight = 0.82,
+      inherit.aes = FALSE)
   }
 
   # Crossed square (hexosamine): diagonal line from top-left to bottom-right
@@ -2403,9 +2457,130 @@
 #' @param r Radius of the symbol (plot units)
 #' @return The modified ggplot2 object with symbol layers added
 #' @keywords internal
-.dnmb_snfg_render_symbol_v2 <- function(p, cx, cy, sugar_name, r = 0.075, label = NULL) {
-  layers <- .dnmb_snfg_symbol_layers_v2(cx, cy, sugar_name, size = r, label = label)
+.dnmb_snfg_render_symbol_v2 <- function(
+    p, cx, cy, sugar_name, r = .dnmb_cct_sugar_icon_radius(),
+    label = NULL, alpha = 1) {
+  layers <- .dnmb_snfg_symbol_layers_v2(
+    cx, cy, sugar_name, size = r, label = label, alpha = alpha
+  )
   for (ly in layers) p <- p + ly
+  p
+}
+
+# Cytoplasmic carbon sources need their own visible glyphs even when several
+# substrates converge on the same downstream sugar-family hub. Disaccharides
+# are represented by their two constituent SNFG symbols; the remaining carbon
+# sources use one substrate-specific symbol.
+.dnmb_cct_carbon_source_render_catalog <- function() {
+  list(
+    Maltose = list(components = c("glucose", "glucose"), bond = "alpha"),
+    Cellobiose = list(components = c("glucose", "glucose"), bond = "beta"),
+    Galactose = list(components = "galactose", bond = NA_character_),
+    Trehalose = list(components = c("glucose", "glucose"), bond = "alpha"),
+    Lactose = list(components = c("galactose", "glucose"), bond = "beta"),
+    Mannose = list(components = "mannose", bond = NA_character_),
+    NAG = list(components = "glcnac", bond = NA_character_),
+    Glucosamine = list(components = "glucosamine", bond = NA_character_),
+    Fructose = list(components = "fructose", bond = NA_character_),
+    Sucrose = list(components = c("glucose", "fructose"), bond = "alpha"),
+    Mannitol = list(components = "mannitol", bond = NA_character_),
+    Glycerol = list(components = "glycerol", bond = NA_character_),
+    Xylose = list(components = "xylose", bond = NA_character_),
+    Arabinose = list(components = "arabinose", bond = NA_character_),
+    Ribose = list(components = "ribose", bond = NA_character_),
+    Deoxyribose = list(components = "deoxyribose", bond = NA_character_),
+    Fucose = list(components = "fucose", bond = NA_character_),
+    Rhamnose = list(components = "rhamnose", bond = NA_character_),
+    Gluconate = list(components = "gluconate", bond = NA_character_)
+  )
+}
+
+.dnmb_cct_carbon_source_render_spec <- function(source_id) {
+  source_id <- trimws(as.character(source_id)[1])
+  catalog <- .dnmb_cct_carbon_source_render_catalog()
+  catalog_names <- names(catalog)
+  catalog_idx <- match(tolower(source_id), tolower(catalog_names))
+  registered <- !is.na(catalog_idx)
+  if (registered) {
+    canonical_id <- catalog_names[catalog_idx]
+    item <- catalog[[catalog_idx]]
+  } else {
+    canonical_id <- source_id
+    item <- list(components = tolower(source_id), bond = NA_character_)
+  }
+  n_comp <- length(item$components)
+  data.frame(
+    source_id = rep(canonical_id, n_comp),
+    component_index = seq_len(n_comp),
+    sugar_type = as.character(item$components),
+    x_offset_r = seq(
+      -(n_comp - 1) / 2, (n_comp - 1) / 2,
+      length.out = n_comp
+    ) * 2.18,
+    bond = rep(as.character(item$bond)[1], n_comp),
+    registered = rep(registered, n_comp),
+    stringsAsFactors = FALSE,
+    row.names = NULL
+  )
+}
+
+.dnmb_cct_render_carbon_source_node <- function(p, x, y, source_id,
+                                                 r = .dnmb_cct_sugar_icon_radius(),
+                                                 alpha = 1) {
+  spec <- .dnmb_cct_carbon_source_render_spec(source_id)
+  component_r <- r
+  component_x <- x + spec$x_offset_r * r
+  source_abbr <- .dnmb_cct_carbon_source_abbreviation(source_id)
+
+  if (nrow(spec) > 1L) {
+    bond_style <- if (identical(spec$bond[1], "beta")) "dashed" else "solid"
+    bond_df <- data.frame(
+      x = head(component_x, -1L), xend = tail(component_x, -1L),
+      y = rep(y, nrow(spec) - 1L), yend = rep(y, nrow(spec) - 1L)
+    )
+    p <- p +
+      ggplot2::geom_segment(
+        data = bond_df,
+        ggplot2::aes(x = .data$x, xend = .data$xend, y = .data$y, yend = .data$yend),
+        color = "white", linewidth = 1.25, alpha = 0.92 * alpha,
+        lineend = "round", inherit.aes = FALSE
+      ) +
+      ggplot2::geom_segment(
+        data = bond_df,
+        ggplot2::aes(x = .data$x, xend = .data$xend, y = .data$y, yend = .data$yend),
+        color = "#4F5963", linewidth = 0.42, linetype = bond_style,
+        alpha = alpha, lineend = "round", inherit.aes = FALSE
+      )
+  }
+
+  for (i in seq_len(nrow(spec))) {
+    component_label <- if (nrow(spec) == 1L) {
+      .dnmb_cct_compact_inside_label(source_abbr, max_chars = 5L)
+    } else {
+      NULL
+    }
+    p <- .dnmb_snfg_render_symbol_v2(
+      p, component_x[i], y, spec$sugar_type[i], r = component_r,
+      label = component_label, alpha = alpha
+    )
+  }
+
+  if (nrow(spec) > 1L && nzchar(source_abbr)) {
+    label_df <- data.frame(x = x, y = y, label = source_abbr)
+    p <- p +
+      ggplot2::geom_text(
+        data = label_df,
+        ggplot2::aes(x = .data$x, y = .data$y, label = .data$label),
+        size = r * 12.0, fontface = "bold", color = "white",
+        alpha = alpha, lineheight = 0.82, inherit.aes = FALSE
+      ) +
+      ggplot2::geom_text(
+        data = label_df,
+        ggplot2::aes(x = .data$x, y = .data$y, label = .data$label),
+        size = r * 9.2, fontface = "bold", color = "#263238",
+        alpha = alpha, lineheight = 0.82, inherit.aes = FALSE
+      )
+  }
   p
 }
 
@@ -2413,15 +2588,140 @@
 .dnmb_snfg_abbreviation_v2 <- function(sugar_type) {
   abbr <- c(
     glucose = "Glc", galactose = "Gal", mannose = "Man", fructose = "Fru",
-    glcnac = "NAc", galnac = "NAc", fucose = "Fuc", rhamnose = "Rha",
-    xylose = "Xyl", arabinose = "Ara", glca = "GA", gala = "GA",
-    ribose = "Rib", glycerol = "Gly", glucosamine = "GlN",
+    glcnac = "GlcNAc", galnac = "GalNAc", fucose = "Fuc", rhamnose = "Rha",
+    xylose = "Xyl", arabinose = "Ara", glca = "GlcA", gala = "GalA",
+    ribose = "Rib", deoxyribose = "dRib", glycerol = "Gro",
+    glucosamine = "GlcN", nag = "GlcNAc",
     trehalose = "Tre", sucrose = "Suc", maltose = "Mal",
     cellobiose = "Cel", lactose = "Lac", mannitol = "Mtl",
     gluconate = "Gnt", intermediate = "", organic_acid = "",
     phospho_sugar = "", generic = "")
   key <- tolower(sugar_type)
   if (key %in% names(abbr)) unname(abbr[key]) else ""
+}
+
+.dnmb_cct_carbon_source_abbreviation <- function(source_id) {
+  source_id <- tolower(trimws(as.character(source_id)[1]))
+  abbr <- c(
+    maltose = "Mal", cellobiose = "Cel", galactose = "Gal",
+    trehalose = "Tre", lactose = "Lac", mannose = "Man",
+    nag = "GlcNAc", glucosamine = "GlcN", fructose = "Fru",
+    sucrose = "Suc", mannitol = "Mtl", glycerol = "Gro",
+    xylose = "Xyl", arabinose = "Ara", ribose = "Rib",
+    deoxyribose = "dRib", fucose = "Fuc", rhamnose = "Rha",
+    gluconate = "Gnt"
+  )
+  if (source_id %in% names(abbr)) unname(abbr[source_id]) else ""
+}
+
+.dnmb_cct_compact_inside_label <- function(label, max_chars = 7L) {
+  label <- trimws(as.character(label)[1])
+  if (is.na(label) || !nzchar(label)) return("")
+  if (max(nchar(strsplit(label, "\n", fixed = TRUE)[[1]])) <= max_chars) {
+    return(label)
+  }
+  if (grepl("-", label, fixed = TRUE)) {
+    return(sub("^([^-]+)-", "\\1-\n", label))
+  }
+  if (identical(label, "GlcNAc")) return("Glc\nNAc")
+  if (identical(label, "GalNAc")) return("Gal\nNAc")
+  label
+}
+
+# Cytoplasmic sugar and sugar-phosphate nodes carry their abbreviation inside
+# the glyph. Non-sugar endpoints retain their external labels.
+.dnmb_cct_cytoplasmic_inside_label <- function(id, label, type, sugar_type) {
+  id <- as.character(id)[1]
+  type <- as.character(type)[1]
+  if (!type %in% c("backbone", "ppp", "entry_intermediate", "ed")) return("")
+  if (id %in% c("Pyruvate", "Acetyl-CoA")) return("")
+
+  short_by_id <- c(
+    Glucose = "Glc",
+    Xylulose = "Xul",
+    Ribulose = "Rul",
+    `Deoxyribose-5-P` = "dRib-5-P",
+    Fuculose = "Fucol",
+    Rhamnulose = "Rhul",
+    `Glycerol-3-P` = "Gro-3-P"
+  )
+  short <- if (id %in% names(short_by_id)) {
+    unname(short_by_id[id])
+  } else {
+    as.character(label)[1]
+  }
+  .dnmb_cct_compact_inside_label(short, max_chars = 7L)
+}
+
+.dnmb_cct_snfg_legend_catalog <- function() {
+  data.frame(
+    sugar = c(
+      "glucose", "galactose", "mannose", "fructose", "glcnac", "galnac",
+      "glucosamine", "fucose", "rhamnose", "xylose", "arabinose", "ribose",
+      "deoxyribose", "glca", "gala", "glycerol", "mannitol", "gluconate",
+      "trehalose", "sucrose", "maltose", "cellobiose", "lactose"
+    ),
+    label = c(
+      "D-Glucose (Glc)", "D-Galactose (Gal)", "D-Mannose (Man)",
+      "D-Fructose (Fru)", "N-Acetyl-D-glucosamine (GlcNAc)",
+      "N-Acetyl-D-galactosamine (GalNAc)", "D-Glucosamine (GlcN)",
+      "L-Fucose (Fuc)", "L-Rhamnose (Rha)", "D-Xylose (Xyl)",
+      "L-Arabinose (Ara)", "D-Ribose (Rib)",
+      "2-Deoxy-D-ribose (dRib)", "D-Glucuronic acid (GlcA)",
+      "D-Galacturonic acid (GalA)", "Glycerol (Gro)",
+      "D-Mannitol (Mtl)", "D-Gluconate", "Trehalose (Tre)",
+      "Sucrose (Suc)", "Maltose (Mal)", "Cellobiose (Cel)", "Lactose (Lac)"
+    ),
+    stringsAsFactors = FALSE,
+    row.names = NULL
+  )
+}
+
+.dnmb_cct_used_snfg_types <- function(cyto_nodes = NULL, source_ids = NULL,
+                                      monomer_ids = NULL, extra_chains = NULL,
+                                      extra_branches = NULL) {
+  used <- character(0)
+  if (is.data.frame(cyto_nodes) && "sugar_type" %in% names(cyto_nodes)) {
+    used <- c(used, as.character(cyto_nodes$sugar_type))
+  }
+  if (length(source_ids)) {
+    source_components <- unlist(lapply(source_ids, function(source_id) {
+      .dnmb_cct_carbon_source_render_spec(source_id)$sugar_type
+    }), use.names = FALSE)
+    used <- c(used, source_components)
+  }
+  if (length(monomer_ids)) used <- c(used, as.character(monomer_ids))
+  if (length(extra_chains)) used <- c(used, unlist(extra_chains, use.names = FALSE))
+  if (length(extra_branches)) {
+    branch_types <- unlist(lapply(extra_branches, function(branches) {
+      if (is.null(branches) || !length(branches)) return(character(0))
+      vapply(branches, function(branch) as.character(branch$sugar)[1], character(1))
+    }), use.names = FALSE)
+    used <- c(used, branch_types)
+  }
+  used <- unique(.dnmb_cct_canonical_sugar_id(used))
+  used <- used[!is.na(used) & nzchar(used)]
+  setdiff(used, c("generic", "intermediate", "organic_acid", "phospho_sugar"))
+}
+
+.dnmb_cct_snfg_legend_data <- function(sugar_types) {
+  used <- unique(.dnmb_cct_canonical_sugar_id(sugar_types))
+  used <- used[!is.na(used) & nzchar(used)]
+  used <- setdiff(used, c("generic", "intermediate", "organic_acid", "phospho_sugar"))
+  catalog <- .dnmb_cct_snfg_legend_catalog()
+  known <- catalog[catalog$sugar %in% used, , drop = FALSE]
+  unknown <- setdiff(used, catalog$sugar)
+  if (length(unknown)) {
+    unknown_df <- data.frame(
+      sugar = unknown,
+      label = tools::toTitleCase(gsub("_", " ", unknown, fixed = TRUE)),
+      stringsAsFactors = FALSE,
+      row.names = NULL
+    )
+    known <- rbind(known, unknown_df)
+  }
+  rownames(known) <- NULL
+  known
 }
 
 .dnmb_cct_canonical_sugar_id <- function(sugar_type) {
@@ -2440,6 +2740,169 @@
   }
   sp <- .dnmb_snfg_sugar_spec_v2(tolower(as.character(sugar_type)))
   if (!is.null(sp$color) && nzchar(sp$color)) sp$color else fallback
+}
+
+.dnmb_cct_monomer_lane_map <- function() {
+  c(
+    glucose = "glucose", galactose = "galactose", mannose = "mannose",
+    fructose = "fructose", glcnac = "glcnac", xylose = "xylose",
+    arabinose = "arabinose", ribose = "ribose", fucose = "fucose",
+    rhamnose = "rhamnose", glca = "glca", gala = "glca",
+    glycerol = "glycerol", glucosamine = "glcnac",
+    deoxyribose = "deoxyribose"
+  )
+}
+
+.dnmb_cct_extracellular_monomer_ids <- function() {
+  c(
+    "glucose", "galactose", "mannose", "fructose", "glcnac",
+    "xylose", "arabinose", "ribose", "deoxyribose", "fucose",
+    "rhamnose", "glca", "gala"
+  )
+}
+
+.dnmb_cct_transporter_pathway_map <- function() {
+  c(
+    glucose = "Glucose", maltose = "Maltose",
+    cellobiose = "Cellobiose", galactose = "Galactose",
+    trehalose = "Trehalose", lactose = "Lactose",
+    mannose = "Mannose", nag = "NAG",
+    glucosamine = "Glucosamine", fructose = "Fructose",
+    sucrose = "Sucrose", mannitol = "Mannitol",
+    glycerol = "Glycerol", xylose = "Xylose",
+    arabinose = "Arabinose", ribose = "Ribose",
+    fucose = "Fucose", rhamnose = "Rhamnose",
+    gluconate = "Gluconate", deoxyribose = "Deoxyribose"
+  )
+}
+
+.dnmb_cct_transporter_route_id <- function(cs_id, target_key) {
+  paste(
+    "transport", trimws(as.character(cs_id)[1L]),
+    trimws(as.character(target_key)[1L]), sep = ":"
+  )
+}
+
+# Resolve the visible extracellular source for each selected transporter lane.
+# Existing chains and monomer glyphs are preferred; a source with no visible
+# extracellular representation receives an explicit substrate glyph at y_mono.
+.dnmb_cct_transporter_source_anchors <- function(cs_ids, carbon_src,
+                                                 mono_x_map, y_mono,
+                                                 extra_center_map = numeric(),
+                                                 extra_y_map = numeric()) {
+  empty <- data.frame(
+    cs_id = character(), source_kind = character(), source_id = character(),
+    source_x = numeric(), source_y = numeric(), create_glyph = logical(),
+    glyph_source_id = character(), sugar_type = character(),
+    cyto_x = numeric(), cyto_y = numeric(), stringsAsFactors = FALSE
+  )
+  cs_ids <- unique(trimws(as.character(cs_ids)))
+  cs_ids <- cs_ids[!is.na(cs_ids) & nzchar(cs_ids)]
+  if (!length(cs_ids) || is.null(carbon_src) || !nrow(carbon_src)) return(empty)
+
+  source_sugar <- c(
+    Glucose = "glucose", Maltose = "maltose", Cellobiose = "cellobiose",
+    Galactose = "galactose", Trehalose = "trehalose",
+    Lactose = "lactose", Mannose = "mannose", NAG = "glcnac",
+    Glucosamine = "glucosamine", Fructose = "fructose",
+    Sucrose = "sucrose", Mannitol = "mannitol", Glycerol = "glycerol",
+    Xylose = "xylose", Arabinose = "arabinose", Ribose = "ribose",
+    Deoxyribose = "deoxyribose", Fucose = "fucose",
+    Rhamnose = "rhamnose", Gluconate = "gluconate"
+  )
+  chain_names <- names(extra_center_map)
+  mono_names <- names(mono_x_map)
+  rows <- lapply(cs_ids, function(cs_id) {
+    cyto_idx <- match(tolower(cs_id), tolower(as.character(carbon_src$id)))
+    if (is.na(cyto_idx)) return(NULL)
+    cyto_x <- suppressWarnings(as.numeric(carbon_src$x[cyto_idx]))
+    cyto_y <- suppressWarnings(as.numeric(carbon_src$y[cyto_idx]))
+    if (!is.finite(cyto_x) || !is.finite(cyto_y)) return(NULL)
+
+    chain_idx <- match(tolower(cs_id), tolower(chain_names))
+    if (!is.na(chain_idx)) {
+      source_x <- suppressWarnings(as.numeric(extra_center_map[chain_idx]))
+      source_y <- suppressWarnings(as.numeric(extra_y_map[chain_idx]))
+      if (is.finite(source_x) && is.finite(source_y)) {
+        return(data.frame(
+          cs_id = cs_id, source_kind = "complex_chain",
+          source_id = chain_names[chain_idx], source_x = source_x,
+          source_y = source_y, create_glyph = FALSE,
+          glyph_source_id = cs_id,
+          sugar_type = unname(source_sugar[cs_id]) %||% tolower(cs_id),
+          cyto_x = cyto_x, cyto_y = cyto_y,
+          stringsAsFactors = FALSE
+        ))
+      }
+    }
+
+    sugar_id <- unname(source_sugar[cs_id])
+    if (is.na(sugar_id) || !nzchar(sugar_id)) sugar_id <- tolower(cs_id)
+    mono_idx <- match(tolower(sugar_id), tolower(mono_names))
+    if (!is.na(mono_idx)) {
+      source_x <- suppressWarnings(as.numeric(mono_x_map[mono_idx]))
+      if (is.finite(source_x) && is.finite(y_mono)) {
+        return(data.frame(
+          cs_id = cs_id, source_kind = "monosaccharide",
+          source_id = mono_names[mono_idx], source_x = source_x,
+          source_y = as.numeric(y_mono), create_glyph = FALSE,
+          glyph_source_id = cs_id, sugar_type = sugar_id,
+          cyto_x = cyto_x, cyto_y = cyto_y,
+          stringsAsFactors = FALSE
+        ))
+      }
+    }
+
+    data.frame(
+      cs_id = cs_id, source_kind = "explicit_source",
+      source_id = paste0("uptake:", tolower(cs_id)), source_x = cyto_x,
+      source_y = as.numeric(y_mono), create_glyph = TRUE,
+      glyph_source_id = cs_id, sugar_type = sugar_id,
+      cyto_x = cyto_x, cyto_y = cyto_y,
+      stringsAsFactors = FALSE
+    )
+  })
+  out <- dplyr::bind_rows(rows)
+  if (!nrow(out)) return(empty)
+  explicit_idx <- which(out$create_glyph)
+  if (length(explicit_idx)) {
+    occupied_x <- suppressWarnings(as.numeric(mono_x_map))
+    occupied_x <- occupied_x[is.finite(occupied_x)]
+    explicit_idx <- explicit_idx[order(out$source_x[explicit_idx], out$cs_id[explicit_idx])]
+    candidate_offsets <- c(0, as.vector(rbind(seq(0.5, 4, by = 0.5), -seq(0.5, 4, by = 0.5))))
+    for (idx in explicit_idx) {
+      desired <- .dnmb_cct_snap_to_grid(out$source_x[idx], step = 0.25)
+      candidates <- desired + candidate_offsets
+      free <- vapply(candidates, function(candidate) {
+        !length(occupied_x) || all(abs(candidate - occupied_x) >= 0.50 - 1e-10)
+      }, logical(1))
+      chosen <- if (any(free)) candidates[which(free)[1L]] else desired
+      out$source_x[idx] <- chosen
+      occupied_x <- c(occupied_x, chosen)
+    }
+  }
+  out[order(out$source_x, out$cs_id), , drop = FALSE]
+}
+
+.dnmb_cct_separate_lanes <- function(x, min_gap = 0.5, snap_step = 0.25) {
+  original_names <- names(x)
+  x <- as.numeric(x)
+  names(x) <- if (!is.null(original_names)) original_names else as.character(seq_along(x))
+  finite <- is.finite(x)
+  if (sum(finite) < 2L) return(x)
+
+  idx <- which(finite)
+  ord <- idx[order(x[idx], idx)]
+  target <- .dnmb_cct_snap_to_grid(x[ord], step = snap_step)
+  placed <- target
+  for (i in seq_along(placed)[-1L]) {
+    placed[i] <- max(target[i], placed[i - 1L] + min_gap)
+  }
+  placed <- placed + .dnmb_cct_snap_to_grid(
+    mean(target) - mean(placed), step = snap_step
+  )
+  x[ord] <- placed
+  x
 }
 
 .dnmb_cct_reference_gray <- function(strength = c("light", "mid", "dark")) {
@@ -2528,9 +2991,9 @@
 .dnmb_cct_is_transport_like_step <- function(step_id, gene_name = NA_character_, is_pts = FALSE) {
   if (isTRUE(is_pts)) return(TRUE)
   # Generic keywords (match anywhere in step_id or gene_name)
-  generic_re <- "transport|permease|porter|uptake|symporter|antiporter|binding.protein|\\bsbp\\b|\\babc\\b|\\bmfs\\b|\\bpts\\b|\\beiic|\\beiib|\\beiia"
+  generic_re <- "transport|permease|porter|uptake|symporter|antiporter|binding.protein|sodium.?solute|\\bsbp\\b|\\babc\\b|\\bmfs\\b|\\bsss\\b|\\bpts\\b|\\beiic|\\beiib|\\beiia"
   # Specific gene names (use word boundaries, check each field separately)
-  gene_re <- "\\b(mgl[ABC]|msiK|malE|malF|malG|malK|thu[EFGK]|rbs[ABC]|xyl[FGH]|ggu[AB]|glc[TUVP]|galP|lac[PEFG]|chvE|gts[ABCD]|kguT|ara[ESTUV]|mtl[AEK]|fucP|nagE|nagF|nagPcb|fruA|fruB|fruD|scrT|sacP|cscB|treB|manP|bglF|celB|ascB|ptsG|ptsH|ptsI|crr)\\b"
+  gene_re <- "\\b(mgl[ABC]|msiK|malE|malF|malG|malK|thu[EFGK]|rbs[ABC]|xyl[FGHT]|ggu[AB]|glc[TUVP]|galP|lac[PEFG]|chvE|gts[ABCD]|kguT|ara[ESTUV]|mtl[AEK]|fucP|deoP|nagE|nagF|nagPcb|fruA|fruB|fruD|scrT|sacP|cscB|treB|manP|bglF|celB|ascB|ptsG|ptsH|ptsI|crr)\\b"
   sid <- as.character(step_id)[1]
   gnm <- as.character(gene_name)[1]
   if (grepl(generic_re, sid, ignore.case = TRUE)) return(TRUE)
@@ -2540,11 +3003,123 @@
   FALSE
 }
 
+# Build one physical transporter entity per locus while retaining every
+# supported locus/pathway/model relationship in a separate membership table.
+.dnmb_cct_transporter_entities <- function(transporters) {
+  empty_entities <- data.frame(
+    entity_id = character(), locus_tag = character(),
+    model_names = character(), substrate_names = character(),
+    pathway_names = character(), n_models = integer(),
+    n_substrates = integer(), n_memberships = integer(),
+    shared = logical(), label = character(),
+    stringsAsFactors = FALSE
+  )
+  empty_memberships <- data.frame(
+    entity_id = character(), locus_tag = character(),
+    pathway = character(), step = character(), cs_id = character(),
+    confidence = character(), step_score = numeric(),
+    shared = logical(), stringsAsFactors = FALSE
+  )
+  if (is.null(transporters) || !is.data.frame(transporters) || !nrow(transporters)) {
+    return(list(entities = empty_entities, memberships = empty_memberships))
+  }
+
+  required <- c("locus_tag", "pathway", "step")
+  missing_required <- setdiff(required, names(transporters))
+  if (length(missing_required)) {
+    stop(
+      "transporter entity construction requires columns: ",
+      paste(required, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  rows <- as.data.frame(transporters, stringsAsFactors = FALSE, row.names = NULL)
+  rows$.source_order <- seq_len(nrow(rows))
+  rows$locus_tag <- trimws(.dnmb_cct_normalize_locus_tag(rows$locus_tag))
+  rows$pathway <- trimws(as.character(rows$pathway))
+  rows$step <- trimws(as.character(rows$step))
+  if (!"cs_id" %in% names(rows)) rows$cs_id <- rows$pathway
+  rows$cs_id <- trimws(as.character(rows$cs_id))
+  missing_cs <- is.na(rows$cs_id) | !nzchar(rows$cs_id)
+  rows$cs_id[missing_cs] <- rows$pathway[missing_cs]
+
+  if (!"confidence" %in% names(rows)) rows$confidence <- NA_character_
+  rows$confidence <- tolower(trimws(as.character(rows$confidence)))
+  if (!"step_score" %in% names(rows)) rows$step_score <- NA_real_
+  rows$step_score <- suppressWarnings(as.numeric(rows$step_score))
+  rows$.confidence_rank <- unname(c(none = 0L, low = 1L, medium = 2L, high = 3L)[rows$confidence])
+  rows$.confidence_rank[is.na(rows$.confidence_rank)] <- 0L
+
+  valid_locus <- !is.na(rows$locus_tag) & nzchar(rows$locus_tag)
+  valid_membership <- !is.na(rows$pathway) & nzchar(rows$pathway) &
+    !is.na(rows$step) & nzchar(rows$step) &
+    !is.na(rows$cs_id) & nzchar(rows$cs_id)
+  foreground <- rows$confidence %in% c("high", "medium") |
+    (!is.na(rows$step_score) & rows$step_score >= 1)
+  rows <- rows[valid_locus & valid_membership & foreground, , drop = FALSE]
+  if (!nrow(rows)) {
+    return(list(entities = empty_entities, memberships = empty_memberships))
+  }
+
+  score_order <- ifelse(is.na(rows$step_score), -Inf, rows$step_score)
+  rows <- rows[order(
+    rows$locus_tag, rows$pathway, rows$step,
+    -rows$.confidence_rank, -score_order, rows$.source_order
+  ), , drop = FALSE]
+  membership_key <- paste(rows$locus_tag, rows$pathway, rows$step, sep = "\r")
+  rows <- rows[!duplicated(membership_key), , drop = FALSE]
+
+  entity_rows <- lapply(split(seq_len(nrow(rows)), rows$locus_tag), function(idx) {
+    member <- rows[idx, , drop = FALSE]
+    models <- unique(member$step)
+    substrates <- unique(member$cs_id)
+    pathways <- unique(member$pathway)
+    is_shared <- length(substrates) > 1L
+    locus <- member$locus_tag[1]
+    model_text <- paste(models, collapse = " | ")
+    substrate_text <- paste(substrates, collapse = " | ")
+    data.frame(
+      entity_id = locus,
+      locus_tag = locus,
+      model_names = model_text,
+      substrate_names = substrate_text,
+      pathway_names = paste(pathways, collapse = " | "),
+      n_models = length(models),
+      n_substrates = length(substrates),
+      n_memberships = nrow(member),
+      shared = is_shared,
+      label = paste0(
+        locus,
+        "\nModels: ", model_text,
+        "\nSubstrates: ", substrate_text,
+        "\nShared: ", if (is_shared) "yes" else "no"
+      ),
+      stringsAsFactors = FALSE
+    )
+  })
+  entities <- do.call(rbind, entity_rows)
+  rownames(entities) <- NULL
+  entities <- entities[order(entities$locus_tag), , drop = FALSE]
+
+  rows$entity_id <- rows$locus_tag
+  rows$shared <- entities$shared[match(rows$locus_tag, entities$locus_tag)]
+  private_columns <- c(".source_order", ".confidence_rank")
+  key_columns <- c(
+    "entity_id", "locus_tag", "pathway", "step", "cs_id",
+    "confidence", "step_score", "shared"
+  )
+  memberships <- rows[, c(key_columns, setdiff(names(rows), c(key_columns, private_columns))), drop = FALSE]
+  rownames(memberships) <- NULL
+
+  list(entities = entities, memberships = memberships)
+}
+
 .dnmb_cct_transporter_half_span <- function(step_id, gene_name = NA_character_, is_pts = FALSE) {
   txt <- paste(step_id, gene_name)
   if (isTRUE(is_pts)) return(0.34)
   if (grepl("abc|sbp|binding|malE|mgl[ABC]|rbs[ABC]|xyl[FGH]|thu[EFG]", txt, ignore.case = TRUE)) return(0.30)
-  if (grepl("mfs|permease|symporter|transporter|porter|gnt|lac|gal|man|srl|iolT|kgtP", txt, ignore.case = TRUE)) return(0.26)
+  if (grepl("mfs|sss|sodium.?solute|permease|symporter|transporter|porter|xylT|gnt|lac|gal|man|srl|iolT|kgtP", txt, ignore.case = TRUE)) return(0.26)
   0.22
 }
 
@@ -2626,7 +3201,7 @@
   if (grepl("abc|sbp|binding|malE|mgl[ABC]|rbs[ABC]|xyl[FGH]|thu[EFG]|pot[ABCD]", txt, ignore.case = TRUE)) {
     return("ABC")
   }
-  if (grepl("mfs|permease|symporter|transporter|porter|gnt|lac|gal|man|srl|iolT|kgtP|thuK|glpO", txt, ignore.case = TRUE)) {
+  if (grepl("mfs|sss|sodium.?solute|permease|symporter|transporter|porter|xylT|gnt|lac|gal|man|srl|iolT|kgtP|thuK|glpO", txt, ignore.case = TRUE)) {
     return("MFS")
   }
   "GEN"
@@ -2910,92 +3485,771 @@
 }
 
 .dnmb_cct_pack_transporters_lane <- function(center_x, half_spans, lane_ranks,
-                                            label_widths = NULL,
-                                            label_dx = NULL,
-                                            desired_x = NULL) {
+                                             label_widths = NULL,
+                                             label_dx = NULL,
+                                             desired_x = NULL,
+                                             stable_ids = NULL,
+                                             y_memb = 8.5,
+                                             xlim = NULL,
+                                             min_gap = 0.08,
+                                             coincident_tolerance = 1e-6,
+                                             coincident_fan_gap = 0.22,
+                                             row_step = 0.12,
+                                             max_rows = 3L) {
   n <- length(half_spans)
   if (n == 0) return(data.frame(tx = numeric(0), ty = numeric(0), row_id = integer(0)))
-  if (n == 1) return(data.frame(tx = center_x, ty = 8.50, row_id = 1L))
-
-  priorities <- if (missing(lane_ranks) || length(lane_ranks) != n) rep(1, n) else lane_ranks
-  priorities <- rank(-priorities, ties.method = "first")
-  weight <- rev(priorities) + 1
-  if (is.null(label_widths) || length(label_widths) != n) label_widths <- rep(0.4, n)
-  if (is.null(label_dx) || length(label_dx) != n) label_dx <- rep(0, n)
-  if (is.null(desired_x) || length(desired_x) != n) desired_x <- rep(center_x, n)
-
-  row_patterns <- switch(as.character(n),
-    `2` = list(c(2L), c(1L, 1L)),
-    `3` = list(c(2L, 1L), c(1L, 2L), c(1L, 1L, 1L)),
-    `4` = list(c(2L, 2L), c(1L, 2L, 1L), c(2L, 1L, 1L), c(1L, 1L, 2L), c(1L, 1L, 1L, 1L)),
-    list(rep(1L, n))
-  )
-  perms <- .dnmb_cct_small_permutations(seq_len(n))
-
-  pack_rows <- function(row_groups) {
-    y_levels <- c(8.56, 8.44, 8.32)
-    tx <- numeric(n)
-    ty <- numeric(n)
-    row_id <- integer(n)
-    gap <- 0.08
-    for (rr in seq_along(row_groups)) {
-      idx <- row_groups[[rr]]
-      spans <- half_spans[idx]
-      widths <- 2 * spans
-      total_w <- sum(widths) + gap * max(0, length(idx) - 1L)
-      left <- center_x - total_w / 2
-      cur <- left
-      for (j in seq_along(idx)) {
-        ii <- idx[j]
-        tx[ii] <- cur + widths[j] / 2
-        ty[ii] <- y_levels[rr]
-        row_id[ii] <- rr
-        cur <- tx[ii] + widths[j] / 2 + gap
-      }
-    }
-    data.frame(tx = tx, ty = ty, row_id = row_id)
+  half_spans <- pmax(0.04, as.numeric(half_spans))
+  desired_x <- if (is.null(desired_x) || length(desired_x) != n) {
+    rep(as.numeric(center_x)[1], n)
+  } else {
+    as.numeric(desired_x)
   }
+  priorities <- if (missing(lane_ranks) || length(lane_ranks) != n) {
+    rep(1, n)
+  } else {
+    as.numeric(lane_ranks)
+  }
+  priorities[!is.finite(priorities)] <- 0
+  stable_ids <- if (is.null(stable_ids) || length(stable_ids) != n) {
+    sprintf("%08d", seq_len(n))
+  } else {
+    as.character(stable_ids)
+  }
+  missing_ids <- is.na(stable_ids) | !nzchar(stable_ids)
+  stable_ids[missing_ids] <- sprintf("%08d", which(missing_ids))
+  min_gap <- max(0, as.numeric(min_gap)[1])
+  coincident_tolerance <- max(0, as.numeric(coincident_tolerance)[1])
+  coincident_fan_gap <- max(0, as.numeric(coincident_fan_gap)[1])
+  row_step <- max(0.10, as.numeric(row_step)[1])
+  max_rows <- max(1L, min(3L, as.integer(max_rows)[1]))
 
-  best <- NULL
-  best_cost <- Inf
-  for (pat in row_patterns) {
-    for (perm in perms) {
-      start <- 1L
-      row_groups <- list()
-      for (ps in pat) {
-        row_groups[[length(row_groups) + 1L]] <- perm[start:(start + ps - 1L)]
-        start <- start + ps
-      }
-      cand <- pack_rows(row_groups)
-      span_cost <- (max(cand$tx) - min(cand$tx)) * 2.5
-      center_cost <- sum(abs(cand$tx - desired_x) * weight)
-      row_cost <- sum((cand$row_id - 1L) * weight * 1.15)
-      low_row_penalty <- sum((cand$row_id > 1L) * weight * 0.35)
-      label_cost <- 0
-      for (rr in unique(cand$row_id)) {
-        idx <- which(cand$row_id == rr)
-        if (length(idx) >= 2) {
-          label_x <- cand$tx[idx] + label_dx[idx]
-          ord2 <- idx[order(label_x)]
-          for (k in 2:length(ord2)) {
-            i1 <- ord2[k - 1L]; i2 <- ord2[k]
-            required_gap <- (label_widths[i1] + label_widths[i2]) / 2 + 0.10
-            actual_gap <- abs((cand$tx[i2] + label_dx[i2]) - (cand$tx[i1] + label_dx[i1]))
-            if (actual_gap < required_gap) {
-              label_cost <- label_cost + (required_gap - actual_gap) * 8
-            }
-          }
+  # Distinct loci can share the same substrate anchor. Fan those centers out
+  # before row packing so their glyphs and route trunks cannot read as one
+  # serial transporter. Stable locus IDs make the layout input-order invariant.
+  original_x <- desired_x
+  finite_ord <- order(original_x, stable_ids, na.last = NA)
+  if (length(finite_ord) > 1L && coincident_fan_gap > 0) {
+    group_start <- 1L
+    for (jj in seq.int(2L, length(finite_ord) + 1L)) {
+      group_done <- jj > length(finite_ord) ||
+        abs(original_x[finite_ord[jj]] - original_x[finite_ord[jj - 1L]]) >
+          coincident_tolerance
+      if (!group_done) next
+      idx <- finite_ord[group_start:(jj - 1L)]
+      if (length(idx) > 1L) {
+        idx <- idx[order(-priorities[idx], stable_ids[idx])]
+        fan_gap <- max(coincident_fan_gap, max(half_spans[idx]) + min_gap)
+        fan_step <- integer(length(idx))
+        if (length(idx) > 1L) {
+          kk <- seq_len(length(idx) - 1L)
+          fan_step[-1L] <- ceiling(kk / 2) * ifelse(kk %% 2L == 1L, 1L, -1L)
         }
+        candidate_x <- original_x[idx[1L]] + fan_step * fan_gap
+
+        if (!is.null(xlim) && length(xlim) >= 2L && all(is.finite(xlim[1:2]))) {
+          bounds <- sort(as.numeric(xlim[1:2]))
+          left <- min(candidate_x - half_spans[idx])
+          right <- max(candidate_x + half_spans[idx])
+          if (right > bounds[2]) candidate_x <- candidate_x - (right - bounds[2])
+          left <- min(candidate_x - half_spans[idx])
+          if (left < bounds[1]) candidate_x <- candidate_x + (bounds[1] - left)
+        }
+        desired_x[idx] <- candidate_x
       }
-      vertical_penalty <- max(cand$row_id) * 0.6
-      cost <- span_cost + center_cost + row_cost + low_row_penalty + label_cost + vertical_penalty
-      if (cost < best_cost) {
-        best <- cand
-        best_cost <- cost
-      }
+      group_start <- jj
     }
   }
-  best
+
+  # Greedy interval coloring keeps non-colliding glyphs on the membrane
+  # centerline. Only genuinely overlapping intervals use the two auxiliary
+  # membrane rows.
+  row_right <- rep(-Inf, max_rows)
+  row_id <- integer(n)
+  ord <- order(desired_x, -priorities, stable_ids, na.last = TRUE)
+  for (ii in ord) {
+    free <- which(desired_x[ii] - half_spans[ii] >= row_right + min_gap)
+    row <- if (length(free)) free[1] else which.min(row_right)
+    row_id[ii] <- row
+    placed_x <- max(desired_x[ii], row_right[row] + min_gap + half_spans[ii])
+    row_right[row] <- placed_x + half_spans[ii]
+  }
+
+  tx <- desired_x
+  for (row in seq_len(max_rows)) {
+    idx <- which(row_id == row)
+    if (!length(idx)) next
+    idx <- idx[order(desired_x[idx], -priorities[idx], stable_ids[idx])]
+    if (length(idx) > 1L) {
+      offsets <- numeric(length(idx))
+      for (jj in 2:length(idx)) {
+        offsets[jj] <- offsets[jj - 1L] + half_spans[idx[jj - 1L]] +
+          half_spans[idx[jj]] + min_gap
+      }
+      target <- desired_x[idx] - offsets
+      tx[idx] <- stats::isoreg(seq_along(target), target)$yf + offsets
+    }
+
+    if (!is.null(xlim) && length(xlim) >= 2L && all(is.finite(xlim[1:2]))) {
+      bounds <- sort(as.numeric(xlim[1:2]))
+      left <- min(tx[idx] - half_spans[idx])
+      right <- max(tx[idx] + half_spans[idx])
+      if (right > bounds[2]) tx[idx] <- tx[idx] - (right - bounds[2])
+      left <- min(tx[idx] - half_spans[idx])
+      if (left < bounds[1]) tx[idx] <- tx[idx] + (bounds[1] - left)
+    }
+  }
+
+  row_offsets <- c(0, row_step, -row_step)[seq_len(max_rows)]
+  data.frame(
+    tx = tx,
+    ty = y_memb + row_offsets[row_id],
+    row_id = row_id
+  )
+}
+
+# Route transporter memberships through one compact bus per substrate lane.
+# At shared transporter loci, each substrate keeps its own coloured landing
+# track so no membership disappears into a neutral common trunk.
+.dnmb_cct_transporter_bus_layout <- function(memberships, y_memb = 8.5,
+                                             bus_offset = 0.70,
+                                             tier_step = 0.065,
+                                             max_bus_offset = 1.12,
+                                             source_offset = 0.76,
+                                             glyph_clearance = 0.11,
+                                             membrane_half_height = 0.20,
+                                             route_gap = 0.10,
+                                             interval_gap = 0.05,
+                                             corner_radius = 0.08,
+                                             suppress_redundant_medium = TRUE) {
+  empty_segment <- data.frame(
+    group = character(), x = numeric(), xend = numeric(),
+    y = numeric(), yend = numeric(), color = character(),
+    confidence = character(), linewidth = numeric(), alpha = numeric(),
+    linetype = character(), stringsAsFactors = FALSE
+  )
+  empty_group <- data.frame(
+    group = character(), cs_id = character(), lane_x = numeric(),
+    source_x = numeric(), source_y = numeric(),
+    x_left = numeric(), x_right = numeric(), tier = integer(),
+    bus_y = numeric(), confidence = character(), color = character(),
+    direct = logical(), stringsAsFactors = FALSE
+  )
+  empty_membership <- data.frame(
+    group = character(), target_key = character(), cs_id = character(),
+    lane_x = numeric(), tx_draw = numeric(), ty_draw = numeric(),
+    bus_y = numeric(), direct = logical(), draw = logical(),
+    stringsAsFactors = FALSE
+  )
+  empty <- list(
+    groups = empty_group, memberships = empty_membership,
+    stems = empty_segment, buses = empty_segment,
+    trunks = empty_segment, direct = empty_segment,
+    exterior_routes = list(), exterior_source_routes = list(),
+    exterior_trunk_routes = list(), exterior_render_routes = list()
+  )
+  if (is.null(memberships) || !is.data.frame(memberships) || !nrow(memberships)) {
+    return(empty)
+  }
+
+  required <- c("cs_id", "lane_x", "tx_draw", "ty_draw")
+  missing_required <- setdiff(required, names(memberships))
+  if (length(missing_required)) {
+    stop(
+      "transporter bus layout requires columns: ",
+      paste(required, collapse = ", "),
+      call. = FALSE
+    )
+  }
+  rows <- as.data.frame(memberships, stringsAsFactors = FALSE, row.names = NULL)
+  if (!"confidence" %in% names(rows)) rows$confidence <- "medium"
+  if (!"color" %in% names(rows)) rows$color <- "#78909C"
+  rows$cs_id <- trimws(as.character(rows$cs_id))
+  rows$confidence <- tolower(trimws(as.character(rows$confidence)))
+  rows$confidence[!rows$confidence %in% c("high", "medium")] <- "medium"
+  rows$color <- as.character(rows$color)
+  rows$color[is.na(rows$color) | !nzchar(rows$color)] <- "#78909C"
+  rows$lane_x <- suppressWarnings(as.numeric(rows$lane_x))
+  if (!"source_x" %in% names(rows)) rows$source_x <- rows$lane_x
+  if (!"source_y" %in% names(rows)) rows$source_y <- y_memb + source_offset
+  if (!"source_trim" %in% names(rows)) rows$source_trim <- 0.10
+  rows$source_x <- suppressWarnings(as.numeric(rows$source_x))
+  rows$source_y <- suppressWarnings(as.numeric(rows$source_y))
+  rows$source_trim <- suppressWarnings(as.numeric(rows$source_trim))
+  rows$source_trim[!is.finite(rows$source_trim) | rows$source_trim < 0] <- 0.10
+  missing_source_x <- !is.finite(rows$source_x)
+  rows$source_x[missing_source_x] <- rows$lane_x[missing_source_x]
+  rows$lane_x <- rows$source_x
+  rows$tx_draw <- suppressWarnings(as.numeric(rows$tx_draw))
+  rows$ty_draw <- suppressWarnings(as.numeric(rows$ty_draw))
+  rows <- rows[
+    !is.na(rows$cs_id) & nzchar(rows$cs_id) &
+      is.finite(rows$lane_x) & is.finite(rows$source_y) &
+      is.finite(rows$tx_draw) & is.finite(rows$ty_draw),
+    , drop = FALSE
+  ]
+  if (!nrow(rows)) return(empty)
+  membrane_half_height <- max(0, as.numeric(membrane_half_height)[1L])
+  route_gap <- max(0, as.numeric(route_gap)[1L])
+  min_bus_offset <- max(
+    membrane_half_height,
+    max(rows$ty_draw + glyph_clearance - y_memb, na.rm = TRUE)
+  ) + route_gap
+  bus_offset <- max(as.numeric(bus_offset)[1L], min_bus_offset)
+  max_bus_offset <- max(as.numeric(max_bus_offset)[1L], bus_offset)
+
+  target_id <- if ("locus_tag" %in% names(rows)) {
+    as.character(rows$locus_tag)
+  } else if ("anchor_id" %in% names(rows)) {
+    as.character(rows$anchor_id)
+  } else {
+    rep(NA_character_, nrow(rows))
+  }
+  missing_target <- is.na(target_id) | !nzchar(target_id)
+  target_id[missing_target] <- paste0(
+    "xy:", formatC(rows$tx_draw[missing_target], digits = 6, format = "f"),
+    ":", formatC(rows$ty_draw[missing_target], digits = 6, format = "f")
+  )
+  rows$target_key <- target_id
+  rows <- rows[order(
+    rows$lane_x, rows$cs_id, rows$target_key,
+    -as.integer(rows$confidence == "high"), rows$tx_draw
+  ), , drop = FALSE]
+  rows <- rows[!duplicated(rows[, c("cs_id", "lane_x", "target_key")]), , drop = FALSE]
+
+  # A medium connector adds no visual information when the same substrate lane
+  # already has high-confidence uptake. Its locus remains in the evidence ledger.
+  rows$draw <- TRUE
+  if (isTRUE(suppress_redundant_medium)) {
+    lane_has_high <- ave(
+      rows$confidence == "high",
+      interaction(rows$cs_id, rows$lane_x, drop = TRUE),
+      FUN = any
+    )
+    rows$draw <- rows$confidence == "high" | !lane_has_high
+  }
+  draw_rows <- rows[rows$draw, , drop = FALSE]
+  if (!nrow(draw_rows)) return(empty)
+
+  lane_key <- paste0(
+    draw_rows$cs_id, "@",
+    formatC(draw_rows$lane_x, digits = 6, format = "f")
+  )
+  draw_rows$group <- lane_key
+  lane_split <- split(seq_len(nrow(draw_rows)), draw_rows$group)
+  group_rows <- lapply(names(lane_split), function(group_id) {
+    idx <- lane_split[[group_id]]
+    lane_x <- stats::median(draw_rows$source_x[idx])
+    source_y <- stats::median(draw_rows$source_y[idx])
+    target_x <- unique(draw_rows$tx_draw[idx])
+    direct <- length(target_x) == 1L && abs(target_x - lane_x) <= 1e-8
+    data.frame(
+      group = group_id,
+      cs_id = draw_rows$cs_id[idx[1L]],
+      lane_x = lane_x,
+      source_x = lane_x,
+      source_y = source_y,
+      x_left = min(c(lane_x, target_x)),
+      x_right = max(c(lane_x, target_x)),
+      tier = 0L,
+      bus_y = NA_real_,
+      confidence = if (any(draw_rows$confidence[idx] == "high")) "high" else "medium",
+      color = draw_rows$color[idx[1L]],
+      direct = direct,
+      stringsAsFactors = FALSE
+    )
+  })
+  groups <- dplyr::bind_rows(group_rows)
+  groups <- groups[order(groups$x_left, groups$x_right, groups$group), , drop = FALSE]
+
+  # Greedy interval coloring guarantees that horizontal buses on a tier do not
+  # overlap. The tier spacing contracts only when needed to remain below the
+  # extracellular monomer row.
+  bus_idx <- which(!groups$direct)
+  if (length(bus_idx)) {
+    tier_right <- numeric(0)
+    for (ii in bus_idx) {
+      free <- which(groups$x_left[ii] >= tier_right + interval_gap)
+      tier <- if (length(free)) free[1L] else length(tier_right) + 1L
+      if (tier > length(tier_right)) tier_right <- c(tier_right, -Inf)
+      groups$tier[ii] <- tier
+      tier_right[tier] <- groups$x_right[ii]
+    }
+    n_tiers <- max(groups$tier[bus_idx])
+    step_used <- if (n_tiers <= 1L) 0 else min(
+      tier_step,
+      max(0, (max_bus_offset - bus_offset) / (n_tiers - 1L))
+    )
+    groups$bus_y[bus_idx] <- y_memb + bus_offset +
+      (groups$tier[bus_idx] - 1L) * step_used
+  }
+  draw_rows$bus_y <- groups$bus_y[match(draw_rows$group, groups$group)]
+  draw_rows$direct <- groups$direct[match(draw_rows$group, groups$group)]
+
+  style_for <- function(confidence, bus = FALSE) {
+    high <- confidence == "high"
+    data.frame(
+      linewidth = ifelse(high, if (bus) 0.28 else 0.24, if (bus) 0.18 else 0.16),
+      alpha = ifelse(high, 0.68, 0.28),
+      linetype = ifelse(high, "solid", "dashed"),
+      stringsAsFactors = FALSE
+    )
+  }
+  segment_frame <- function(group, x, xend, y, yend, color, confidence,
+                            bus = FALSE) {
+    style <- style_for(confidence, bus = bus)
+    data.frame(
+      group = group, x = x, xend = xend, y = y, yend = yend,
+      color = color, confidence = confidence,
+      linewidth = style$linewidth, alpha = style$alpha,
+      linetype = style$linetype, stringsAsFactors = FALSE
+    )
+  }
+
+  buses <- if (length(bus_idx)) {
+    bus_groups <- groups[bus_idx, , drop = FALSE]
+    segment_frame(
+      bus_groups$group, bus_groups$x_left, bus_groups$x_right,
+      bus_groups$bus_y, bus_groups$bus_y,
+      bus_groups$color, bus_groups$confidence, bus = TRUE
+    )
+  } else empty_segment
+
+  # If a transporter trunk is already on the source x, it also serves as the
+  # substrate stem. The trunk is extended to source_y below so this omission
+  # never leaves a gap when the same group also has off-axis targets.
+  stem_groups <- groups[bus_idx, , drop = FALSE]
+  has_lane_trunk <- vapply(stem_groups$group, function(group_id) {
+    idx <- which(draw_rows$group == group_id)
+    any(abs(draw_rows$tx_draw[idx] - draw_rows$lane_x[idx]) <= 0.015)
+  }, logical(1))
+  stem_groups <- stem_groups[!has_lane_trunk, , drop = FALSE]
+  stems <- if (nrow(stem_groups)) {
+    segment_frame(
+      stem_groups$group, stem_groups$lane_x, stem_groups$lane_x,
+      stem_groups$source_y, stem_groups$bus_y,
+      stem_groups$color, stem_groups$confidence
+    )
+  } else empty_segment
+
+  # One trunk per physical transporter. Every substrate bus intersects this
+  # trunk at its own tier, preserving shared-locus traceability without fans.
+  trunk_rows <- draw_rows[!draw_rows$direct, , drop = FALSE]
+  trunk_split <- split(seq_len(nrow(trunk_rows)), trunk_rows$target_key)
+  trunks <- if (length(trunk_split)) {
+    dplyr::bind_rows(lapply(names(trunk_split), function(target_key) {
+      idx <- trunk_split[[target_key]]
+      target_conf <- if (any(trunk_rows$confidence[idx] == "high")) "high" else "medium"
+      target_colors <- unique(trunk_rows$color[idx])
+      trunk_color <- if (length(unique(trunk_rows$group[idx])) > 1L) "#52616B" else target_colors[1L]
+      aligned_source <- any(
+        draw_rows$target_key == target_key &
+          abs(draw_rows$lane_x - draw_rows$tx_draw) <= 1e-8
+      )
+      trunk_top <- max(
+        trunk_rows$bus_y[idx],
+        if (aligned_source) trunk_rows$source_y[idx] else -Inf
+      )
+      segment_frame(
+        paste0("target:", target_key),
+        trunk_rows$tx_draw[idx[1L]], trunk_rows$tx_draw[idx[1L]],
+        trunk_top,
+        trunk_rows$ty_draw[idx[1L]] + glyph_clearance,
+        trunk_color, target_conf
+      )
+    }))
+  } else empty_segment
+
+  direct_rows <- draw_rows[draw_rows$direct, , drop = FALSE]
+  # A shared trunk from another bus already passes through an aligned source.
+  trunk_targets <- names(trunk_split)
+  direct_rows <- direct_rows[!direct_rows$target_key %in% trunk_targets, , drop = FALSE]
+  direct <- if (nrow(direct_rows)) {
+    segment_frame(
+      direct_rows$group, direct_rows$lane_x, direct_rows$tx_draw,
+      direct_rows$source_y,
+      direct_rows$ty_draw + glyph_clearance,
+      direct_rows$color, direct_rows$confidence
+    )
+  } else empty_segment
+
+  rows$group <- paste0(
+    rows$cs_id, "@", formatC(rows$lane_x, digits = 6, format = "f")
+  )
+  rows$bus_y <- groups$bus_y[match(rows$group, groups$group)]
+  rows$direct <- groups$direct[match(rows$group, groups$group)]
+  membership_out <- rows[, c(
+    "group", "target_key", "cs_id", "lane_x", "source_x", "source_y",
+    "source_trim", "tx_draw", "ty_draw", "bus_y", "direct", "draw"
+  ), drop = FALSE]
+
+  # The plotted exterior connectors are complete raw orthogonal paths. Apply
+  # the corner radius only once after all bus coordinates are fixed, avoiding
+  # curve-then-step artifacts at the horizontal lane.
+  exterior_routes <- lapply(seq_len(nrow(draw_rows)), function(i) {
+    row <- draw_rows[i, , drop = FALSE]
+    target_y <- row$ty_draw + glyph_clearance
+    raw <- if (isTRUE(row$direct)) {
+      data.frame(x = c(row$source_x, row$tx_draw),
+                 y = c(row$source_y, target_y))
+    } else {
+      data.frame(
+        x = c(row$source_x, row$source_x, row$tx_draw, row$tx_draw),
+        y = c(row$source_y, row$bus_y, row$bus_y, target_y)
+      )
+    }
+    raw <- raw[c(TRUE, diff(raw$x) != 0 | diff(raw$y) != 0), , drop = FALSE]
+    points <- .dnmb_cct_round_orthogonal_route(
+      raw, radius = max(0.08, as.numeric(corner_radius)[1L])
+    )
+    style <- style_for(row$confidence)
+    list(
+      route_id = .dnmb_cct_transporter_route_id(row$cs_id, row$target_key),
+      cs_id = row$cs_id, target_key = row$target_key,
+      source_x = row$source_x, source_y = row$source_y,
+      target_x = row$tx_draw, target_y = target_y,
+      points = points, color = row$color,
+      confidence = row$confidence, linewidth = style$linewidth,
+      alpha = style$alpha, linetype = style$linetype,
+      trim_start = row$source_trim, arrow_last = TRUE
+    )
+  })
+
+  # Parallel landing tracks remain inside the transporter glyph envelope. One
+  # route stays on the physical centre; additional routes alternate right and
+  # left in deterministic substrate order so every colour remains visible.
+  render_target_x <- draw_rows$tx_draw
+  target_split <- split(seq_len(nrow(draw_rows)), draw_rows$target_key)
+  for (target_key in names(target_split)) {
+    idx <- target_split[[target_key]]
+    if (length(idx) < 2L) next
+    aligned <- abs(draw_rows$source_x[idx] - draw_rows$tx_draw[idx]) <= 1e-8
+    ord <- idx[order(
+      -as.integer(aligned),
+      -as.integer(draw_rows$confidence[idx] == "high"),
+      draw_rows$cs_id[idx], draw_rows$group[idx], draw_rows$source_x[idx]
+    )]
+    kk <- seq_len(length(ord) - 1L)
+    track_step <- integer(length(ord))
+    track_step[-1L] <- ceiling(kk / 2) * ifelse(kk %% 2L == 1L, 1L, -1L)
+    track_offset <- track_step * 0.035
+    if (max(abs(track_offset)) > 0.07) {
+      track_offset <- track_offset * 0.07 / max(abs(track_offset))
+    }
+    render_target_x[ord] <- stats::median(draw_rows$tx_draw[idx]) + track_offset
+  }
+
+  exterior_render_routes <- lapply(seq_len(nrow(draw_rows)), function(i) {
+    row <- draw_rows[i, , drop = FALSE]
+    landing_x <- render_target_x[i]
+    target_y <- row$ty_draw + glyph_clearance
+    has_fan_in <- abs(landing_x - row$tx_draw) > 1e-8
+    landing_y <- target_y + if (has_fan_in) 0.075 else 0
+    raw <- if (isTRUE(row$direct) && abs(row$source_x - landing_x) <= 1e-8) {
+      data.frame(x = c(row$source_x, landing_x), y = c(row$source_y, landing_y))
+    } else {
+      join_y <- if (isTRUE(row$direct)) y_memb + bus_offset else row$bus_y
+      data.frame(
+        x = c(row$source_x, row$source_x, landing_x, landing_x),
+        y = c(row$source_y, join_y, join_y, landing_y)
+      )
+    }
+    raw <- raw[c(TRUE, diff(raw$x) != 0 | diff(raw$y) != 0), , drop = FALSE]
+    points <- .dnmb_cct_round_orthogonal_route(
+      raw, radius = max(0.08, as.numeric(corner_radius)[1L])
+    )
+    if (has_fan_in) {
+      points <- rbind(
+        points,
+        data.frame(x = row$tx_draw, y = target_y)
+      )
+    }
+    style <- style_for(row$confidence)
+    list(
+      route_id = .dnmb_cct_transporter_route_id(row$cs_id, row$target_key),
+      cs_id = row$cs_id, target_key = row$target_key,
+      source_x = row$source_x, source_y = row$source_y,
+      transporter_x = row$tx_draw, landing_x = landing_x,
+      landing_y = landing_y,
+      target_x = row$tx_draw, target_y = target_y,
+      points = points,
+      color = row$color, confidence = row$confidence,
+      linewidth = style$linewidth, alpha = style$alpha,
+      linetype = style$linetype, trim_start = row$source_trim,
+      arrow_last = TRUE
+    )
+  })
+  exterior_source_routes <- exterior_render_routes
+  exterior_trunk_routes <- list()
+  list(
+    groups = groups, memberships = membership_out,
+    stems = stems, buses = buses, trunks = trunks, direct = direct,
+    exterior_routes = exterior_routes,
+    exterior_source_routes = exterior_source_routes,
+    exterior_trunk_routes = exterior_trunk_routes,
+    exterior_render_routes = exterior_render_routes
+  )
+}
+
+.dnmb_cct_transporter_interior_routes <- function(memberships, y_memb = 8.5,
+                                                  glyph_clearance = 0.11,
+                                                  source_clearance = 0.11,
+                                                  membrane_half_height = 0.20,
+                                                  route_gap = 0.10,
+                                                  lane_step = 0.045,
+                                                  max_lane_offset = 0.18,
+                                                  corner_radius = 0.08) {
+  if (is.null(memberships) || !is.data.frame(memberships) || !nrow(memberships)) {
+    return(list())
+  }
+  required <- c(
+    "cs_id", "tx_draw", "ty_draw", "cyto_x", "cyto_y",
+    "confidence", "color"
+  )
+  if (length(missing <- setdiff(required, names(memberships)))) {
+    stop(
+      "transporter interior routing requires columns: ",
+      paste(missing, collapse = ", "), call. = FALSE
+    )
+  }
+  rows <- as.data.frame(memberships, stringsAsFactors = FALSE, row.names = NULL)
+  rows <- rows[
+    is.finite(rows$tx_draw) & is.finite(rows$ty_draw) &
+      is.finite(rows$cyto_x) & is.finite(rows$cyto_y),
+    , drop = FALSE
+  ]
+  if (!nrow(rows)) return(list())
+  if (!"locus_tag" %in% names(rows)) rows$locus_tag <- seq_len(nrow(rows))
+  rows <- rows[order(rows$cyto_x, rows$cs_id, rows$tx_draw, rows$locus_tag), , drop = FALSE]
+  rows <- rows[!duplicated(rows[, c("cs_id", "locus_tag", "tx_draw", "cyto_x")]), , drop = FALSE]
+  membrane_half_height <- max(0, as.numeric(membrane_half_height)[1L])
+  route_gap <- max(0, as.numeric(route_gap)[1L])
+  max_lane_offset <- max(0, as.numeric(max_lane_offset)[1L])
+
+  route_specs <- lapply(seq_len(nrow(rows)), function(i) {
+    row <- rows[i, , drop = FALSE]
+    start_y <- row$ty_draw - glyph_clearance
+    end_y <- row$cyto_y + source_clearance
+    lower_envelope <- min(y_memb - membrane_half_height, start_y)
+    lane_y <- lower_envelope - route_gap - max_lane_offset
+    lane_y <- max(end_y + 0.06, lane_y)
+    raw <- if (abs(row$tx_draw - row$cyto_x) <= 1e-8) {
+      data.frame(x = c(row$tx_draw, row$cyto_x), y = c(start_y, end_y))
+    } else {
+      data.frame(
+        x = c(row$tx_draw, row$tx_draw, row$cyto_x, row$cyto_x),
+        y = c(start_y, lane_y, lane_y, end_y)
+      )
+    }
+    list(
+      route_id = .dnmb_cct_transporter_route_id(row$cs_id, row$locus_tag),
+      group = paste0("inside:", row$cs_id),
+      priority = if (tolower(row$confidence) == "high") 2 else 1,
+      raw = raw, row = row,
+      min_lane_y = end_y + 0.06,
+      max_lane_y = lower_envelope - route_gap
+    )
+  })
+  metadata <- data.frame(
+    route_id = vapply(route_specs, `[[`, character(1), "route_id"),
+    group = vapply(route_specs, `[[`, character(1), "group"),
+    priority = vapply(route_specs, `[[`, numeric(1), "priority"),
+    stringsAsFactors = FALSE
+  )
+  unrounded_paths <- .dnmb_cct_separate_route_lanes(
+    routes = lapply(route_specs, `[[`, "raw"), metadata = metadata,
+    lane_step = lane_step, max_offset = max_lane_offset,
+    horizontal_tolerance = 0.01, y_tolerance = 0.05,
+    min_overlap = 0.10, connection_mode = "move_internal",
+    round_radius = 0
+  )
+  paths <- lapply(seq_along(route_specs), function(i) {
+    spec <- route_specs[[i]]
+    pts <- unrounded_paths[[i]]
+    if (nrow(spec$raw) <= 2L) return(pts)
+    dx <- diff(pts$x)
+    dy <- diff(pts$y)
+    horizontal_y <- pts$y[-nrow(pts)][abs(dx) > 1e-8 & abs(dy) <= 1e-8]
+    lane_y <- if (length(horizontal_y)) stats::median(horizontal_y) else {
+      stats::median(spec$raw$y[2:(nrow(spec$raw) - 1L)])
+    }
+    lane_y <- min(spec$max_lane_y, max(spec$min_lane_y, lane_y))
+    raw <- data.frame(
+      x = c(spec$raw$x[1L], spec$raw$x[1L],
+            spec$raw$x[nrow(spec$raw)], spec$raw$x[nrow(spec$raw)]),
+      y = c(spec$raw$y[1L], lane_y, lane_y, spec$raw$y[nrow(spec$raw)])
+    )
+    raw <- raw[c(TRUE, diff(raw$x) != 0 | diff(raw$y) != 0), , drop = FALSE]
+    .dnmb_cct_round_orthogonal_route(
+      raw, radius = max(0.08, as.numeric(corner_radius)[1L])
+    )
+  })
+  lapply(seq_along(route_specs), function(i) {
+    row <- route_specs[[i]]$row
+    high <- tolower(row$confidence) == "high"
+    c(route_specs[[i]][c("route_id", "group", "priority")], list(
+      cs_id = row$cs_id, target_key = as.character(row$locus_tag),
+      points = paths[[i]], color = row$color,
+      confidence = row$confidence,
+      linewidth = if (high) 0.24 else 0.16,
+      alpha = if (high) 0.68 else 0.28,
+      linetype = if (high) "solid" else "dashed"
+    ))
+  })
+}
+
+.dnmb_cct_drawn_transporter_entities <- function(entities, memberships) {
+  if (is.null(entities) || !is.data.frame(entities) || !nrow(entities)) {
+    return(entities)
+  }
+  if (!"locus_tag" %in% names(entities) ||
+      is.null(memberships) || !is.data.frame(memberships) ||
+      !nrow(memberships) ||
+      !all(c("target_key", "draw") %in% names(memberships))) {
+    return(entities[0, , drop = FALSE])
+  }
+  drawn_targets <- unique(as.character(
+    memberships$target_key[memberships$draw]
+  ))
+  entities[
+    as.character(entities$locus_tag) %in% drawn_targets,
+    , drop = FALSE
+  ]
+}
+
+.dnmb_cct_layout_transporter_labels <- function(labels, xlim, y_memb = 8.5,
+                                                base_offset = 0.40,
+                                                track_step = 0.16,
+                                                max_aux_tracks = 2L,
+                                                min_gap = 0.08) {
+  if (is.null(labels) || !nrow(labels)) return(labels)
+  out <- as.data.frame(labels, stringsAsFactors = FALSE, row.names = NULL)
+  if (!"anchor_x" %in% names(out)) out$anchor_x <- out$x
+  if (!"anchor_y" %in% names(out)) out$anchor_y <- out$y
+  if (!"priority" %in% names(out)) out$priority <- 0
+  if (!"hjust" %in% names(out)) out$hjust <- 0.5
+
+  xlim <- sort(as.numeric(xlim)[seq_len(2L)])
+  if (any(!is.finite(xlim)) || xlim[1] >= xlim[2]) {
+    stop("transporter label layout requires a finite increasing xlim", call. = FALSE)
+  }
+  base_offset <- max(0.20, as.numeric(base_offset)[1])
+  track_step <- max(0.08, as.numeric(track_step)[1])
+  max_aux_tracks <- max(0L, as.integer(max_aux_tracks)[1])
+  min_gap <- max(0, as.numeric(min_gap)[1])
+
+  out$label_width <- pmax(
+    0.20,
+    vapply(strsplit(as.character(out$label), "\n", fixed = TRUE), function(parts) {
+      max(nchar(parts), na.rm = TRUE) * 0.06
+    }, numeric(1))
+  )
+  out$x_lab <- pmin(
+    pmax(out$anchor_x, xlim[1] + out$label_width / 2),
+    xlim[2] - out$label_width / 2
+  )
+  out$track_level <- 0L
+
+  # Assign the primary track first. A label is raised only when its anchored
+  # interval collides with a label already occupying a lower track.
+  occupied <- replicate(max_aux_tracks + 1L, integer(0), simplify = FALSE)
+  ord <- order(
+    out$anchor_x, -out$priority, as.character(out$label),
+    na.last = TRUE
+  )
+  for (ii in ord) {
+    collision_count <- vapply(seq_along(occupied), function(track) {
+      idx <- occupied[[track]]
+      if (!length(idx)) return(0L)
+      required <- (out$label_width[idx] + out$label_width[ii]) / 2 + min_gap
+      sum(abs(out$x_lab[idx] - out$x_lab[ii]) < required)
+    }, integer(1))
+    free_track <- which(collision_count == 0L)[1]
+    if (is.na(free_track)) free_track <- which.min(collision_count)
+    out$track_level[ii] <- free_track - 1L
+    occupied[[free_track]] <- c(occupied[[free_track]], ii)
+  }
+
+  # Pack each occupied track left-to-right while preserving anchor order.
+  # This handles dense sites after all three tracks have been used.
+  for (track in seq.int(0L, max_aux_tracks)) {
+    idx <- which(out$track_level == track)
+    if (!length(idx)) next
+    idx <- idx[order(out$anchor_x[idx], out$label[idx])]
+    widths <- out$label_width[idx]
+    pos <- out$x_lab[idx]
+    pos[1] <- max(pos[1], xlim[1] + widths[1] / 2)
+    if (length(idx) > 1L) {
+      for (jj in 2:length(idx)) {
+        required <- (widths[jj - 1L] + widths[jj]) / 2 + min_gap
+        pos[jj] <- max(pos[jj], pos[jj - 1L] + required)
+      }
+      overflow <- pos[length(pos)] + widths[length(widths)] / 2 - xlim[2]
+      if (overflow > 0) pos <- pos - overflow
+      for (jj in rev(seq_len(length(idx) - 1L))) {
+        required <- (widths[jj] + widths[jj + 1L]) / 2 + min_gap
+        pos[jj] <- min(pos[jj], pos[jj + 1L] - required)
+      }
+    }
+    underflow <- xlim[1] - (pos[1] - widths[1] / 2)
+    if (underflow > 0) pos <- pos + underflow
+    out$x_lab[idx] <- pos
+  }
+
+  out$y_lab <- y_memb + base_offset + out$track_level * track_step
+  out$hjust <- 0.5
+  out$draw_leader <- abs(out$x_lab - out$anchor_x) > 0.04 |
+    out$track_level > 0L
+  out
+}
+
+.dnmb_cct_transporter_label_leaders <- function(labels, clearance = 0.05,
+                                                glyph_clearance = 0.11) {
+  empty <- data.frame(
+    group = character(), x = numeric(), y = numeric(), color = character(),
+    stringsAsFactors = FALSE
+  )
+  required <- c("anchor_x", "anchor_y", "x_lab", "y_lab")
+  if (is.null(labels) || !nrow(labels) || !all(required %in% names(labels))) {
+    return(empty)
+  }
+  rows <- labels[
+    is.finite(labels$anchor_x) & is.finite(labels$anchor_y) &
+      is.finite(labels$x_lab) & is.finite(labels$y_lab),
+    , drop = FALSE
+  ]
+  if ("draw_leader" %in% names(rows)) {
+    keep <- !is.na(rows$draw_leader) & rows$draw_leader
+    rows <- rows[keep, , drop = FALSE]
+  }
+  if (!nrow(rows)) return(empty)
+  if (!"color" %in% names(rows)) rows$color <- "#52616B"
+
+  dplyr::bind_rows(lapply(seq_len(nrow(rows)), function(i) {
+    y_start <- rows$anchor_y[i] + glyph_clearance
+    y_elbow <- max(y_start, rows$y_lab[i] - clearance)
+    data.frame(
+      group = paste0("transporter-label-", i),
+      x = c(rows$anchor_x[i], rows$anchor_x[i], rows$x_lab[i]),
+      y = c(y_start, y_elbow, y_elbow),
+      color = rep(as.character(rows$color[i]), 3L),
+      stringsAsFactors = FALSE
+    )
+  }))
+}
+
+.dnmb_cct_transporter_text_layer <- function(labels) {
+  if (is.null(labels) || !nrow(labels)) return(NULL)
+  ggplot2::geom_text(
+    data = labels,
+    ggplot2::aes(x = .data$x_lab, y = .data$y_lab, label = .data$label),
+    color = labels$color,
+    size = labels$size,
+    fontface = labels$fontface,
+    hjust = labels$hjust,
+    lineheight = 0.9,
+    check_overlap = FALSE,
+    inherit.aes = FALSE
+  )
 }
 
 .dnmb_cct_junction_glyph_layers <- function(x, y, color, size = 2.1, alpha = 0.9) {
@@ -3057,6 +4311,174 @@
   out
 }
 
+.dnmb_cct_layout_external_labels <- function(labels, xlim,
+                                              row_step = 0.15,
+                                              max_aux_rows = 2L,
+                                              min_gap = 0.08) {
+  if (is.null(labels) || !nrow(labels)) return(labels)
+  out <- as.data.frame(labels, stringsAsFactors = FALSE, row.names = NULL)
+  if (!"label_kind" %in% names(out)) out$label_kind <- "fixed"
+  if (!"anchor_x" %in% names(out)) out$anchor_x <- out$x
+  if (!"anchor_y" %in% names(out)) out$anchor_y <- out$y
+  if (!"priority" %in% names(out)) out$priority <- 0
+  if (!"hjust" %in% names(out)) out$hjust <- 0.5
+  if (!"color" %in% names(out)) out$color <- "#455A64"
+
+  xlim <- sort(as.numeric(xlim)[seq_len(2L)])
+  if (any(!is.finite(xlim)) || xlim[1] >= xlim[2]) {
+    stop("external label layout requires a finite increasing xlim", call. = FALSE)
+  }
+  row_step <- max(0.05, as.numeric(row_step)[1])
+  max_aux_rows <- max(0L, as.integer(max_aux_rows)[1])
+  min_gap <- max(0, as.numeric(min_gap)[1])
+
+  out$x_lab <- out$x
+  out$y_lab <- out$y
+  out$row_level <- 0L
+  out$draw_leader <- FALSE
+  out$hjust <- ifelse(is.na(out$hjust), 0.5, out$hjust)
+
+  gh_idx <- which(out$label_kind == "gh" &
+                    is.finite(out$anchor_x) & is.finite(out$anchor_y) &
+                    is.finite(out$x) & is.finite(out$y))
+  if (!length(gh_idx)) return(out)
+
+  gh <- out[gh_idx, , drop = FALSE]
+  gh$label_width <- pmax(
+    0.20,
+    vapply(strsplit(as.character(gh$label), "\n", fixed = TRUE), function(parts) {
+      max(nchar(parts), na.rm = TRUE) * 0.055
+    }, numeric(1))
+  )
+
+  # Use a single global row grid. Labels stay on their primary row whenever
+  # their horizontal intervals fit; only a collision opens one of two lower
+  # auxiliary rows.
+  grid_origin <- max(gh$y, na.rm = TRUE)
+  gh$primary_y <- grid_origin - round((grid_origin - gh$y) / row_step) * row_step
+  gh$x_lab <- pmin(
+    pmax(gh$anchor_x, xlim[1] + gh$label_width / 2),
+    xlim[2] - gh$label_width / 2
+  )
+  gh$y_lab <- gh$primary_y
+  gh$row_level <- 0L
+
+  placed <- data.frame(
+    x = numeric(), y = numeric(), width = numeric(),
+    stringsAsFactors = FALSE
+  )
+  horizontal_step <- max(0.24, max(gh$label_width, na.rm = TRUE) + min_gap)
+  horizontal_offsets <- c(0, horizontal_step, -horizontal_step)
+  ord <- order(
+    -gh$priority, -gh$primary_y, gh$anchor_x,
+    as.character(gh$label), na.last = TRUE
+  )
+  for (ii in ord) {
+    candidate_level <- rep(
+      seq.int(0L, max_aux_rows),
+      each = length(horizontal_offsets)
+    )
+    candidate_x <- gh$anchor_x[ii] + rep(
+      horizontal_offsets,
+      times = max_aux_rows + 1L
+    )
+    candidate_y <- gh$primary_y[ii] - candidate_level * row_step
+    within_bounds <-
+      candidate_x - gh$label_width[ii] / 2 >= xlim[1] &
+      candidate_x + gh$label_width[ii] / 2 <= xlim[2]
+    collision_count <- vapply(seq_along(candidate_x), function(candidate_i) {
+      if (!within_bounds[candidate_i]) return(.Machine$integer.max)
+      cx <- candidate_x[candidate_i]
+      cy <- candidate_y[candidate_i]
+      same_row <- abs(placed$y - cy) < row_step * 0.45
+      if (!any(same_row)) return(0L)
+      required <- (placed$width[same_row] + gh$label_width[ii]) / 2 + min_gap
+      sum(abs(placed$x[same_row] - cx) < required)
+    }, integer(1))
+    chosen <- which(collision_count == 0L)[1]
+    if (is.na(chosen)) {
+      valid <- which(within_bounds)
+      if (!length(valid)) valid <- seq_along(candidate_x)
+      penalty <- collision_count[valid] * 100L +
+        candidate_level[valid] * 10L +
+        rep(c(0L, 1L, 1L), times = max_aux_rows + 1L)[valid]
+      chosen <- valid[which.min(penalty)]
+    }
+    gh$x_lab[ii] <- pmin(
+      pmax(candidate_x[chosen], xlim[1] + gh$label_width[ii] / 2),
+      xlim[2] - gh$label_width[ii] / 2
+    )
+    gh$row_level[ii] <- candidate_level[chosen]
+    gh$y_lab[ii] <- candidate_y[chosen]
+    placed <- rbind(placed, data.frame(
+      x = gh$x_lab[ii], y = gh$y_lab[ii], width = gh$label_width[ii],
+      stringsAsFactors = FALSE
+    ))
+  }
+
+  # Pack each occupied row left-to-right without changing anchor order. This
+  # resolves the rare case where more than three labels share one cut site.
+  row_key <- sprintf("%.5f", gh$y_lab)
+  for (rk in unique(row_key)) {
+    idx <- which(row_key == rk)
+    idx <- idx[order(gh$x_lab[idx], gh$anchor_x[idx], gh$label[idx])]
+    if (length(idx) <= 1L) next
+    pos <- gh$x_lab[idx]
+    widths <- gh$label_width[idx]
+    pos[1] <- max(pos[1], xlim[1] + widths[1] / 2)
+    for (jj in 2:length(idx)) {
+      required <- (widths[jj - 1L] + widths[jj]) / 2 + min_gap
+      pos[jj] <- max(pos[jj], pos[jj - 1L] + required)
+    }
+    overflow <- pos[length(pos)] + widths[length(widths)] / 2 - xlim[2]
+    if (overflow > 0) pos <- pos - overflow
+    for (jj in rev(seq_len(length(idx) - 1L))) {
+      required <- (widths[jj] + widths[jj + 1L]) / 2 + min_gap
+      pos[jj] <- min(pos[jj], pos[jj + 1L] - required)
+    }
+    underflow <- xlim[1] - (pos[1] - widths[1] / 2)
+    if (underflow > 0) pos <- pos + underflow
+    gh$x_lab[idx] <- pos
+  }
+
+  gh$draw_leader <- gh$row_level > 0L | abs(gh$x_lab - gh$anchor_x) > 0.04
+  gh$hjust <- 0.5
+  out[gh_idx, c("x_lab", "y_lab", "row_level", "draw_leader", "hjust")] <-
+    gh[, c("x_lab", "y_lab", "row_level", "draw_leader", "hjust")]
+  out
+}
+
+.dnmb_cct_external_label_leaders <- function(labels, label_clearance = 0.045) {
+  empty <- data.frame(
+    group = character(), x = numeric(), y = numeric(), color = character(),
+    stringsAsFactors = FALSE
+  )
+  if (is.null(labels) || !nrow(labels) || !"draw_leader" %in% names(labels)) {
+    return(empty)
+  }
+  rows <- labels[
+    labels$label_kind == "gh" & labels$draw_leader &
+      is.finite(labels$anchor_x) & is.finite(labels$anchor_y) &
+      is.finite(labels$x_lab) & is.finite(labels$y_lab),
+    , drop = FALSE
+  ]
+  if (!nrow(rows)) return(empty)
+
+  dplyr::bind_rows(lapply(seq_len(nrow(rows)), function(i) {
+    direction <- sign(rows$anchor_y[i] - rows$y_lab[i])
+    if (!is.finite(direction) || direction == 0) direction <- 1
+    y_start <- rows$anchor_y[i] - direction * label_clearance
+    y_elbow <- rows$y_lab[i] + direction * label_clearance
+    data.frame(
+      group = paste0("external-label-", i),
+      x = c(rows$anchor_x[i], rows$anchor_x[i], rows$x_lab[i]),
+      y = c(y_start, y_elbow, y_elbow),
+      color = rep(as.character(rows$color[i]), 3L),
+      stringsAsFactors = FALSE
+    )
+  }))
+}
+
 .dnmb_cct_lane_label_offsets <- function(n, lane_dir = 0) {
   lane_dir <- sign(as.numeric(lane_dir)[1])
   if (!is.finite(lane_dir)) lane_dir <- 0
@@ -3107,7 +4529,8 @@
 .dnmb_cct_hub_entry_path <- function(hub_x, hub_y, target_x, target_y,
                                      lane_rank = 1L,
                                      target_count = 1L,
-                                     grid_step = 0.5) {
+                                     grid_step = 0.5,
+                                     rounded = TRUE) {
   dx <- target_x - hub_x
   dy <- target_y - hub_y
   if (abs(dx) <= max(0.30, grid_step * 0.6) || abs(dy) <= 0.02) {
@@ -3152,13 +4575,16 @@
     slot_y <- .dnmb_cct_snap_to_grid(target_y + grid_step * 0.25, step = grid_step / 2)
   }
 
-  .dnmb_cct_waypoint_route_points(
-    data.frame(
-      x = c(hub_x, hub_x, approach_x, approach_x, slot_x, slot_x, target_x),
-      y = c(hub_y, corridor_y, corridor_y, approach_y, approach_y, target_y, target_y)
-    ),
-    grid_step = grid_step
+  waypoints <- data.frame(
+    x = c(hub_x, hub_x, approach_x, approach_x, slot_x, slot_x, target_x),
+    y = c(hub_y, corridor_y, corridor_y, approach_y, approach_y, target_y, target_y)
   )
+  waypoints <- waypoints[
+    c(TRUE, diff(waypoints$x) != 0 | diff(waypoints$y) != 0),
+    , drop = FALSE
+  ]
+  if (!isTRUE(rounded)) return(waypoints)
+  .dnmb_cct_waypoint_route_points(waypoints, grid_step = grid_step)
 }
 
 .dnmb_cct_waypoint_route_points <- function(points_df, grid_step = 0.5) {
@@ -3194,25 +4620,46 @@
   seq_ids
 }
 
+.dnmb_cct_initial_entry_targets <- function(cs_id, node_ids = NULL) {
+  cid <- tolower(trimws(as.character(cs_id)[1L]))
+  branched_targets <- list(
+    lactose = c("Glucose", "Gal-1-P"),
+    sucrose = c("Glucose", "Fru-6-P")
+  )
+  targets <- branched_targets[[cid]]
+  if (is.null(targets)) {
+    route_nodes <- .dnmb_cct_entry_route_nodes(cid, node_ids = node_ids)
+    targets <- if (length(route_nodes)) route_nodes[1L] else character(0)
+  }
+  targets <- unique(as.character(targets))
+  targets <- targets[!is.na(targets) & nzchar(targets)]
+  if (!is.null(node_ids)) targets <- targets[targets %in% node_ids]
+  targets
+}
+
 .dnmb_cct_points_from_start_to_nodes <- function(start_x, start_y, node_ids, node_x, node_y,
                                                  grid_step = 0.5,
-                                                 lane_rank = 1L, lane_count = 1L) {
+                                                 lane_rank = 1L, lane_count = 1L,
+                                                 obstacle_x = node_x,
+                                                 obstacle_y = node_y) {
   if (length(node_ids) == 0) return(NULL)
   keep_ids <- node_ids[node_ids %in% names(node_x) & node_ids %in% names(node_y)]
   if (length(keep_ids) == 0) return(NULL)
-  # y-offset to separate overlapping routes targeting the same nodes
-  y_spread <- if (lane_count > 1L) {
-    (lane_rank - (lane_count + 1) / 2) * grid_step * 0.18
-  } else 0
+  # Keep every biochemical node coordinate exact. Shared horizontal portions
+  # are separated while these routes are still orthogonal waypoints; corners
+  # are rounded only after the lane heights have been finalized.
+  y_spread <- 0
   cur_x <- start_x
   cur_y <- start_y
   out <- data.frame(x = cur_x, y = cur_y)
   for (nid in keep_ids) {
     tgt_y <- unname(node_y[nid]) + y_spread
-    seg <- .dnmb_cct_pair_route_points(
+    seg <- .dnmb_cct_safe_pair_route_points(
       x1 = cur_x, y1 = cur_y,
       x2 = unname(node_x[nid]), y2 = tgt_y,
-      grid_step = grid_step
+      obstacle_x = obstacle_x, obstacle_y = obstacle_y,
+      grid_step = grid_step,
+      rounded = FALSE
     )
     out <- rbind(out, seg[-1, , drop = FALSE])
     cur_x <- unname(node_x[nid])
@@ -3236,29 +4683,38 @@
   as.integer(max(1L, min(nrow(points_df), idx)))
 }
 
+.dnmb_cct_route_label_point <- function(points_df, frac = 0.50) {
+  if (is.null(points_df) || !is.data.frame(points_df) || !nrow(points_df) ||
+      !all(c("x", "y") %in% names(points_df))) {
+    return(data.frame(x = NA_real_, y = NA_real_))
+  }
+  pts <- points_df[is.finite(points_df$x) & is.finite(points_df$y), c("x", "y"), drop = FALSE]
+  if (!nrow(pts)) return(data.frame(x = NA_real_, y = NA_real_))
+  if (nrow(pts) == 1L) return(pts)
+  keep <- c(TRUE, diff(pts$x) != 0 | diff(pts$y) != 0)
+  pts <- pts[keep, , drop = FALSE]
+  if (nrow(pts) == 1L) return(pts)
+
+  seg_len <- sqrt(diff(pts$x)^2 + diff(pts$y)^2)
+  total_len <- sum(seg_len)
+  if (!is.finite(total_len) || total_len <= 0) return(pts[1, , drop = FALSE])
+  frac <- min(1, max(0, as.numeric(frac)[1]))
+  if (!is.finite(frac)) frac <- 0.5
+  target_len <- total_len * frac
+  cumulative <- c(0, cumsum(seg_len))
+  seg_idx <- which(cumulative[-1L] >= target_len)[1]
+  if (is.na(seg_idx)) return(pts[nrow(pts), , drop = FALSE])
+  local_frac <- (target_len - cumulative[seg_idx]) / seg_len[seg_idx]
+  data.frame(
+    x = pts$x[seg_idx] + local_frac * (pts$x[seg_idx + 1L] - pts$x[seg_idx]),
+    y = pts$y[seg_idx] + local_frac * (pts$y[seg_idx + 1L] - pts$y[seg_idx])
+  )
+}
+
 .dnmb_cct_edge_points_from_row <- function(ce, edge_idx = 1L, grid_step = 0.5) {
   x1 <- ce$x; y1 <- ce$y; x2 <- ce$xend; y2 <- ce$yend
   if (any(is.na(c(x1, y1, x2, y2)))) return(data.frame(x = numeric(), y = numeric()))
-  stagger <- (edge_idx %% 5 - 2) * 0.25
-  is_straight <- abs(x2 - x1) < 0.01 || abs(y2 - y1) < 0.01
-  if (is_straight) {
-    return(data.frame(x = c(x1, x2), y = c(y1, y2)))
-  }
-  is_mostly_vertical <- abs(y2 - y1) >= abs(x2 - x1)
-  if (is_mostly_vertical) {
-    mid_y <- round((y2 + stagger) * 4) / 4
-    route_pts <- data.frame(
-      x = c(x1, x1, x2, x2),
-      y = c(y1, mid_y, mid_y, y2)
-    )
-  } else {
-    mid_x <- round((x2 + stagger) * 4) / 4
-    route_pts <- data.frame(
-      x = c(x1, mid_x, mid_x, x2),
-      y = c(y1, y1, y2, y2)
-    )
-  }
-  .dnmb_cct_rounded_route_points(route_pts, radius = grid_step)
+  .dnmb_cct_pair_route_points(x1, y1, x2, y2, grid_step = grid_step)
 }
 
 .dnmb_cct_pathway_hint_nodes <- function(path_ids, matched_steps, transporters, entry_map = NULL) {
@@ -3314,8 +4770,8 @@
 
 .dnmb_cct_layout_route_labels <- function(df, center_x = NA_real_,
                                           max_iter = 200L,
-                                          label_w = 0.30,
-                                          label_h = 0.10,
+                                          label_w = 0.38,
+                                          label_h = 0.14,
                                           k_repel = 0.008,
                                           k_attract = 0.06,
                                           damping = 0.85,
@@ -3394,10 +4850,6 @@
   if (is.na(gh) || !nzchar(gh)) gh <- "GH"
   if (is.na(gn) || !nzchar(gn)) return(gh)
   if (.dnmb_cct_is_generic_feature_id(gn)) return(gh)
-  gn <- sub("/.*$", "", gn)
-  gn <- sub("\\|.*$", "", gn)
-  gn <- gsub("_", "-", gn, fixed = TRUE)
-  if (nchar(gn) > 10) gn <- substr(gn, 1, 10)
   paste0(gh, " ", gn)
 }
 
@@ -3439,7 +4891,205 @@
   x <- as.character(label)[1]
   if (is.na(x) || !nzchar(x)) return(0.3)
   lines <- unlist(strsplit(x, "\n", fixed = TRUE))
-  max(0.3, max(nchar(lines), na.rm = TRUE) * 0.06)
+  max(0.3, max(nchar(lines), na.rm = TRUE) * 0.08)
+}
+
+.dnmb_cct_final_text_layer <- function(labels, obstacles = NULL,
+                                       xlim = c(NA, NA), ylim = c(NA, NA),
+                                       seed = 42L, force = 1.1,
+                                       force_pull = 2.2) {
+  if (is.null(labels) || !nrow(labels)) return(NULL)
+  labels <- as.data.frame(labels, stringsAsFactors = FALSE, row.names = NULL)
+  defaults <- list(
+    color = "#222222", size = 1, fontface = "plain", hjust = 0.5,
+    priority = 0, nudge_x = 0, nudge_y = 0, alpha = 1
+  )
+  for (column in names(defaults)) {
+    if (!column %in% names(labels)) labels[[column]] <- defaults[[column]]
+  }
+  labels <- labels[!is.na(labels$label) & nzchar(labels$label), , drop = FALSE]
+  if (!nrow(labels)) return(NULL)
+  labels <- labels[order(labels$priority, decreasing = TRUE, na.last = TRUE), , drop = FALSE]
+
+  plot_df <- labels[, c(
+    "x", "y", "label", "color", "size", "fontface", "hjust", "alpha",
+    "nudge_x", "nudge_y"
+  ), drop = FALSE]
+  if (!is.null(obstacles) && nrow(obstacles)) {
+    obstacles <- unique(as.data.frame(obstacles[, c("x", "y"), drop = FALSE]))
+    obstacles <- obstacles[is.finite(obstacles$x) & is.finite(obstacles$y), , drop = FALSE]
+    if (nrow(obstacles)) {
+      obstacle_rows <- data.frame(
+        x = obstacles$x, y = obstacles$y, label = "",
+        color = "#00000000", size = 0.01, fontface = "plain", hjust = 0.5,
+        nudge_x = 0, nudge_y = 0, alpha = 0,
+        stringsAsFactors = FALSE
+      )
+      plot_df <- rbind(plot_df, obstacle_rows)
+    }
+  }
+
+  ggrepel::geom_text_repel(
+    data = plot_df,
+    ggplot2::aes(x = .data$x, y = .data$y, label = .data$label),
+    color = plot_df$color,
+    size = plot_df$size,
+    alpha = plot_df$alpha,
+    fontface = plot_df$fontface,
+    hjust = plot_df$hjust,
+    nudge_x = plot_df$nudge_x,
+    nudge_y = plot_df$nudge_y,
+    bg.color = "#FFFFFF",
+    bg.r = 0.045,
+    box.padding = grid::unit(0.08, "lines"),
+    point.padding = grid::unit(0.10, "lines"),
+    min.segment.length = 0.04,
+    segment.size = 0.12,
+    segment.color = "#B0BEC5",
+    segment.alpha = 0.65,
+    force = force,
+    force_pull = force_pull,
+    max.overlaps = Inf,
+    max.time = 3,
+    max.iter = 15000,
+    xlim = xlim,
+    ylim = ylim,
+    seed = seed,
+    inherit.aes = FALSE
+  )
+}
+
+.dnmb_cct_obstacle_perimeter <- function(x, y, rx = 0.1, ry = rx,
+                                         points = 8L, include_center = TRUE) {
+  x <- as.numeric(x)
+  y <- as.numeric(y)
+  rx <- rep_len(pmax(0, as.numeric(rx)), length(x))
+  ry <- rep_len(pmax(0, as.numeric(ry)), length(x))
+  keep <- is.finite(x) & is.finite(y) & is.finite(rx) & is.finite(ry)
+  x <- x[keep]
+  y <- y[keep]
+  rx <- rx[keep]
+  ry <- ry[keep]
+  if (!length(x)) return(data.frame(x = numeric(), y = numeric()))
+
+  theta <- seq(0, 2 * pi, length.out = max(4L, as.integer(points)[1]) + 1L)
+  theta <- theta[-length(theta)]
+  perimeter <- do.call(rbind, lapply(seq_along(x), function(i) {
+    data.frame(
+      x = x[i] + rx[i] * cos(theta),
+      y = y[i] + ry[i] * sin(theta)
+    )
+  }))
+  if (isTRUE(include_center)) {
+    perimeter <- rbind(data.frame(x = x, y = y), perimeter)
+  }
+  rownames(perimeter) <- NULL
+  perimeter
+}
+
+.dnmb_cct_collapse_route_labels <- function(route_labels) {
+  if (is.null(route_labels) || !nrow(route_labels)) return(route_labels)
+  route_labels <- as.data.frame(route_labels, stringsAsFactors = FALSE, row.names = NULL)
+  required <- c("label", "locus_tag", "member_keys", "target_id", "priority")
+  if (!all(required %in% names(route_labels))) {
+    stop("route label deduplication requires membership and target columns", call. = FALSE)
+  }
+  exact_key <- paste(
+    route_labels$target_id,
+    route_labels$locus_tag,
+    route_labels$member_keys,
+    route_labels$label,
+    sep = "\r"
+  )
+  ord <- order(-route_labels$priority)
+  route_labels <- route_labels[ord, , drop = FALSE]
+  exact_key <- exact_key[ord]
+  route_labels[!duplicated(exact_key), , drop = FALSE]
+}
+
+.dnmb_cct_pathway_presence <- function(step_status, pstats = NULL,
+                                       valid_pathways = NULL) {
+  empty <- data.frame(
+    pathway_id = character(), fraction = numeric(),
+    n_transport = integer(), n_intracellular = integer(),
+    cytoplasm_status = character(), stringsAsFactors = FALSE
+  )
+  if (is.null(step_status) || !nrow(step_status)) return(empty)
+
+  steps <- as.data.frame(step_status, stringsAsFactors = FALSE, row.names = NULL)
+  required <- c("pathway_id", "step_id", "confidence", "locus_tag")
+  if (!all(required %in% names(steps))) return(empty)
+  steps$pathway_id <- tolower(as.character(steps$pathway_id))
+  if (!is.null(valid_pathways)) {
+    steps <- steps[steps$pathway_id %in% tolower(valid_pathways), , drop = FALSE]
+  }
+  if (!nrow(steps)) return(empty)
+
+  conf_rank <- c(none = 0L, low = 1L, medium = 2L, high = 3L)
+  steps$rank <- unname(conf_rank[tolower(as.character(steps$confidence))])
+  steps$rank[is.na(steps$rank)] <- 0L
+  steps <- steps[
+    steps$rank >= 2L & !is.na(steps$locus_tag) & nzchar(steps$locus_tag),
+    , drop = FALSE
+  ]
+
+  path_ids <- unique(c(
+    if (!is.null(valid_pathways)) tolower(valid_pathways) else character(),
+    steps$pathway_id,
+    if (!is.null(pstats) && "pathway_id" %in% names(pstats)) {
+      tolower(as.character(pstats$pathway_id))
+    } else character()
+  ))
+  path_ids <- path_ids[!is.na(path_ids) & nzchar(path_ids)]
+  if (!length(path_ids)) return(empty)
+
+  out <- data.frame(
+    pathway_id = path_ids,
+    fraction = 0,
+    n_transport = 0L,
+    n_intracellular = 0L,
+    stringsAsFactors = FALSE
+  )
+  if (!is.null(pstats) && nrow(pstats) &&
+      all(c("pathway_id", "fraction") %in% names(pstats))) {
+    ps <- as.data.frame(pstats, stringsAsFactors = FALSE, row.names = NULL)
+    ps$pathway_id <- tolower(as.character(ps$pathway_id))
+    idx <- match(out$pathway_id, ps$pathway_id)
+    found <- !is.na(idx)
+    out$fraction[found] <- suppressWarnings(as.numeric(ps$fraction[idx[found]]))
+    out$fraction[!is.finite(out$fraction)] <- 0
+  }
+
+  if (nrow(steps)) {
+    steps$is_transport <- mapply(
+      .dnmb_cct_is_transport_like_step,
+      step_id = steps$step_id,
+      gene_name = steps$step_id,
+      MoreArgs = list(is_pts = FALSE)
+    )
+    count_distinct <- function(df, keep_transport) {
+      sub <- df[df$is_transport == keep_transport, , drop = FALSE]
+      if (!nrow(sub)) return(integer())
+      vapply(split(sub$step_id, sub$pathway_id), function(x) {
+        length(unique(as.character(x)))
+      }, integer(1))
+    }
+    tr_count <- count_distinct(steps, TRUE)
+    in_count <- count_distinct(steps, FALSE)
+    if (length(tr_count)) {
+      out$n_transport[match(names(tr_count), out$pathway_id)] <- unname(tr_count)
+    }
+    if (length(in_count)) {
+      out$n_intracellular[match(names(in_count), out$pathway_id)] <- unname(in_count)
+    }
+  }
+
+  active <- (out$fraction >= 0.50 & out$n_intracellular >= 2L) |
+    (out$fraction >= 0.25 & out$n_transport >= 1L & out$n_intracellular >= 1L)
+  partial <- !active & (out$n_transport > 0L | out$n_intracellular > 0L |
+                          out$fraction > 0)
+  out$cytoplasm_status <- ifelse(active, "active", ifelse(partial, "partial", "reference"))
+  out
 }
 
 .dnmb_cct_lighten_color <- function(color, amount = 0.65) {
@@ -3630,15 +5280,167 @@
   0.45 * conf_score + 0.40 * frac_score + 0.15 * sink_score
 }
 
+.dnmb_cct_path_step_key <- function(pathway_id, step_id) {
+  pathway_id <- tolower(trimws(as.character(pathway_id)))
+  step_id <- tolower(trimws(as.character(step_id)))
+  paste(pathway_id, step_id, sep = "\r")
+}
+
+# Only reactions with an explicit directed biochemical edge are eligible for a
+# map label. Evidence without one of these mappings remains in the ledger.
+.dnmb_cct_exact_step_edge_map <- function() {
+  data.frame(
+    pathway_id = rep("deoxyribose", 8L),
+    step_id = c("deoK", "deoC", "deoC", "adh", "ackA", "pta", "acs", "ald-dh-CoA"),
+    from = c(
+      "Deoxyribose", "Deoxyribose-5-P", "Deoxyribose-5-P",
+      "Acetaldehyde", "Acetate", "Acetyl-P", "Acetate", "Acetaldehyde"
+    ),
+    to = c(
+      "Deoxyribose-5-P", "GA3P", "Acetaldehyde", "Acetate",
+      "Acetyl-P", "Acetyl-CoA", "Acetyl-CoA", "Acetyl-CoA"
+    ),
+    label_anchor = c(TRUE, TRUE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE),
+    stringsAsFactors = FALSE
+  )
+}
+
+.dnmb_cct_exact_step_edge_matches <- function(step_evidence, cyto_edges,
+                                               edge_map = .dnmb_cct_exact_step_edge_map()) {
+  empty <- data.frame()
+  if (is.null(step_evidence) || !is.data.frame(step_evidence) || !nrow(step_evidence) ||
+      is.null(cyto_edges) || !is.data.frame(cyto_edges) || !nrow(cyto_edges) ||
+      is.null(edge_map) || !is.data.frame(edge_map) || !nrow(edge_map)) {
+    return(empty)
+  }
+  if (!all(c("pathway_id", "step_id") %in% names(step_evidence)) ||
+      !all(c("from", "to") %in% names(cyto_edges)) ||
+      !all(c("pathway_id", "step_id", "from", "to", "label_anchor") %in% names(edge_map))) {
+    return(empty)
+  }
+
+  evidence <- as.data.frame(step_evidence, stringsAsFactors = FALSE, row.names = NULL)
+  evidence$.evidence_order <- seq_len(nrow(evidence))
+  evidence$.path_step_key <- .dnmb_cct_path_step_key(
+    evidence$pathway_id, evidence$step_id
+  )
+  mapping <- as.data.frame(edge_map, stringsAsFactors = FALSE, row.names = NULL)
+  mapping$.map_order <- seq_len(nrow(mapping))
+  mapping$.path_step_key <- .dnmb_cct_path_step_key(
+    mapping$pathway_id, mapping$step_id
+  )
+  names(mapping)[names(mapping) %in% c("pathway_id", "step_id", "from", "to")] <-
+    c("mapped_pathway_id", "mapped_step_id", "mapped_from", "mapped_to")
+
+  matched <- merge(
+    evidence, mapping,
+    by = ".path_step_key", all = FALSE, sort = FALSE
+  )
+  if (!nrow(matched)) return(empty)
+
+  edge_key <- paste(cyto_edges$from, cyto_edges$to, sep = "\r")
+  matched$edge_index <- match(
+    paste(matched$mapped_from, matched$mapped_to, sep = "\r"),
+    edge_key
+  )
+  matched <- matched[!is.na(matched$edge_index), , drop = FALSE]
+  if (!nrow(matched)) return(empty)
+  matched <- matched[order(matched$.evidence_order, matched$.map_order), , drop = FALSE]
+  rownames(matched) <- NULL
+  matched
+}
+
+.dnmb_cct_exact_step_labels <- function(step_evidence, cyto_edges,
+                                        edge_map = .dnmb_cct_exact_step_edge_map()) {
+  empty <- data.frame(
+    x = numeric(), y = numeric(), label = character(), base_label = character(),
+    step_id = character(), pathway_id = character(), confidence = character(),
+    rank = integer(), locus_tag = character(), member_loci = character(),
+    member_keys = character(), color = character(), target_id = character(),
+    target_rank = integer(), priority = numeric(), angle = numeric(),
+    nudge_x = numeric(), nudge_y = numeric(), size = numeric(),
+    fontface = character(), hjust = numeric(), alpha = numeric(),
+    stringsAsFactors = FALSE
+  )
+  matches <- .dnmb_cct_exact_step_edge_matches(
+    step_evidence = step_evidence,
+    cyto_edges = cyto_edges,
+    edge_map = edge_map
+  )
+  if (!nrow(matches)) return(empty)
+
+  if (!"rank" %in% names(matches)) {
+    confidence_rank <- c(none = 0L, low = 1L, medium = 2L, high = 3L)
+    matches$rank <- unname(confidence_rank[tolower(as.character(matches$confidence))])
+    matches$rank[is.na(matches$rank)] <- 0L
+  }
+  if (!"confidence" %in% names(matches)) {
+    matches$confidence <- ifelse(matches$rank >= 3L, "high", "medium")
+  }
+  if (!"locus_tag" %in% names(matches)) matches$locus_tag <- ""
+
+  split_rows <- split(
+    seq_len(nrow(matches)),
+    .dnmb_cct_path_step_key(matches$mapped_pathway_id, matches$mapped_step_id)
+  )
+  rows <- lapply(split_rows, function(idx) {
+    group <- matches[idx, , drop = FALSE]
+    anchor <- group[group$label_anchor %in% TRUE, , drop = FALSE]
+    if (!nrow(anchor)) anchor <- group[1, , drop = FALSE]
+    anchor <- anchor[1, , drop = FALSE]
+    edge <- cyto_edges[anchor$edge_index, , drop = FALSE]
+
+    loci <- sort(unique(trimws(as.character(group$locus_tag))))
+    loci <- loci[!is.na(loci) & nzchar(loci)]
+    if (!length(loci)) return(NULL)
+    rank <- max(suppressWarnings(as.integer(group$rank)), na.rm = TRUE)
+    if (!is.finite(rank) || rank < 2L) return(NULL)
+    confidence <- if (rank >= 3L) "high" else "medium"
+    step_label <- as.character(anchor$mapped_step_id)
+    label <- paste0(step_label, "\n", paste(loci, collapse = " | "))
+    edge_points <- .dnmb_cct_edge_points_from_row(
+      edge, edge_idx = anchor$edge_index, grid_step = 0.5
+    )
+    label_point <- .dnmb_cct_route_label_point(edge_points, frac = 0.5)
+    x <- label_point$x[1]
+    y <- label_point$y[1]
+    is_split <- identical(tolower(step_label), "deoc")
+
+    data.frame(
+      x = x, y = y, label = label, base_label = label,
+      step_id = step_label,
+      pathway_id = as.character(anchor$mapped_pathway_id),
+      confidence = confidence, rank = rank,
+      locus_tag = paste(loci, collapse = ","),
+      member_loci = paste(loci, collapse = ";"),
+      member_keys = paste(
+        paste0(tolower(step_label), "::", loci), collapse = ";"
+      ),
+      color = if (rank >= 3L) "#007C83" else "#B7791F",
+      target_id = paste(unique(group$mapped_to), collapse = ";"),
+      target_rank = 1L, priority = 24 + rank, angle = 0,
+      nudge_x = if (is_split) 0.24 else 0.12,
+      nudge_y = if (is_split) -0.08 else 0,
+      size = 1.14, fontface = "bold", hjust = 0,
+      alpha = 1,
+      stringsAsFactors = FALSE
+    )
+  })
+  rows <- Filter(Negate(is.null), rows)
+  if (!length(rows)) return(empty)
+  out <- dplyr::bind_rows(rows)
+  out[order(out$pathway_id, out$step_id), , drop = FALSE]
+}
+
 .dnmb_cct_step_target_nodes <- function(step_id, pathway_id = NA_character_) {
-  sid <- tolower(as.character(step_id)[1])
-  pid <- tolower(as.character(pathway_id)[1])
+  sid <- tolower(trimws(as.character(step_id)[1]))
+  pid <- tolower(trimws(as.character(pathway_id)[1]))
   if (is.na(sid) || !nzchar(sid)) return(character(0))
   entry_map <- .dnmb_cct_auto_entry_map()
   entry_node <- unname(entry_map[pid])
 
   is_transport_like <- grepl(
-    "pts|transport|permease|porter|abc|binding|mfs|symporter|tm00|ggu|mgl|rbs|xyl[FGH]|lac[EFG]|mal[EFGK]|thu[EFGK]|ara[ETUV]|galP|glc[PTUV]|kguT|nup[ABC]|pot[ABCD]|mtl[EK]|chvE",
+    "pts|transport|permease|porter|abc|binding|mfs|symporter|tm00|ggu|mgl|rbs|xyl[fgh]|lac[efg]|mal[efgk]|thu[efgk]|ara[etuv]|galp|glc[ptuv]|kgut|nup[abc]|pot[abcd]|mtl[ek]|chve",
     sid, ignore.case = TRUE
   )
   if (is_transport_like && !is.na(entry_node) && nzchar(entry_node)) {
@@ -3646,28 +5448,37 @@
   }
 
   if (sid %in% c("glk", "mgla", "mglb", "mglc")) return(c("Glc-6-P"))
-  if (sid %in% c("nagA")) return(c("GlcN-6-P"))
-  if (sid %in% c("nagB", "manA")) return(c("Fru-6-P"))
-  if (sid %in% c("galK")) return(c("Gal-1-P"))
-  if (sid %in% c("galT")) return(c("UDP-Gal", "Glc-1-P", "UDP-Glc"))
-  if (sid %in% c("galE")) return(c("UDP-Gal", "UDP-Glc"))
-  if (sid %in% c("pgmA")) return(c("Glc-1-P", "Glc-6-P"))
-  if (sid %in% c("gntK", "gnd")) return(c("6-PG"))
-  if (sid %in% c("kdgK", "eda")) return(c("KDPG", "Pyruvate", "GA3P"))
-  if (sid %in% c("xylA")) return(c("Xylulose", "Xu-5-P"))
-  if (sid %in% c("xylB")) return(c("Xu-5-P"))
-  if (sid %in% c("rbsK")) return(c("R-5-P"))
-  if (sid %in% c("araA")) return(c("Ribulose", "Ribulose-5-P", "Xu-5-P"))
-  if (sid %in% c("araB")) return(c("Ribulose-5-P", "Xu-5-P"))
-  if (sid %in% c("araD", "gguA", "gguB")) return(c("Xu-5-P"))
-  if (sid %in% c("glpK", "glpO")) return(c("Glycerol-3-P", "DHAP"))
-  if (sid %in% c("fucI")) return(c("Fuculose", "Fuculose-1-P", "DHAP"))
-  if (sid %in% c("fucK")) return(c("Fuculose-1-P", "DHAP"))
+  if (sid %in% c("naga")) return(c("GlcN-6-P"))
+  if (sid %in% c("nagb", "mana")) return(c("Fru-6-P"))
+  if (sid %in% c("galk")) return(c("Gal-1-P"))
+  if (sid %in% c("galt")) return(c("UDP-Gal", "Glc-1-P", "UDP-Glc"))
+  if (sid %in% c("gale")) return(c("UDP-Gal", "UDP-Glc"))
+  if (sid %in% c("pgma")) return(c("Glc-1-P", "Glc-6-P"))
+  if (sid %in% c("gntk", "gnd")) return(c("6-PG"))
+  if (sid %in% c("kdgk", "eda")) return(c("KDPG", "Pyruvate", "GA3P"))
+  if (sid %in% c("xyla")) return(c("Xylulose", "Xu-5-P"))
+  if (sid %in% c("xylb")) return(c("Xu-5-P"))
+  if (sid %in% c("rbsk")) return(c("R-5-P"))
+  if (sid %in% c("araa")) return(c("Ribulose", "Ribulose-5-P", "Xu-5-P"))
+  if (sid %in% c("arab")) return(c("Ribulose-5-P", "Xu-5-P"))
+  if (sid %in% c("arad", "ggua", "ggub")) return(c("Xu-5-P"))
+  if (sid %in% c("glpk", "glpo")) return(c("Glycerol-3-P", "DHAP"))
+  if (sid %in% c("fuci")) return(c("Fuculose", "Fuculose-1-P", "DHAP"))
+  if (sid %in% c("fuck")) return(c("Fuculose-1-P", "DHAP"))
   if (sid %in% c("fba")) return(c("Fru-1,6-BP", "GA3P"))
   if (sid %in% c("tpi")) return(c("DHAP", "GA3P"))
-  if (sid %in% c("thuK", "pstp")) return(c("Trehalose-6-P", "Glc-6-P"))
-  if (sid %in% c("lacZ", "lacE", "lacF", "lacG", "lacK")) return(c("Gal-1-P", "Glc-6-P"))
-  if (sid %in% c("ggua", "ggub", "chve", "xylg", "xylh", "rbsa", "rbsb", "rbsc", "nupa", "nupb", "nupc'",
+  if (pid == "deoxyribose" && sid == "deok") return(c("Deoxyribose-5-P"))
+  if (pid == "deoxyribose" && sid == "deoc") {
+    return(c("Deoxyribose-5-P", "GA3P", "Acetaldehyde"))
+  }
+  if (pid == "deoxyribose" && sid == "adh") return(c("Acetaldehyde", "Acetate"))
+  if (pid == "deoxyribose" && sid == "acka") return(c("Acetate", "Acetyl-P"))
+  if (pid == "deoxyribose" && sid == "pta") return(c("Acetyl-P", "Acetyl-CoA"))
+  if (pid == "deoxyribose" && sid == "acs") return(c("Acetate", "Acetyl-CoA"))
+  if (pid == "deoxyribose" && sid == "ald-dh-coa") return(c("Acetaldehyde", "Acetyl-CoA"))
+  if (sid %in% c("thuk", "pstp")) return(c("Trehalose-6-P", "Glc-6-P"))
+  if (sid %in% c("lacz", "lace", "lacf", "lacg", "lack")) return(c("Gal-1-P", "Glc-6-P"))
+  if (sid %in% c("ggua", "ggub", "chve", "xylg", "xylh", "rbsa", "rbsb", "rbsc", "nupa", "nupb", "nupc",
                  "male1", "male2", "malf1", "malk1", "malt1", "mtlk", "mtle", "glcv", "glct", "glu",
                  "aglf", "aglk", "tm0027", "tm0028", "tm0029", "tm0030", "tm0031")) {
     if (!is.na(entry_node) && nzchar(entry_node)) return(c(entry_node))
@@ -3678,6 +5489,9 @@
   if (pid %in% c("ribose")) return(c("R-5-P", "GA3P"))
   if (pid %in% c("glycerol")) return(c("Glycerol-3-P", "DHAP"))
   if (pid %in% c("fucose")) return(c("Fuculose", "Fuculose-1-P", "DHAP", "GA3P"))
+  if (pid == "deoxyribose") {
+    return(c("Deoxyribose-5-P", "GA3P", "Acetaldehyde", "Acetate", "Acetyl-CoA"))
+  }
   character(0)
 }
 
@@ -3765,10 +5579,30 @@
     xylose = c("Xylulose", "Xu-5-P", "GA3P", "1,3-BPG", "3-PG", "2-PG", "PEP", "Pyruvate"),
     arabinose = c("Ribulose", "Ribulose-5-P", "Xu-5-P", "GA3P", "1,3-BPG", "3-PG", "2-PG", "PEP", "Pyruvate"),
     ribose = c("R-5-P", "S-7-P", "Fru-6-P", "Fru-1,6-BP", "GA3P", "1,3-BPG", "3-PG", "2-PG", "PEP", "Pyruvate"),
+    deoxyribose = c("Deoxyribose-5-P", "GA3P", "1,3-BPG", "3-PG", "2-PG", "PEP", "Pyruvate"),
     gluconate = c("6-PG", "KDPG", "Pyruvate"),
     fucose = c("Fuculose", "Fuculose-1-P", "DHAP", "GA3P", "1,3-BPG", "3-PG", "2-PG", "PEP", "Pyruvate"),
     rhamnose = c("Rhamnulose", "Rhamnulose-1-P", "DHAP", "GA3P", "1,3-BPG", "3-PG", "2-PG", "PEP", "Pyruvate")
   )
+}
+
+.dnmb_cct_core_merge_nodes <- function() {
+  c(
+    "Glc-6-P", "Fru-6-P", "Fru-1,6-BP", "DHAP", "GA3P",
+    "1,3-BPG", "3-PG", "2-PG", "PEP", "Pyruvate", "Acetyl-CoA",
+    "6-PGL", "6-PG", "Ru-5-P", "R-5-P", "Xu-5-P", "S-7-P", "E-4-P",
+    "KDPG"
+  )
+}
+
+.dnmb_cct_route_to_first_core_merge <- function(node_ids,
+                                                merge_nodes = .dnmb_cct_core_merge_nodes()) {
+  node_ids <- as.character(node_ids)
+  node_ids <- node_ids[!is.na(node_ids) & nzchar(node_ids)]
+  if (length(node_ids) < 2L || node_ids[1L] %in% merge_nodes) return(NULL)
+  merge_index <- which(node_ids[-1L] %in% merge_nodes)
+  if (!length(merge_index)) return(NULL)
+  node_ids[seq_len(merge_index[1L] + 1L)]
 }
 
 .dnmb_cct_route_group_for_pathway <- function(pathway_id, route_group_members) {
@@ -3815,7 +5649,7 @@
   if (!is.na(et) && et %in% c("Glycerol-3-P", "DHAP", "GA3P")) {
     return(c("Pyruvate", "Acetyl-CoA"))
   }
-  if (pid %in% c("gluconate", "xylose", "arabinose", "ribose")) {
+  if (pid %in% c("gluconate", "xylose", "arabinose", "ribose", "deoxyribose")) {
     return(c("Pyruvate", "GA3P", "Acetyl-CoA"))
   }
   c("Pyruvate", "Acetyl-CoA")
@@ -3832,6 +5666,9 @@
   }
   if (pid %in% c("xylose", "arabinose", "ribose")) {
     return(c("Xu-5-P", "R-5-P", "S-7-P", "E-4-P", "Fru-6-P", "GA3P", "Pyruvate"))
+  }
+  if (pid == "deoxyribose") {
+    return(c("Deoxyribose-5-P", "GA3P", "Acetaldehyde", "Acetate", "Acetyl-CoA", "Pyruvate"))
   }
   c("Glc-6-P", "Fru-6-P", "Fru-1,6-BP", "GA3P", "1,3-BPG", "3-PG", "2-PG", "PEP", "Pyruvate", "Acetyl-CoA")
 }
@@ -3872,14 +5709,19 @@
     node_bonus <- merged_bonus
   }
 
-  candidate_starts <- unique(c(
-    entry_target,
-    graph$from[graph$pathway %in% preferred_paths]
-  ))
+  # The overlay must retain the pathway-specific entry chemistry. Starting at
+  # any low-cost backbone/PPP node can otherwise skip named intermediates (for
+  # example Glucose, Xylulose, or Deoxyribose-5-P).
+  seed_route <- .dnmb_cct_continuity_routes()[[pid]]
+  explicit_start <- if (length(seed_route)) seed_route[1L] else NA_character_
+  candidate_starts <- unique(c(explicit_start, entry_target))
   candidate_starts <- candidate_starts[
     candidate_starts %in% names(node_type) &
       node_type[candidate_starts] %in% c("entry_intermediate", "backbone", "ppp", "ed")
   ]
+  if (!is.na(explicit_start) && explicit_start %in% candidate_starts) {
+    candidate_starts <- explicit_start
+  }
   sink_ids <- sink_ids[sink_ids %in% names(node_type)]
   if (length(candidate_starts) == 0 || length(sink_ids) == 0) return(NULL)
 
@@ -3959,6 +5801,234 @@
   .dnmb_cct_rounded_route_points(pts, radius = max(0.05, safe_radius))
 }
 
+.dnmb_cct_path_obstacle_score <- function(points_df, obstacle_x, obstacle_y,
+                                          clearance = 0.14) {
+  if (is.null(points_df) || nrow(points_df) < 2) return(Inf)
+  obstacles <- data.frame(x = as.numeric(obstacle_x), y = as.numeric(obstacle_y))
+  obstacles <- obstacles[is.finite(obstacles$x) & is.finite(obstacles$y), , drop = FALSE]
+  if (!nrow(obstacles)) {
+    return(sum(sqrt(diff(points_df$x)^2 + diff(points_df$y)^2)))
+  }
+
+  start_dist <- sqrt((obstacles$x - points_df$x[1])^2 +
+                     (obstacles$y - points_df$y[1])^2)
+  end_dist <- sqrt((obstacles$x - points_df$x[nrow(points_df)])^2 +
+                   (obstacles$y - points_df$y[nrow(points_df)])^2)
+  obstacles <- obstacles[
+    start_dist > clearance * 0.85 & end_dist > clearance * 0.85,
+    , drop = FALSE
+  ]
+
+  min_dist <- rep(Inf, nrow(obstacles))
+  if (nrow(obstacles)) {
+    for (i in seq_len(nrow(points_df) - 1L)) {
+      ax <- points_df$x[i]
+      ay <- points_df$y[i]
+      bx <- points_df$x[i + 1L]
+      by <- points_df$y[i + 1L]
+      vx <- bx - ax
+      vy <- by - ay
+      denom <- vx^2 + vy^2
+      if (denom <= 1e-12) next
+      projection <- ((obstacles$x - ax) * vx + (obstacles$y - ay) * vy) / denom
+      projection <- pmin(1, pmax(0, projection))
+      px <- ax + projection * vx
+      py <- ay + projection * vy
+      distance <- sqrt((obstacles$x - px)^2 + (obstacles$y - py)^2)
+      min_dist <- pmin(min_dist, distance)
+    }
+  }
+
+  collision <- min_dist < clearance
+  collision_penalty <- sum(ifelse(
+    collision, 1000 + 250 * (clearance - min_dist), 0
+  ))
+  path_length <- sum(sqrt(diff(points_df$x)^2 + diff(points_df$y)^2))
+  bend_penalty <- 0.04 * max(0, nrow(points_df) - 2L)
+  collision_penalty + path_length + bend_penalty
+}
+
+# Choose an orthogonal hub route that avoids unrelated metabolite nodes.
+.dnmb_cct_safe_pair_route_points <- function(x1, y1, x2, y2, obstacle_x,
+                                             obstacle_y, grid_step = 0.5,
+                                             clearance = 0.14,
+                                             rounded = TRUE) {
+  if (any(!is.finite(c(x1, y1, x2, y2)))) {
+    return(data.frame(x = numeric(), y = numeric()))
+  }
+  clean_candidate <- function(points) {
+    keep <- c(TRUE, diff(points$x) != 0 | diff(points$y) != 0)
+    points[keep, , drop = FALSE]
+  }
+  candidates <- list(
+    clean_candidate(data.frame(x = c(x1, x1, x2), y = c(y1, y2, y2))),
+    clean_candidate(data.frame(x = c(x1, x2, x2), y = c(y1, y1, y2)))
+  )
+  if (abs(x2 - x1) < 0.01 || abs(y2 - y1) < 0.01) {
+    candidates <- c(list(data.frame(x = c(x1, x2), y = c(y1, y2))), candidates)
+  }
+
+  y_direction <- if (y2 < y1) -1 else 1
+  x_direction <- if (x2 < x1) -1 else 1
+  corridor_y <- unique(c(
+    y1 + y_direction * grid_step / 2,
+    y2 - y_direction * grid_step / 2,
+    y1 - y_direction * grid_step / 2,
+    y2 + y_direction * grid_step / 2
+  ))
+  for (cy in corridor_y) {
+    candidates[[length(candidates) + 1L]] <- clean_candidate(data.frame(
+      x = c(x1, x1, x2, x2), y = c(y1, cy, cy, y2)
+    ))
+  }
+  corridor_x <- unique(c(
+    x1 + x_direction * grid_step / 2,
+    x2 - x_direction * grid_step / 2,
+    x1 - x_direction * grid_step / 2,
+    x2 + x_direction * grid_step / 2
+  ))
+  for (cx in corridor_x) {
+    candidates[[length(candidates) + 1L]] <- clean_candidate(data.frame(
+      x = c(x1, cx, cx, x2), y = c(y1, y1, y2, y2)
+    ))
+  }
+
+  scores <- vapply(
+    candidates, .dnmb_cct_path_obstacle_score, numeric(1),
+    obstacle_x = obstacle_x, obstacle_y = obstacle_y, clearance = clearance
+  )
+  best <- candidates[[which.min(scores)]]
+  if (!isTRUE(rounded)) return(best)
+  .dnmb_cct_rounded_route_points(best, radius = min(grid_step * 0.35, clearance * 0.9))
+}
+
+.dnmb_cct_raw_pair_route_points <- function(x1, y1, x2, y2,
+                                            grid_step = 0.5) {
+  if (any(!is.finite(c(x1, y1, x2, y2)))) {
+    return(data.frame(x = numeric(), y = numeric()))
+  }
+  if (abs(x2 - x1) < 0.01 || abs(y2 - y1) < 0.01) {
+    return(data.frame(x = c(x1, x2), y = c(y1, y2)))
+  }
+
+  # Keep a horizontal corridor between two vertical endpoint stems. Lane
+  # offsets can then move the corridor without moving either metabolite node.
+  corridor_y <- .dnmb_cct_snap_to_grid(
+    (y1 + y2) / 2,
+    step = max(0.01, grid_step / 2)
+  )
+  if (abs(corridor_y - y1) < 0.01 || abs(corridor_y - y2) < 0.01) {
+    corridor_y <- (y1 + y2) / 2
+  }
+  data.frame(
+    x = c(x1, x1, x2, x2),
+    y = c(y1, corridor_y, corridor_y, y2)
+  )
+}
+
+.dnmb_cct_route_overlay_edges <- function(node_ids, node_x, node_y,
+                                          grid_step = 0.5) {
+  keep_ids <- node_ids[node_ids %in% names(node_x) & node_ids %in% names(node_y)]
+  if (length(keep_ids) < 2L) return(list())
+  lapply(seq_len(length(keep_ids) - 1L), function(edge_index) {
+    from_id <- keep_ids[edge_index]
+    to_id <- keep_ids[edge_index + 1L]
+    pts <- .dnmb_cct_raw_pair_route_points(
+      x1 = unname(node_x[from_id]), y1 = unname(node_y[from_id]),
+      x2 = unname(node_x[to_id]), y2 = unname(node_y[to_id]),
+      grid_step = grid_step
+    )
+    attr(pts, "from_id") <- from_id
+    attr(pts, "to_id") <- to_id
+    pts
+  })
+}
+
+.dnmb_cct_validate_extracellular_routes <- function(specs, anchors,
+                                                     tolerance = 1e-6) {
+  if (is.null(specs) || !length(specs)) return(list())
+  if (!is.list(specs)) {
+    stop("extracellular route specs must be a list", call. = FALSE)
+  }
+  required_anchor_cols <- c("kind", "id", "x", "y")
+  if (is.null(anchors) || !is.data.frame(anchors) ||
+      !all(required_anchor_cols %in% names(anchors))) {
+    stop(
+      "extracellular anchors require kind, id, x, and y columns",
+      call. = FALSE
+    )
+  }
+  anchors <- as.data.frame(anchors, stringsAsFactors = FALSE, row.names = NULL)
+  anchors$kind <- trimws(as.character(anchors$kind))
+  anchors$id <- trimws(as.character(anchors$id))
+  anchors$x <- suppressWarnings(as.numeric(anchors$x))
+  anchors$y <- suppressWarnings(as.numeric(anchors$y))
+  anchors <- anchors[
+    !is.na(anchors$kind) & nzchar(anchors$kind) &
+      !is.na(anchors$id) & nzchar(anchors$id) &
+      is.finite(anchors$x) & is.finite(anchors$y),
+    , drop = FALSE
+  ]
+  tolerance <- max(0, suppressWarnings(as.numeric(tolerance)[1L]))
+  if (!is.finite(tolerance)) tolerance <- 1e-6
+  axis_tolerance <- max(1e-8, tolerance)
+
+  anchor_for <- function(kind, id) {
+    idx <- which(anchors$kind == kind & anchors$id == id)
+    if (length(idx) != 1L) return(NULL)
+    anchors[idx, , drop = FALSE]
+  }
+  validated <- list()
+  for (spec in specs) {
+    if (!is.list(spec)) next
+    required_spec <- c(
+      "source_kind", "source_id", "target_kind", "target_id", "points"
+    )
+    if (!all(required_spec %in% names(spec))) next
+    source_kind <- trimws(as.character(spec$source_kind)[1L])
+    source_id <- trimws(as.character(spec$source_id)[1L])
+    target_kind <- trimws(as.character(spec$target_kind)[1L])
+    target_id <- trimws(as.character(spec$target_id)[1L])
+    if (any(is.na(c(source_kind, source_id, target_kind, target_id))) ||
+        any(!nzchar(c(source_kind, source_id, target_kind, target_id)))) next
+    source <- anchor_for(source_kind, source_id)
+    target <- anchor_for(target_kind, target_id)
+    if (is.null(source) || is.null(target)) next
+
+    points <- spec$points
+    if (is.null(points) || !is.data.frame(points) || nrow(points) < 2L ||
+        !all(c("x", "y") %in% names(points))) next
+    points <- as.data.frame(points[, c("x", "y"), drop = FALSE])
+    points$x <- suppressWarnings(as.numeric(points$x))
+    points$y <- suppressWarnings(as.numeric(points$y))
+    if (any(!is.finite(points$x)) || any(!is.finite(points$y))) next
+    source_distance <- sqrt(
+      (points$x[1L] - source$x)^2 + (points$y[1L] - source$y)^2
+    )
+    target_distance <- sqrt(
+      (points$x[nrow(points)] - target$x)^2 +
+        (points$y[nrow(points)] - target$y)^2
+    )
+    if (source_distance > tolerance || target_distance > tolerance) next
+
+    points$x[1L] <- source$x
+    points$y[1L] <- source$y
+    points$x[nrow(points)] <- target$x
+    points$y[nrow(points)] <- target$y
+    points <- points[
+      c(TRUE, diff(points$x) != 0 | diff(points$y) != 0),
+      , drop = FALSE
+    ]
+    if (nrow(points) < 2L) next
+    dx <- diff(points$x)
+    dy <- diff(points$y)
+    if (any(abs(dx) > axis_tolerance & abs(dy) > axis_tolerance)) next
+    spec$points <- points
+    validated[[length(validated) + 1L]] <- spec
+  }
+  validated
+}
+
 .dnmb_cct_route_overlay_points <- function(node_ids, node_x, node_y, grid_step = 0.5) {
   keep_ids <- node_ids[node_ids %in% names(node_x) & node_ids %in% names(node_y)]
   if (length(keep_ids) < 2) return(NULL)
@@ -3979,6 +6049,330 @@
   }
   keep <- c(TRUE, diff(out$x) != 0 | diff(out$y) != 0)
   out[keep, , drop = FALSE]
+}
+
+.dnmb_cct_round_orthogonal_route <- function(points_df, radius = 0.04,
+                                             n_arc = 5L,
+                                             axis_tolerance = 1e-8) {
+  if (is.null(points_df) || !is.data.frame(points_df) || nrow(points_df) < 3L) {
+    return(points_df)
+  }
+  pts <- as.data.frame(points_df[, c("x", "y"), drop = FALSE])
+  keep <- is.finite(pts$x) & is.finite(pts$y)
+  pts <- pts[keep, , drop = FALSE]
+  if (nrow(pts) < 3L) return(pts)
+  pts <- pts[c(TRUE, diff(pts$x) != 0 | diff(pts$y) != 0), , drop = FALSE]
+  if (nrow(pts) < 3L || !is.finite(radius) || radius <= 0) return(pts)
+
+  out <- pts[1L, , drop = FALSE]
+  for (i in 2:(nrow(pts) - 1L)) {
+    prev <- c(pts$x[i - 1L], pts$y[i - 1L])
+    corner <- c(pts$x[i], pts$y[i])
+    next_pt <- c(pts$x[i + 1L], pts$y[i + 1L])
+    vin <- corner - prev
+    vout <- next_pt - corner
+    len_in <- sqrt(sum(vin^2))
+    len_out <- sqrt(sum(vout^2))
+    if (len_in <= axis_tolerance || len_out <= axis_tolerance) next
+    uin <- vin / len_in
+    uout <- vout / len_out
+    orthogonal <- abs(sum(uin * uout)) <= axis_tolerance &&
+      ((abs(uin[1]) <= axis_tolerance || abs(uin[2]) <= axis_tolerance) &&
+       (abs(uout[1]) <= axis_tolerance || abs(uout[2]) <= axis_tolerance))
+    if (!orthogonal) {
+      out <- rbind(out, pts[i, , drop = FALSE])
+      next
+    }
+    r_eff <- min(radius, len_in * 0.30, len_out * 0.30)
+    if (!is.finite(r_eff) || r_eff <= axis_tolerance) {
+      out <- rbind(out, pts[i, , drop = FALSE])
+      next
+    }
+    tangent_in <- corner - uin * r_eff
+    arc <- .dnmb_cct_quarter_arc_points(
+      corner = corner, dir_in = uin, dir_out = uout,
+      radius = r_eff, n = max(3L, as.integer(n_arc)[1L])
+    )
+    out <- rbind(
+      out,
+      data.frame(x = tangent_in[1L], y = tangent_in[2L]),
+      arc[-1L, , drop = FALSE]
+    )
+  }
+  out <- rbind(out, pts[nrow(pts), , drop = FALSE])
+  out[c(TRUE, diff(out$x) != 0 | diff(out$y) != 0), , drop = FALSE]
+}
+
+.dnmb_cct_route_lane_assignments <- function(routes, metadata = NULL,
+                                             lane_step = 0.05,
+                                             max_offset = 0.18,
+                                             horizontal_tolerance = 0.01,
+                                             y_tolerance = 0.04,
+                                             min_overlap = 0.18) {
+  if (is.null(routes)) routes <- list()
+  if (!is.list(routes)) stop("route lanes require a list of polylines", call. = FALSE)
+  n_routes <- length(routes)
+  empty <- data.frame(
+    route_index = integer(), route_id = character(), segment_index = integer(),
+    group = character(), priority = numeric(), x_min = numeric(), x_max = numeric(),
+    original_y = numeric(), lane_y = numeric(), offset = numeric(),
+    component = integer(), stringsAsFactors = FALSE
+  )
+  if (!n_routes) return(empty)
+
+  if (is.null(metadata)) metadata <- data.frame(route_id = as.character(seq_len(n_routes)))
+  metadata <- as.data.frame(metadata, stringsAsFactors = FALSE, row.names = NULL)
+  if (nrow(metadata) != n_routes) {
+    stop("route metadata must have one row per polyline", call. = FALSE)
+  }
+  if (!"route_id" %in% names(metadata)) metadata$route_id <- as.character(seq_len(n_routes))
+  if (!"priority" %in% names(metadata)) metadata$priority <- 0
+  if (!"group" %in% names(metadata)) metadata$group <- "route"
+  metadata$route_id <- as.character(metadata$route_id)
+  metadata$group <- as.character(metadata$group)
+  metadata$priority <- suppressWarnings(as.numeric(metadata$priority))
+  metadata$priority[!is.finite(metadata$priority)] <- 0
+  if (anyNA(metadata$route_id) || any(!nzchar(metadata$route_id)) || anyDuplicated(metadata$route_id)) {
+    stop("route_id values must be unique and non-empty", call. = FALSE)
+  }
+
+  segment_rows <- list()
+  for (route_index in seq_len(n_routes)) {
+    pts <- routes[[route_index]]
+    if (is.null(pts) || !is.data.frame(pts) || nrow(pts) < 2L ||
+        !all(c("x", "y") %in% names(pts))) next
+    for (segment_index in seq_len(nrow(pts) - 1L)) {
+      x1 <- suppressWarnings(as.numeric(pts$x[segment_index]))
+      x2 <- suppressWarnings(as.numeric(pts$x[segment_index + 1L]))
+      y1 <- suppressWarnings(as.numeric(pts$y[segment_index]))
+      y2 <- suppressWarnings(as.numeric(pts$y[segment_index + 1L]))
+      if (any(!is.finite(c(x1, x2, y1, y2)))) next
+      if (abs(y2 - y1) > horizontal_tolerance || abs(x2 - x1) < min_overlap) next
+      segment_rows[[length(segment_rows) + 1L]] <- data.frame(
+        route_index = route_index,
+        route_id = metadata$route_id[route_index],
+        segment_index = segment_index,
+        group = metadata$group[route_index],
+        priority = metadata$priority[route_index],
+        x_min = min(x1, x2), x_max = max(x1, x2),
+        original_y = mean(c(y1, y2)),
+        stringsAsFactors = FALSE
+      )
+    }
+  }
+  if (!length(segment_rows)) return(empty)
+  segments <- do.call(rbind, segment_rows)
+  n_segments <- nrow(segments)
+  adjacency <- vector("list", n_segments)
+  for (i in seq_len(n_segments)) adjacency[[i]] <- integer()
+  if (n_segments > 1L) {
+    for (i in seq_len(n_segments - 1L)) {
+      for (j in (i + 1L):n_segments) {
+        if (segments$route_index[i] == segments$route_index[j]) {
+          # Collinear pieces of one uninterrupted run must share a component.
+          # Otherwise different competitors on its left and right can assign
+          # opposite lane ranks and create an artificial H-V-H notch midway.
+          interval_gap <- max(
+            segments$x_min[i], segments$x_min[j]
+          ) - min(segments$x_max[i], segments$x_max[j])
+          contiguous <- interval_gap <= horizontal_tolerance + 1e-12 &&
+            abs(segments$original_y[i] - segments$original_y[j]) <= y_tolerance
+          if (contiguous) {
+            adjacency[[i]] <- c(adjacency[[i]], j)
+            adjacency[[j]] <- c(adjacency[[j]], i)
+          }
+          next
+        }
+        overlap <- min(segments$x_max[i], segments$x_max[j]) -
+          max(segments$x_min[i], segments$x_min[j])
+        if (overlap + 1e-12 < min_overlap ||
+            abs(segments$original_y[i] - segments$original_y[j]) > y_tolerance) next
+        adjacency[[i]] <- c(adjacency[[i]], j)
+        adjacency[[j]] <- c(adjacency[[j]], i)
+      }
+    }
+  }
+
+  component <- integer(n_segments)
+  next_component <- 0L
+  for (seed in seq_len(n_segments)) {
+    if (component[seed] != 0L) next
+    next_component <- next_component + 1L
+    queue <- seed
+    component[seed] <- next_component
+    while (length(queue)) {
+      current <- queue[1L]
+      queue <- queue[-1L]
+      unseen <- adjacency[[current]][component[adjacency[[current]]] == 0L]
+      if (length(unseen)) {
+        component[unseen] <- next_component
+        queue <- c(queue, unseen)
+      }
+    }
+  }
+  segments$component <- component
+  segments$lane_y <- segments$original_y
+  segments$offset <- 0
+
+  lane_step <- max(0, as.numeric(lane_step)[1L])
+  max_offset <- max(0, as.numeric(max_offset)[1L])
+  for (component_id in unique(component)) {
+    idx <- which(component == component_id)
+    route_ids <- unique(segments$route_id[idx])
+    if (length(route_ids) < 2L) next
+    route_rows <- lapply(route_ids, function(route_id) {
+      ridx <- idx[segments$route_id[idx] == route_id]
+      data.frame(
+        route_id = route_id,
+        original_y = stats::median(segments$original_y[ridx]),
+        priority = max(segments$priority[ridx]),
+        group = sort(unique(segments$group[ridx]))[1L],
+        stringsAsFactors = FALSE
+      )
+    })
+    route_rows <- do.call(rbind, route_rows)
+    route_rows <- route_rows[order(
+      route_rows$original_y, -route_rows$priority,
+      route_rows$group, route_rows$route_id
+    ), , drop = FALSE]
+    center_y <- stats::median(route_rows$original_y)
+    half_span <- lane_step * (nrow(route_rows) - 1L) / 2
+    original_span <- max(abs(route_rows$original_y - center_y))
+    allowed_span <- max(0, max_offset - original_span)
+    if (half_span > allowed_span && half_span > 0) {
+      effective_step <- lane_step * allowed_span / half_span
+    } else {
+      effective_step <- lane_step
+    }
+    lane_y <- center_y +
+      (seq_len(nrow(route_rows)) - (nrow(route_rows) + 1) / 2) * effective_step
+    lane_map <- stats::setNames(lane_y, route_rows$route_id)
+    for (route_id in route_rows$route_id) {
+      ridx <- idx[segments$route_id[idx] == route_id]
+      target_y <- unname(lane_map[route_id])
+      shift <- target_y - segments$original_y[ridx]
+      shift <- pmax(-max_offset, pmin(max_offset, shift))
+      segments$offset[ridx] <- shift
+      segments$lane_y[ridx] <- segments$original_y[ridx] + shift
+    }
+  }
+  segments
+}
+
+.dnmb_cct_separate_route_lanes <- function(routes, metadata = NULL,
+                                           lane_step = 0.05,
+                                           max_offset = 0.18,
+                                           horizontal_tolerance = 0.01,
+                                           y_tolerance = 0.04,
+                                           min_overlap = 0.18,
+                                           transition_span = 0.04,
+                                           connection_mode = c("move_internal", "transition"),
+                                           round_radius = 0) {
+  connection_mode <- match.arg(connection_mode)
+  assignments <- .dnmb_cct_route_lane_assignments(
+    routes = routes, metadata = metadata,
+    lane_step = lane_step, max_offset = max_offset,
+    horizontal_tolerance = horizontal_tolerance,
+    y_tolerance = y_tolerance, min_overlap = min_overlap
+  )
+  if (!length(routes) || !nrow(assignments)) {
+    if (length(routes) && round_radius > 0) {
+      routes <- lapply(routes, function(points) {
+        .dnmb_cct_round_orthogonal_route(points, radius = round_radius)
+      })
+    }
+    attr(routes, "lane_assignments") <- assignments
+    return(routes)
+  }
+
+  out <- vector("list", length(routes))
+  for (route_index in seq_along(routes)) {
+    pts <- routes[[route_index]]
+    route_assignments <- assignments[assignments$route_index == route_index, , drop = FALSE]
+    if (!nrow(route_assignments) || is.null(pts) || nrow(pts) < 2L) {
+      out[[route_index]] <- if (round_radius > 0) {
+        .dnmb_cct_round_orthogonal_route(pts, radius = round_radius)
+      } else pts
+      next
+    }
+    offset_map <- stats::setNames(route_assignments$offset, route_assignments$segment_index)
+    lane_y_map <- stats::setNames(route_assignments$lane_y, route_assignments$segment_index)
+
+    if (connection_mode == "move_internal") {
+      adjusted <- as.data.frame(pts[, c("x", "y"), drop = FALSE])
+      proposals <- vector("list", nrow(adjusted))
+      for (segment_index in as.integer(names(lane_y_map))) {
+        if (abs(offset_map[as.character(segment_index)]) <= 1e-12) next
+        target_y <- unname(lane_y_map[as.character(segment_index)])
+        if (segment_index > 1L) {
+          proposals[[segment_index]] <- c(proposals[[segment_index]], target_y)
+        }
+        if (segment_index + 1L < nrow(adjusted)) {
+          proposals[[segment_index + 1L]] <- c(proposals[[segment_index + 1L]], target_y)
+        }
+      }
+      for (vertex in seq_along(proposals)) {
+        if (length(proposals[[vertex]])) adjusted$y[vertex] <- stats::median(proposals[[vertex]])
+      }
+      adjusted$x[1L] <- pts$x[1L]
+      adjusted$y[1L] <- pts$y[1L]
+      adjusted$x[nrow(adjusted)] <- pts$x[nrow(pts)]
+      adjusted$y[nrow(adjusted)] <- pts$y[nrow(pts)]
+
+      # If the separated horizontal corridor starts or ends at a protected
+      # route endpoint, add a vertical stem at that endpoint. This keeps the
+      # endpoint exact without inserting a height-changing notch inside the
+      # horizontal run. Internal elbow vertices are moved directly above.
+      expanded <- adjusted[1L, c("x", "y"), drop = FALSE]
+      for (segment_index in seq_len(nrow(adjusted) - 1L)) {
+        key <- as.character(segment_index)
+        has_lane <- key %in% names(lane_y_map) &&
+          abs(offset_map[key]) > 1e-12 &&
+          abs(pts$y[segment_index + 1L] - pts$y[segment_index]) <= horizontal_tolerance
+        if (has_lane && segment_index == 1L) {
+          expanded <- rbind(expanded, data.frame(
+            x = pts$x[1L], y = unname(lane_y_map[key])
+          ))
+        }
+        if (has_lane && segment_index + 1L == nrow(adjusted)) {
+          expanded <- rbind(expanded, data.frame(
+            x = pts$x[nrow(pts)], y = unname(lane_y_map[key])
+          ))
+        }
+        expanded <- rbind(expanded, adjusted[segment_index + 1L, c("x", "y"), drop = FALSE])
+      }
+      adjusted <- expanded
+      adjusted <- adjusted[c(TRUE, diff(adjusted$x) != 0 | diff(adjusted$y) != 0), , drop = FALSE]
+      out[[route_index]] <- if (round_radius > 0) {
+        .dnmb_cct_round_orthogonal_route(adjusted, radius = round_radius)
+      } else adjusted
+      next
+    }
+
+    adjusted <- pts[1L, c("x", "y"), drop = FALSE]
+    for (segment_index in seq_len(nrow(pts) - 1L)) {
+      p0 <- pts[segment_index, c("x", "y"), drop = FALSE]
+      p1 <- pts[segment_index + 1L, c("x", "y"), drop = FALSE]
+      key <- as.character(segment_index)
+      offset <- if (key %in% names(offset_map)) unname(offset_map[key]) else 0
+      if (!is.finite(offset) || abs(offset) <= 1e-12) {
+        adjusted <- rbind(adjusted, p1)
+        next
+      }
+      dx <- p1$x - p0$x
+      inset <- min(max(0, transition_span), abs(dx) * 0.25)
+      direction <- sign(dx)
+      before <- data.frame(x = p0$x + direction * inset, y = p0$y)
+      lane_before <- data.frame(x = before$x, y = p0$y + offset)
+      lane_after <- data.frame(x = p1$x - direction * inset, y = p1$y + offset)
+      after <- data.frame(x = lane_after$x, y = p1$y)
+      adjusted <- rbind(adjusted, before, lane_before, lane_after, after, p1)
+    }
+    adjusted <- adjusted[c(TRUE, diff(adjusted$x) != 0 | diff(adjusted$y) != 0), , drop = FALSE]
+    out[[route_index]] <- adjusted
+  }
+  attr(out, "lane_assignments") <- assignments
+  out
 }
 
 .dnmb_cct_extra_preferred_lane <- function(substrate_id, extra_chains = NULL) {
@@ -4134,7 +6528,9 @@
 }
 
 .dnmb_cct_extra_product_exit_x <- function(chain, chain_x, product_sugar,
-                                           branches = NULL, sym_size = 0.075, gap = 0.02,
+                                           branches = NULL,
+                                           sym_size = .dnmb_cct_sugar_icon_radius(),
+                                           gap = 0.02,
                                            target_x = NA_real_) {
   if (is.null(chain)) chain <- character(0)
   step <- sym_size * 2 + gap
@@ -4278,15 +6674,18 @@
   min_gap + extra
 }
 
-.dnmb_cct_extra_chain_step <- function(sym_size = 0.075, gap = 0.18) {
+.dnmb_cct_extra_chain_step <- function(
+    sym_size = .dnmb_cct_sugar_icon_radius(), gap = 0.18) {
   sym_size * 2 + gap
 }
 
-.dnmb_cct_extra_chain_node_x <- function(chain_x, pos, sym_size = 0.075, gap = 0.18) {
+.dnmb_cct_extra_chain_node_x <- function(
+    chain_x, pos, sym_size = .dnmb_cct_sugar_icon_radius(), gap = 0.18) {
   chain_x + (as.numeric(pos)[1] - 1) * .dnmb_cct_extra_chain_step(sym_size = sym_size, gap = gap)
 }
 
-.dnmb_cct_extra_route_trim <- function(sym_size = 0.075) {
+.dnmb_cct_extra_route_trim <- function(
+    sym_size = .dnmb_cct_sugar_icon_radius()) {
   max(0.06, sym_size * 1.05)
 }
 
@@ -4392,7 +6791,7 @@
 
 .dnmb_cct_extra_layout <- function(extra_substrates, extra_chains, sugar_lane_x,
                                    row_y_map, extra_branches = NULL, cascades = NULL,
-                                   sym_size = 0.075,
+                                   sym_size = .dnmb_cct_sugar_icon_radius(),
                                    gap = 0.02, min_gap = 0.35) {
   step <- sym_size * 2 + gap
   extra_df <- extra_substrates
@@ -4525,7 +6924,9 @@
 #' @return List of ggplot2 layers
 #' @keywords internal
 .dnmb_draw_sugar_chain_v2 <- function(x_start, y, monomers, bonds = NULL,
-                                   size = 0.075, gap = 0.18, show_label = TRUE) {
+                                   size = .dnmb_cct_sugar_icon_radius(),
+                                   gap = 0.18, show_label = TRUE,
+                                   show_bond_label = TRUE) {
 
   n_mono <- length(monomers)
   if (n_mono == 0L) return(list())
@@ -4569,17 +6970,19 @@
       # Bond notation: compact label at midpoint above the linkage line
       mid_x <- (seg_x1 + seg_x2) / 2
       bond_label <- if (length(pos_parts) >= 2L) {
-        paste0(anom_sym, pos_parts[1L], "\u2013", pos_parts[2L])
+        paste0(anom_sym, pos_parts[1L], "-", pos_parts[2L])
       } else {
         paste0(anom_sym, pos_parts[1L])
       }
-      layers[[length(layers) + 1L]] <- ggplot2::geom_text(
-        data    = data.frame(x = mid_x, y = y + size * 2.0,
-                             label = bond_label),
-        mapping = ggplot2::aes(x = .data[["x"]], y = .data[["y"]],
-                               label = .data[["label"]]),
-        size = 1.2, color = "#888888", hjust = 0.5, inherit.aes = FALSE
-      )
+      if (isTRUE(show_bond_label)) {
+        layers[[length(layers) + 1L]] <- ggplot2::geom_text(
+          data    = data.frame(x = mid_x, y = y + size * 2.0,
+                               label = bond_label),
+          mapping = ggplot2::aes(x = .data[["x"]], y = .data[["y"]],
+                                 label = .data[["label"]]),
+          size = 1.2, color = "#888888", hjust = 0.5, inherit.aes = FALSE
+        )
+      }
 
       # alpha-1,6 gets a small vertical branch stub
       if (bonds[i] == "alpha-1,6") {
@@ -4685,54 +7088,80 @@
 # Scissors grob for GH cleavage marks
 # ---------------------------------------------------------------------------
 
-#' Draw scissors symbol (two crossed blades) for GH cleavage
-#' @param x,y Position of the scissors
-#' @param size Scale factor
-#' @param angle Rotation angle in degrees (0 = horizontal cut)
-#' @return List of ggplot2 layers (two curved blade segments + pivot)
+#' Compute the geometry for the GH-cleavage scissors glyph
+#' @keywords internal
+.dnmb_scissors_geometry_v2 <- function(x, y, size = 0.12, angle = 0) {
+  d <- max(0.001, as.numeric(size)[1])
+  rad <- as.numeric(angle)[1] * pi / 180
+  rotate <- function(dx, dy) {
+    data.frame(
+      x = x + dx * cos(rad) - dy * sin(rad),
+      y = y + dx * sin(rad) + dy * cos(rad)
+    )
+  }
+
+  handles <- rotate(c(-0.78, -0.78) * d, c(0.42, -0.42) * d)
+  handles$group <- c("upper", "lower")
+  pivot <- rotate(0, 0)
+  tips <- rotate(c(1.12, 1.12) * d, c(-0.42, 0.42) * d)
+  tips$group <- c("lower", "upper")
+
+  shanks <- data.frame(
+    x = handles$x, y = handles$y,
+    xend = pivot$x, yend = pivot$y,
+    group = handles$group
+  )
+  blades <- data.frame(
+    x = pivot$x, y = pivot$y,
+    xend = tips$x, yend = tips$y,
+    group = tips$group
+  )
+  list(
+    handles = handles,
+    pivot = pivot,
+    tips = tips,
+    shanks = shanks,
+    blades = blades,
+    handle_radius = 0.27 * d,
+    pivot_radius = 0.12 * d
+  )
+}
+
+#' Draw a foreground scissors symbol for GH cleavage
+#' @param x,y Position of the pivot
+#' @param size Scale factor in plot coordinates
+#' @param angle Rotation angle in degrees
+#' @return List of ggplot2 layers
 #' @keywords internal
 .dnmb_scissors_grob_v2 <- function(x, y, size = 0.12, angle = 0) {
-  d <- size
-  rad <- angle * pi / 180
-  # Two blade lines crossing at (x, y)
-  # Blade 1: top-left to bottom-right
-  b1 <- data.frame(
-    x    = x + d * cos(rad + pi * 0.75),
-    xend = x + d * cos(rad - pi * 0.25),
-    y    = y + d * sin(rad + pi * 0.75),
-    yend = y + d * sin(rad - pi * 0.25)
-  )
-  # Blade 2: bottom-left to top-right
-  b2 <- data.frame(
-    x    = x + d * cos(rad + pi * 1.25),
-    xend = x + d * cos(rad + pi * 0.25),
-    y    = y + d * sin(rad + pi * 1.25),
-    yend = y + d * sin(rad + pi * 0.25)
-  )
-  # Handle rings (small circles at blade ends)
-  r <- size * 0.3
-  ring1 <- .dnmb_snfg_polygon_coords_v2("circle", b1$x, b1$y, r)
-  ring2 <- .dnmb_snfg_polygon_coords_v2("circle", b2$x, b2$y, r)
-  ring1$group <- "r1"; ring2$group <- "r2"
+  geom <- .dnmb_scissors_geometry_v2(x, y, size = size, angle = angle)
+  all_segments <- rbind(geom$shanks, geom$blades)
 
-  list(
+  layers <- list(
     ggplot2::geom_segment(
-      data = b1, mapping = ggplot2::aes(x = .data[["x"]], xend = .data[["xend"]],
-                                         y = .data[["y"]], yend = .data[["yend"]]),
-      linewidth = 0.7, color = "#ED1C24", inherit.aes = FALSE),
+      data = all_segments,
+      ggplot2::aes(x = .data$x, y = .data$y, xend = .data$xend, yend = .data$yend),
+      linewidth = 1.25, color = "#FFFFFF", lineend = "round", inherit.aes = FALSE),
     ggplot2::geom_segment(
-      data = b2, mapping = ggplot2::aes(x = .data[["x"]], xend = .data[["xend"]],
-                                         y = .data[["y"]], yend = .data[["yend"]]),
-      linewidth = 0.7, color = "#ED1C24", inherit.aes = FALSE),
-    ggplot2::geom_polygon(
-      data = ring1, mapping = ggplot2::aes(x = .data[["x"]], y = .data[["y"]],
-                                            group = .data[["group"]]),
-      fill = NA, color = "#ED1C24", linewidth = 0.4, inherit.aes = FALSE),
-    ggplot2::geom_polygon(
-      data = ring2, mapping = ggplot2::aes(x = .data[["x"]], y = .data[["y"]],
-                                            group = .data[["group"]]),
-      fill = NA, color = "#ED1C24", linewidth = 0.8, inherit.aes = FALSE)
+      data = geom$blades,
+      ggplot2::aes(x = .data$x, y = .data$y, xend = .data$xend, yend = .data$yend),
+      linewidth = 0.62, color = "#687078", lineend = "round", inherit.aes = FALSE),
+    ggplot2::geom_segment(
+      data = geom$shanks,
+      ggplot2::aes(x = .data$x, y = .data$y, xend = .data$xend, yend = .data$yend),
+      linewidth = 0.62, color = "#C62828", lineend = "round", inherit.aes = FALSE)
   )
+  for (i in seq_len(nrow(geom$handles))) {
+    layers[[length(layers) + 1L]] <- .dnmb_native_circle_layer_v2(
+      geom$handles$x[i], geom$handles$y[i], radius = geom$handle_radius,
+      fill = "#FFFFFF", color = "#C62828", linewidth = 0.42
+    )
+  }
+  layers[[length(layers) + 1L]] <- .dnmb_native_circle_layer_v2(
+    geom$pivot$x, geom$pivot$y, radius = geom$pivot_radius,
+    fill = "#FFFFFF", color = "#7F1D1D", linewidth = 0.38
+  )
+  layers
 }
 
 # ---------------------------------------------------------------------------
@@ -4743,15 +7172,26 @@
 #' @keywords internal
 .dnmb_cct_3zone_extract_gh <- function(genbank_table) {
   tbl <- base::as.data.frame(genbank_table, stringsAsFactors = FALSE, row.names = NULL)
-  family_col <- .dnmb_pick_column(tbl, c("dbCAN_family_id", "family_id"))
-  if (is.null(family_col)) return(NULL)
-  tbl <- tbl[!is.na(tbl[[family_col]]) & nzchar(tbl[[family_col]]), , drop = FALSE]
-  if (!nrow(tbl)) return(NULL)
-  tbl$family <- as.character(tbl[[family_col]])
-  # Keep only GH families
+  family_cols <- intersect(
+    c("dbCAN_dbcan_all_families", "dbCAN_dbcan_hit", "dbCAN_family_id", "family_id"),
+    names(tbl)
+  )
+  if (!length(family_cols) || !nrow(tbl)) return(NULL)
 
-  gh <- tbl[grepl("^GH", tbl$family), , drop = FALSE]
-  if (!nrow(gh)) return(NULL)
+  gh_by_row <- lapply(seq_len(nrow(tbl)), function(i) {
+    families <- character()
+    for (column in family_cols) {
+      families <- .dnmb_dbcan_family_tokens(tbl[[column]][i])
+      if (length(families)) break
+    }
+    families[grepl("^GH", families)]
+  })
+  keep <- lengths(gh_by_row) > 0L
+  if (!any(keep)) return(NULL)
+
+  row_index <- rep(which(keep), lengths(gh_by_row[keep]))
+  gh <- tbl[row_index, , drop = FALSE]
+  gh$family <- unlist(gh_by_row[keep], use.names = FALSE)
   lt_col <- .dnmb_pick_column(gh, c("locus_tag", "old_locus_tag"))
   gn_col <- .dnmb_pick_column(gh, c("gene", "gene_name"))
   data.frame(
@@ -4799,7 +7239,7 @@
   if (path_col %in% names(tbl)) {
     tbl2 <- tbl[!is.na(tbl[[path_col]]) & nzchar(tbl[[path_col]]), , drop = FALSE]
     if (nrow(tbl2) > 0) {
-      is_t <- grepl("transport|PTS|permease|ABC|SBP|MFS|EIICB|IIBC|EIIBC|EIIA|crr|porter|uptake", tbl2[[step_col]], ignore.case = TRUE) |
+      is_t <- grepl("transport|PTS|permease|ABC|SBP|MFS|EIICB|IIBC|EIIBC|EIIA|crr|porter|uptake|\\bdeoP\\b", tbl2[[step_col]], ignore.case = TRUE) |
               grepl("transport", tbl2[[path_col]], ignore.case = TRUE) |
               grepl("^pts[A-Z]|^mal[EF]IICB|^fru[A-Z]*-ABC", tbl2[[step_col]], ignore.case = FALSE)
       trans <- tbl2[is_t, , drop = FALSE]
@@ -4827,7 +7267,7 @@
       if (file.exists(f)) {
         st <- utils::read.delim(f, stringsAsFactors = FALSE, row.names = NULL)
         if (all(c("pathway","step","locusId") %in% names(st))) {
-          is_t <- grepl("transport|PTS|pts|permease|ABC|SBP|MFS", st$step, ignore.case = TRUE)
+          is_t <- grepl("transport|PTS|pts|permease|ABC|SBP|MFS|\\bdeoP\\b", st$step, ignore.case = TRUE)
           has_l <- !is.na(st$locusId) & nzchar(st$locusId)
           ts <- st[is_t & has_l, , drop = FALSE]
           ts <- ts[!duplicated(ts$locusId), , drop = FALSE]
@@ -5131,7 +7571,7 @@
   all_cs <- c("Maltose","Cellobiose","Galactose","Trehalose","Lactose",
               "Mannose","NAG","Glucosamine","Fructose","Sucrose",
               "Mannitol","Glycerol","Xylose","Arabinose","Ribose",
-              "Fucose","Rhamnose","Gluconate")
+              "Deoxyribose","Fucose","Rhamnose","Gluconate")
   # Family base positions: compact around backbone (bx=10)
   #   Glc family left of backbone, Fru/Man right, PPP/Xyl further right
   fam_cs_base <- c(Glc=7, GlcNAc=8, Gal=9, Fru=11, Man=12, Xyl=13.5, Other=15)
@@ -5144,14 +7584,15 @@
       fam_cs_base["Gal"]+dx_cs, fam_cs_base["Man"], fam_cs_base["GlcNAc"], fam_cs_base["GlcNAc"]+dx_cs,
       fam_cs_base["Fru"], fam_cs_base["Fru"]+dx_cs, fam_cs_base["Man"]+dx_cs, fam_cs_base["Other"],
       fam_cs_base["Xyl"], fam_cs_base["Xyl"]+dx_cs, fam_cs_base["Xyl"]+2*dx_cs,
-      fam_cs_base["Other"]+dx_cs, fam_cs_base["Other"]+2*dx_cs, fam_cs_base["Other"]+3*dx_cs)
+      fam_cs_base["Other"]+dx_cs, fam_cs_base["Other"]+2*dx_cs,
+      fam_cs_base["Other"]+3*dx_cs, fam_cs_base["Other"]+4*dx_cs)
     cs_xs <- stats::setNames(cs_xs_default, all_cs)
   }
   cs_map <- cs_xs
 
   # Backbone top y -- just below membrane
-  by <- 7.5  # Glucose starts here
-  cs_y <- by + 0.5  # carbon source row y
+  by <- 7.2  # shift the upper cytoplasmic grid below the membrane gutter
+  cs_y <- by + 0.45
 
   # ---- Backbone centered, entries at their family x ----
   bx <- 10.0                   # Glycolysis backbone at center x
@@ -5171,7 +7612,7 @@
     Fru = compact_anchor(c("Fructose", "Sucrose"), bx, fallback = fam_cs_base["Fru"], pull_left = 0.40, pull_right = 0.40),
     Man = compact_anchor(c("Mannose", "Mannitol"), bx, fallback = fam_cs_base["Man"], pull_left = 0.45, pull_right = 0.40),
     Xyl = compact_anchor(c("Xylose", "Arabinose", "Ribose"), px, fallback = fam_cs_base["Xyl"], pull_left = 0.35, pull_right = 0.40),
-    Other = compact_anchor(c("Glycerol", "Fucose", "Rhamnose", "Gluconate"), bx + 2.0, fallback = fam_cs_base["Other"], pull_left = 0.35, pull_right = 0.45)
+    Other = compact_anchor(c("Glycerol", "Deoxyribose", "Fucose", "Rhamnose", "Gluconate"), bx + 2.0, fallback = fam_cs_base["Other"], pull_left = 0.35, pull_right = 0.45)
   )
   xyl_lane <- .dnmb_cct_snap_to_grid(fam_cs["Xyl"], step = 0.5)
   arab_lane <- .dnmb_cct_snap_to_grid(fam_cs["Xyl"] + dx_cs, step = 0.5)
@@ -5255,6 +7696,8 @@
     n("Xylulose",     csx("Xylose", xyl_lane),           7.0, "Xylulose",    "entry_intermediate", "xylose"),
     n("Ribulose",     csx("Arabinose", arab_lane),        7.0, "Ribulose",   "entry_intermediate", "arabinose"),
     n("Ribulose-5-P", csx("Arabinose", arab_lane),        6.5, "Ribu-5-P",   "entry_intermediate", "arabinose"),
+    n("Deoxyribose-5-P", csx("Deoxyribose", fam_cs["Other"]), 7.0,
+      "dRibose-5-P", "entry_intermediate", "deoxyribose"),
     n("Fuculose",     csx("Fucose", fam_cs["Other"]),     7.0, "Fuculose",    "entry_intermediate", "fucose"),
     n("Fuculose-1-P", csx("Fucose", fam_cs["Other"]),     6.5, "Fuc-1-P",    "entry_intermediate", "fucose"),
     n("Rhamnulose",    csx("Rhamnose", fam_cs["Other"]+dx_cs), 7.0, "Rhamnulose","entry_intermediate", "rhamnose"),
@@ -5359,6 +7802,8 @@
     e("Xylulose", "Xu-5-P", "xylan", 0.10),      # xylA/xylB
     e("Ribulose", "Ribulose-5-P", "xylan", -0.10), # araA / araB
     e("Ribulose-5-P", "Xu-5-P", "xylan", -0.10),   # araD
+    e("Deoxyribose-5-P", "GA3P", "deoxyribose", -0.12), # deoC product 1
+    e("Deoxyribose-5-P", "Acetaldehyde", "deoxyribose", 0.12), # deoC product 2
     e("Fuculose", "Fuculose-1-P", "fucose", -0.10), # fucI / fucK
     e("Fuculose-1-P", "DHAP", "fucose", -0.15),  # fucI/fucK
     e("Rhamnulose", "Rhamnulose-1-P", "rhamnose"),
@@ -5378,6 +7823,11 @@
     e("Acetyl-P", "Acetate", "pyruvate_branch"),    # ackA
     e("Acetyl-CoA", "Acetaldehyde", "pyruvate_branch"), # aldh
     e("Acetaldehyde", "Ethanol", "pyruvate_branch"),    # adh
+    e("Acetaldehyde", "Acetate", "deoxyribose"),        # deoxyribose adh
+    e("Acetate", "Acetyl-P", "deoxyribose"),            # deoxyribose ackA
+    e("Acetyl-P", "Acetyl-CoA", "deoxyribose"),         # deoxyribose pta
+    e("Acetate", "Acetyl-CoA", "deoxyribose"),          # deoxyribose acs
+    e("Acetaldehyde", "Acetyl-CoA", "deoxyribose"),     # deoxyribose ald-dh-CoA
 
     # Anaplerotic reactions
     e("PEP", "OAA", "backbone", -0.2),              # ppc: PEP carboxylase (anaplerosis)
@@ -5411,6 +7861,7 @@
     e("Xylose", "Xylulose", "xylan"),
     e("Arabinose", "Ribulose", "xylan", -0.15),
     e("Ribose", "R-5-P", "pentose"),
+    e("Deoxyribose", "Deoxyribose-5-P", "deoxyribose"),
     e("Fucose", "Fuculose", "fucose", -0.2),
     e("Rhamnose", "Rhamnulose", "rhamnose", -0.2),
     e("Gluconate", "6-PG", "gluconate", -0.15)
@@ -5446,13 +7897,18 @@
   if (is.null(nodes) || nrow(nodes) < 2) return(nodes)
   # TCA nodes use exact circle positions — exempt from grid snapping
   is_tca <- nodes$type == "tca"
+  is_carbon_source <- nodes$type == "carbon_source"
   tca_save_x <- nodes$x[is_tca]
   tca_save_y <- nodes$y[is_tca]
+  carbon_source_x <- nodes$x[is_carbon_source]
   nodes$x <- .dnmb_cct_snap_to_grid(nodes$x, step = step)
   nodes$y <- .dnmb_cct_snap_to_grid(nodes$y, step = step)
   # Restore TCA exact positions
   nodes$x[is_tca] <- tca_save_x
   nodes$y[is_tca] <- tca_save_y
+  # Carbon-source lanes are optimized on a 0.25-unit lattice.  Preserve that
+  # spacing so a source is not snapped onto a neighboring pathway's chain.
+  nodes$x[is_carbon_source] <- carbon_source_x
 
   # Priority: backbone > ppp > tca > ed > entry_intermediate > carbon_source
   type_priority <- c(backbone = 6, ppp = 5, tca = 4, ed = 3,
@@ -5541,6 +7997,7 @@
     Xylose = "pentose",
     Arabinose = "pentose",
     Ribose = "pentose",
+    Deoxyribose = "deoxy",
     Fucose = "deoxy",
     Rhamnose = "deoxy",
     Gluconate = "gluconate",
@@ -5810,6 +8267,7 @@
     sucrose   = "#A8D08D",    # light green
     xylan     = "#F69EA1",    # pink (Xylose/Arabinose)
     pentose   = "#F69EA1",    # pink
+    deoxyribose = "#8C6BB1",  # muted violet
     fucose    = "#ED1C24",    # red
     gluconate = "#6BAED6",    # light blue
     glycerol  = "#3182BD",    # medium blue
@@ -5833,7 +8291,7 @@
 .dnmb_cct_pul_substrate_to_cs <- function() {
   c(
     starch = "Maltose", cellulose = "Cellobiose", xylan = "Xylose",
-    chitin = "NAG", pectin = "Gluconate", mannan = "Mannose",
+    chitin = "NAG", mannan = "Mannose",
     inulin = "Fructose", fructan = "Fructose", sucrose = "Sucrose",
     "beta-glucan" = "Cellobiose", "beta-mannan" = "Mannose",
     arabinan = "Arabinose", galactan = "Galactose",
@@ -5846,7 +8304,7 @@
     agarose = "Galactose",
     agar = "Galactose", carrageenan = "Galactose",
     cellobiose = "Cellobiose", mannose = "Mannose",
-    fructose = "Fructose", glucose = "Maltose",
+    fructose = "Fructose", glucose = "Glucose",
     galactose = "Galactose", ribose = "Ribose",
     glycerol = "Glycerol", gluconate = "Gluconate"
   )
@@ -5948,12 +8406,13 @@
     NAG         = "^(nagA|nagB|nagC|nagK|gamA|nag1|nag2)",
     Glucosamine = "^(nagB|gamA|glmS|glmM)",
     Fructose    = "^(fruK|fruA|fruB|scrK|1pfk)",
-    Sucrose     = "^(sacA|scrB|sacB|sacC|inv[ABCD]|sucA)",
+    Sucrose     = "^(sacA|scrB|sacB|sacC|inv[ABCD])",
     Mannitol    = "^(mtlD|mtlK|mtlA)",
     Glycerol    = "^(glpK|glpD|glpA|glpB|glpC|dhaK|dhaL|dhaM)",
     Xylose      = "^(xylA|xylB|xylR)",
     Arabinose   = "^(araA|araB|araD|araR)",
     Ribose      = "^(rbsK|rbsR|rbsD)",
+    Deoxyribose = "^(deoK|deoC)",
     Fucose      = "^(fucI|fucK|fucA|fucO|fucR)",
     Rhamnose    = "^(rhaA|rhaB|rhaD|rhaR|rhaS)",
     Gluconate   = "^(gntK|gntR|gntU|gntT|gnd|edd|eda|kdgK|kduD)",
@@ -5982,6 +8441,7 @@
     Xylose      = "xylose isomerase|xylulokinase",
     Arabinose   = "L-arabinose isomerase|ribulokinase|L-ribulose",
     Ribose      = "ribokinase|ribose-5-phosphate",
+    Deoxyribose = "deoxyribose kinase|deoxyribose-5-phosphate|deoxyribose-phosphate aldolase",
     Fucose      = "L-fucose isomerase|L-fuculose|fuculokinase",
     Rhamnose    = "L-rhamnose isomerase|rhamnulokinase|L-rhamnulose",
     Gluconate   = "gluconate kinase|gluconokinase|Entner-Doudoroff|KDG|KDPG",
@@ -6007,6 +8467,7 @@
     Sucrose     = "^3\\.2\\.1\\.26$|^2\\.4\\.1\\.7$",                    # invertase, sucrose phosphorylase
     Xylose      = "^5\\.3\\.1\\.5$",                                      # xylose isomerase
     Arabinose   = "^5\\.3\\.1\\.4$|^2\\.7\\.1\\.16$",                    # araA, araB
+    Deoxyribose = "^2\\.7\\.1\\.15$|^4\\.1\\.2\\.4$",                    # deoK, deoC
     Fucose      = "^5\\.3\\.1\\.25$|^2\\.7\\.1\\.51$",                   # fucI, fucK
     Rhamnose    = "^5\\.3\\.1\\.14$|^2\\.7\\.1\\.5$",                    # rhaA, rhaB
     Gluconate   = "^2\\.7\\.1\\.12$|^4\\.2\\.1\\.12$|^4\\.1\\.2\\.14$"  # gntK, edd, eda
@@ -6024,6 +8485,531 @@
   unique(evidence_cs)
 }
 
+# Conservative annotation scan for the central-carbon reactions that are not
+# assessed by GapMindCarbon's substrate-utilization paths.  A strong hit needs
+# agreement between at least two independent annotation axes (gene name,
+# product, EC, or KO); single exact gene/EC/KO matches remain partial evidence.
+.dnmb_cct_core_metabolism_evidence <- function(genbank_table) {
+  if (is.list(genbank_table) && !is.data.frame(genbank_table) &&
+      "features" %in% names(genbank_table)) {
+    genbank_table <- genbank_table$features
+  }
+  tbl <- base::as.data.frame(genbank_table, stringsAsFactors = FALSE, row.names = NULL)
+
+  empty_hits <- data.frame(
+    reaction_id = character(), pathway = character(), component = character(),
+    component_required = logical(), locus_tag = character(), gene_name = character(),
+    product = character(), evidence_level = character(), evidence_axes = character(),
+    stringsAsFactors = FALSE
+  )
+
+  component <- function(name, required = TRUE, genes = character(),
+                        products = character(), ecs = character(), kos = character(),
+                        exclude_genes = character(), exclude_products = character(),
+                        exclude_kos = character(), allow_cs_ambiguity = FALSE) {
+    list(
+      name = name, required = required, genes = genes, products = products,
+      ecs = ecs, kos = kos, exclude_genes = exclude_genes,
+      exclude_products = exclude_products, exclude_kos = exclude_kos,
+      allow_cs_ambiguity = allow_cs_ambiguity
+    )
+  }
+
+  catalog <- list(
+    list(id = "C01", pathway = "TCA cycle", from = "OAA", to = "Citrate",
+         label = "Citrate synthase", mode = "all", components = list(
+           component(
+             "CS", genes = c("gltA", "citZ"),
+             products = c("citrate synthase"), ecs = "2.3.3.1", kos = "K01647",
+             exclude_genes = c("prpC", "mmgD", "cimA", "leuA"),
+             exclude_products = c("methylcitrate", "2-methylcitrate", "citramalate",
+                                  "homocitrate", "isopropylmalate"),
+             exclude_kos = "K01659", allow_cs_ambiguity = TRUE
+           )
+         )),
+    list(id = "C02", pathway = "TCA cycle", from = "Citrate", to = "Isocit",
+         label = "Aconitate hydratase", mode = "all", components = list(
+           component(
+             "ACN", genes = c("acn", "acnA", "acnB", "citB"),
+             products = c("aconitate hydratase", "aconitase"),
+             ecs = "4.2.1.3", kos = c("K01681", "K01682"),
+             exclude_genes = c("prpD", "leuC", "leuD"),
+             exclude_products = c("methylcitrate", "isopropylmalate", "homoaconitate")
+           )
+         )),
+    list(id = "C03", pathway = "TCA cycle", from = "Isocit", to = "AKG",
+         label = "Isocitrate dehydrogenase", mode = "all", components = list(
+           component(
+             "ICD", genes = c("icd", "icdA", "icdB", "idh", "idhA", "idp"),
+             products = c("isocitrate dehydrogenase"),
+             ecs = c("1.1.1.41", "1.1.1.42"), kos = c("K00030", "K00031"),
+             exclude_genes = c("leuB"),
+             exclude_products = c("isopropylmalate", "isocitrate/isopropylmalate")
+           )
+         )),
+    list(id = "C04", pathway = "TCA cycle", from = "AKG", to = "SucCoA",
+         label = "2-Oxoglutarate DH E1/E2", mode = "all", components = list(
+           component(
+             "E1", genes = c("sucA", "odhA", "ogdh"),
+             products = c("2-oxoglutarate dehydrogenase.*E1",
+                          "alpha-ketoglutarate dehydrogenase.*E1"),
+             ecs = "1.2.4.2", kos = "K00164",
+             exclude_genes = c("pdhA", "bkdA"),
+             exclude_products = c("pyruvate dehydrogenase", "branched-chain.*dehydrogenase")
+           ),
+           component(
+             "E2", genes = c("sucB", "odhB"),
+             products = c("dihydrolipo.*succinyltransferase",
+                          "2-oxoglutarate dehydrogenase.*E2"),
+             ecs = "2.3.1.61", kos = "K00658",
+             exclude_genes = c("pdhC", "bkdB"),
+             exclude_products = c("pyruvate dehydrogenase", "branched-chain.*dehydrogenase")
+           )
+         )),
+    list(id = "C05", pathway = "TCA cycle", from = "SucCoA", to = "Succinate",
+         label = "Succinate-CoA ligase alpha/beta", mode = "all", components = list(
+           component(
+             "alpha", genes = "sucD", products = c("succinate--CoA ligase.*alpha",
+                                                    "succinyl-CoA synthetase.*alpha"),
+             ecs = c("6.2.1.4", "6.2.1.5"), kos = "K01902"
+           ),
+           component(
+             "beta", genes = "sucC", products = c("succinate--CoA ligase.*beta",
+                                                   "succinyl-CoA synthetase.*beta"),
+             ecs = c("6.2.1.4", "6.2.1.5"), kos = "K01903"
+           )
+         )),
+    list(id = "C06", pathway = "TCA cycle", from = "Succinate", to = "Fumarate",
+         label = "Succinate dehydrogenase A/B", mode = "all", components = list(
+           component(
+             "A", genes = "sdhA", products = "succinate dehydrogenase.*flavoprotein",
+             ecs = "1.3.5.1", kos = "K00239",
+             exclude_genes = "frdA", exclude_products = "fumarate reductase"
+           ),
+           component(
+             "B", genes = "sdhB", products = "succinate dehydrogenase.*iron-sulfur",
+             ecs = "1.3.5.1", kos = "K00240",
+             exclude_genes = "frdB", exclude_products = "fumarate reductase"
+           ),
+           component(
+             "membrane", genes = c("sdhC", "sdhD"),
+             products = c("succinate dehydrogenase.*cytochrome",
+                          "succinate dehydrogenase.*membrane"),
+             ecs = "1.3.5.1", kos = c("K00241", "K00242"),
+             exclude_genes = c("frdC", "frdD"), exclude_products = "fumarate reductase"
+           ),
+           component(
+             "FRD alternative", required = FALSE,
+             genes = c("frdA", "frdB", "frdC", "frdD"),
+             products = "fumarate reductase", ecs = "1.3.5.4",
+             kos = c("K00244", "K00245", "K00246", "K00247")
+           )
+         )),
+    list(id = "C07", pathway = "TCA cycle", from = "Fumarate", to = "Malate",
+         label = "Fumarate hydratase", mode = "all", components = list(
+           component(
+             "FUM", genes = c("fum", "fumA", "fumB", "fumC"),
+             products = c("fumarate hydratase", "fumarase"),
+             ecs = "4.2.1.2", kos = c("K01676", "K01677", "K01678"),
+             exclude_products = c("fumarylacetoacetate hydrolase", "fumarate reductase",
+                                  "tartrate hydratase")
+           )
+         )),
+    list(id = "C08", pathway = "TCA cycle", from = "Malate", to = "OAA",
+         label = "Malate DH / Mqo", mode = "any", components = list(
+           component(
+             "MDH", genes = "mdh", products = "malate dehydrogenase",
+             ecs = "1.1.1.37", kos = "K00024",
+             exclude_products = c("lactate dehydrogenase", "malic enzyme",
+                                  "isopropylmalate", "methylmalonate-semialdehyde")
+           ),
+           component(
+             "Mqo", genes = c("mqo", "mqoA"),
+             products = c("malate dehydrogenase \\(quinone\\)",
+                          "malate:quinone oxidoreductase", "malate quinone oxidoreductase"),
+             ecs = "1.1.5.4", kos = "K00116",
+             exclude_products = c("lactate dehydrogenase", "malic enzyme")
+           )
+         )),
+    list(id = "C09", pathway = "Glyoxylate shunt", from = "Isocit", to = "Glyoxylate",
+         label = "Isocitrate lyase", mode = "all", components = list(
+           component(
+             "ICL", genes = "aceA", products = "isocitrate lyase",
+             ecs = "4.1.3.1", kos = "K01637",
+             exclude_genes = "prpB", exclude_products = "methylisocitrate lyase",
+             exclude_kos = "K03417"
+           )
+         )),
+    list(id = "C10", pathway = "Glyoxylate shunt", from = "Glyoxylate", to = "Malate",
+         label = "Malate synthase", mode = "all", components = list(
+           component(
+             "MS", genes = c("aceB", "glcB"), products = c("malate synthase A?", "malate synthase"),
+             ecs = "2.3.3.9", kos = "K01638",
+             exclude_genes = "bshA",
+             exclude_products = c("N-acetylglucosaminyl.*malate synthase", "glucosaminyl.*malate synthase")
+           )
+         )),
+    list(id = "C11", pathway = "Glycolysis", from = "Glucose", to = "Glc-6-P",
+         label = "Glucose phosphorylation", mode = "any", components = list(
+           component(
+             "Glk", genes = c("glk", "glcK"), products = c("glucokinase", "glucose kinase"),
+             ecs = "2.7.1.2", kos = "K00845",
+             exclude_products = c("regulatory protein", "transcriptional regulator")
+           ),
+           component(
+             "Hxk", genes = c("hxk", "hexK"), products = "hexokinase",
+             ecs = "2.7.1.1", kos = "K00844",
+             exclude_products = "regulatory protein"
+           )
+         )),
+    list(id = "C12", pathway = "Glycolysis", from = "Glc-6-P", to = "Fru-6-P",
+         label = "Glucose-6-P isomerase", mode = "all", components = list(
+           component(
+             "Pgi", genes = c("pgi", "pgiA"),
+             products = "glucose-6-phosphate isomerase",
+             ecs = "5.3.1.9", kos = "K01810",
+             exclude_genes = "manA", exclude_products = "mannose-6-phosphate isomerase"
+           )
+         )),
+    list(id = "C13", pathway = "Glycolysis", from = "Fru-6-P", to = "Fru-1,6-BP",
+         label = "6-Phosphofructokinase", mode = "all", components = list(
+           component(
+             "Pfk", genes = c("pfk", "pfkA"), products = "6-phosphofructokinase",
+             ecs = "2.7.1.11", kos = c("K00850", "K21071"),
+             exclude_genes = c("fruK", "pfkB"),
+             exclude_products = c("1-phosphofructokinase", "ribokinase family")
+           )
+         )),
+    list(id = "C14", pathway = "Glycolysis", from = "Fru-1,6-BP", to = "GA3P",
+         label = "Fructose-bisphosphate aldolase", mode = "all", components = list(
+           component(
+             "Fba", genes = c("fba", "fbaA", "fbaB"),
+             products = "fructose.*bisphosphate aldolase",
+             ecs = "4.1.2.13", kos = c("K01623", "K01624", "K11645"),
+             exclude_products = c("2-dehydro-3-deoxy", "tagatose-bisphosphate aldolase")
+           )
+         )),
+    list(id = "C15", pathway = "Glycolysis", from = "DHAP", to = "GA3P",
+         label = "Triose-phosphate isomerase", mode = "all", components = list(
+           component(
+             "Tpi", genes = c("tpi", "tpiA"), products = "triose-phosphate isomerase",
+             ecs = "5.3.1.1", kos = "K01803"
+           )
+         )),
+    list(id = "C16", pathway = "Glycolysis", from = "GA3P", to = "1,3-BPG",
+         label = "Glyceraldehyde-3-P DH", mode = "all", components = list(
+           component(
+             "Gap", genes = c("gap", "gapA", "gapB"),
+             products = "glyceraldehyde-3-phosphate dehydrogenase",
+             ecs = "1.2.1.12", kos = "K00134",
+             exclude_genes = "gapN", exclude_products = "non-phosphorylating"
+           )
+         )),
+    list(id = "C17", pathway = "Glycolysis", from = "1,3-BPG", to = "3-PG",
+         label = "Phosphoglycerate kinase", mode = "all", components = list(
+           component(
+             "Pgk", genes = "pgk", products = "phosphoglycerate kinase",
+             ecs = "2.7.2.3", kos = "K00927"
+           )
+         )),
+    list(id = "C18", pathway = "Glycolysis", from = "3-PG", to = "2-PG",
+         label = "Phosphoglycerate mutase", mode = "all", components = list(
+           component(
+             "Gpm", genes = c("gpm", "gpmA", "gpmB", "gpmI"),
+             products = c("phosphoglycerate mutase", "2,3-bisphosphoglycerate-independent phosphoglycerate mutase"),
+             ecs = c("5.4.2.11", "5.4.2.12"),
+             kos = c("K01834", "K15633", "K15634"),
+             exclude_products = c("histidine phosphatase family", "cofactor-dependent phosphoglycerate mutase regulator")
+           )
+         )),
+    list(id = "C19", pathway = "Glycolysis", from = "2-PG", to = "PEP",
+         label = "Enolase", mode = "all", components = list(
+           component(
+             "Eno", genes = "eno", products = c("enolase", "phosphopyruvate hydratase"),
+             ecs = "4.2.1.11", kos = "K01689",
+             exclude_products = c("methylthiopentyl", "mandelate racemase")
+           )
+         )),
+    list(id = "C20", pathway = "Glycolysis", from = "PEP", to = "Pyruvate",
+         label = "Pyruvate kinase", mode = "all", components = list(
+           component(
+             "Pyk", genes = c("pyk", "pykA", "pykF"), products = "pyruvate kinase",
+             ecs = "2.7.1.40", kos = "K00873",
+             exclude_products = c("pyruvate phosphate dikinase", "phosphoenolpyruvate synthase")
+           )
+         ))
+  )
+
+  pick <- function(candidates, default = "") {
+    hit <- intersect(candidates, names(tbl))
+    if (!length(hit)) return(rep(default, nrow(tbl)))
+    out <- as.character(tbl[[hit[1]]])
+    out[is.na(out)] <- default
+    trimws(out)
+  }
+  locus <- pick(c("locus_tag", "old_locus_tag"))
+  gene <- pick(c("gene", "gene_name"))
+  preferred <- pick(c("EggNOG_Preferred_name", "eggnog_preferred_name"))
+  product <- pick(c("product", "description"))
+  egg_desc <- pick(c("EggNOG_Description", "eggnog_description"))
+  ec_text <- paste(pick(c("EC_number", "ec_number")), pick(c("EggNOG_EC", "eggnog_ec")))
+  ko_text <- paste(pick(c("EggNOG_KEGG_ko", "eggnog_kegg_ko")))
+
+  has_token <- function(values, tokens) {
+    if (!length(tokens)) return(rep(FALSE, length(values)))
+    tokens <- toupper(tokens)
+    vapply(toupper(values), function(value) {
+      observed <- unlist(strsplit(value, "[^A-Z0-9.]+"))
+      any(observed[nzchar(observed)] %in% tokens)
+    }, logical(1))
+  }
+  has_gene <- function(values, aliases) {
+    if (!length(aliases)) return(rep(FALSE, length(values)))
+    aliases <- tolower(aliases)
+    vapply(tolower(values), function(value) {
+      observed <- unlist(strsplit(value, "[^a-z0-9]+"))
+      any(observed[nzchar(observed)] %in% aliases)
+    }, logical(1))
+  }
+  has_pattern <- function(values, patterns) {
+    if (!length(patterns)) return(rep(FALSE, length(values)))
+    grepl(paste(patterns, collapse = "|"), values, ignore.case = TRUE, perl = TRUE)
+  }
+
+  hit_rows <- list()
+  step_rows <- list()
+  for (spec in catalog) {
+    component_levels <- character()
+    for (rule in spec$components) {
+      trusted_gene <- has_gene(gene, rule$genes)
+      preferred_gene <- has_gene(preferred, rule$genes)
+      gene_axis <- trusted_gene | preferred_gene
+      product_axis <- has_pattern(product, rule$products)
+      ec_axis <- has_token(ec_text, rule$ecs)
+      ko_axis <- has_token(ko_text, rule$kos)
+
+      negative_gene <- has_gene(gene, rule$exclude_genes) |
+        has_gene(preferred, rule$exclude_genes)
+      negative_product <- has_pattern(product, rule$exclude_products)
+      negative_ko <- has_token(ko_text, rule$exclude_kos)
+      cs_exception <- isTRUE(rule$allow_cs_ambiguity) & gene_axis & ko_axis &
+        !negative_gene & !negative_ko
+      rejected <- negative_gene | negative_ko | (negative_product & !cs_exception)
+
+      strong <- !rejected & (
+        (gene_axis & (product_axis | ec_axis | ko_axis)) |
+          (product_axis & (ec_axis | ko_axis))
+      )
+      candidate <- !rejected & !strong & (trusted_gene | ec_axis | ko_axis)
+      keep <- (strong | candidate) & nzchar(locus)
+      level <- ifelse(strong, "strong", ifelse(candidate, "candidate", "none"))
+      component_levels[rule$name] <- if (any(strong & keep)) {
+        "strong"
+      } else if (any(candidate & keep)) {
+        "candidate"
+      } else {
+        "none"
+      }
+
+      if (any(keep)) {
+        axes <- vapply(which(keep), function(i) {
+          paste(c(
+            if (gene_axis[i]) "gene" else NULL,
+            if (product_axis[i]) "product" else NULL,
+            if (ec_axis[i]) "EC" else NULL,
+            if (ko_axis[i]) "KO" else NULL
+          ), collapse = "+")
+        }, character(1))
+        display_gene <- gene[keep]
+        missing_gene <- !nzchar(display_gene)
+        display_gene[missing_gene] <- preferred[keep][missing_gene]
+        display_gene[!nzchar(display_gene)] <- "unassigned"
+        display_product <- product[keep]
+        display_product[!nzchar(display_product)] <- egg_desc[keep][!nzchar(display_product)]
+        display_product[!nzchar(display_product)] <- "not annotated"
+        hit_rows[[length(hit_rows) + 1L]] <- data.frame(
+          reaction_id = spec$id,
+          pathway = spec$pathway,
+          component = rule$name,
+          component_required = isTRUE(rule$required),
+          locus_tag = locus[keep],
+          gene_name = display_gene,
+          product = display_product,
+          evidence_level = level[keep],
+          evidence_axes = axes,
+          stringsAsFactors = FALSE
+        )
+      }
+    }
+
+    required_names <- vapply(
+      Filter(function(rule) isTRUE(rule$required), spec$components),
+      function(rule) rule$name, character(1)
+    )
+    required_levels <- component_levels[required_names]
+    strong_complete <- if (identical(spec$mode, "any")) {
+      any(component_levels == "strong")
+    } else {
+      length(required_levels) > 0L && all(required_levels == "strong")
+    }
+    any_evidence <- any(component_levels != "none")
+    status <- if (strong_complete) "active" else if (any_evidence) "partial" else "reference"
+    step_rows[[length(step_rows) + 1L]] <- data.frame(
+      reaction_id = spec$id,
+      pathway = spec$pathway,
+      from = spec$from,
+      to = spec$to,
+      reaction_label = spec$label,
+      status = status,
+      stringsAsFactors = FALSE
+    )
+  }
+
+  hits <- if (length(hit_rows)) dplyr::bind_rows(hit_rows) else empty_hits
+  if (nrow(hits)) {
+    hits <- hits[!duplicated(hits[, c("reaction_id", "component", "locus_tag")]), , drop = FALSE]
+    hits <- hits[order(hits$reaction_id, hits$component, hits$locus_tag), , drop = FALSE]
+  }
+  steps <- dplyr::bind_rows(step_rows)
+  summary_hits <- hits
+  if (nrow(summary_hits)) {
+    keep_summary <- unlist(lapply(
+      split(seq_len(nrow(summary_hits)), paste(summary_hits$reaction_id, summary_hits$component)),
+      function(idx) {
+        strong_idx <- idx[summary_hits$evidence_level[idx] == "strong"]
+        if (length(strong_idx)) strong_idx else idx
+      }
+    ), use.names = FALSE)
+    summary_hits <- summary_hits[sort(unique(keep_summary)), , drop = FALSE]
+    active_ids <- steps$reaction_id[steps$status == "active"]
+    summary_hits <- summary_hits[
+      !(summary_hits$reaction_id %in% active_ids & !summary_hits$component_required),
+      , drop = FALSE
+    ]
+  }
+  steps$locus_tags <- vapply(steps$reaction_id, function(id) {
+    vals <- unique(summary_hits$locus_tag[summary_hits$reaction_id == id])
+    paste(vals[nzchar(vals)], collapse = "; ")
+  }, character(1))
+  steps$gene_names <- vapply(steps$reaction_id, function(id) {
+    vals <- unique(summary_hits$gene_name[summary_hits$reaction_id == id])
+    paste(vals[nzchar(vals)], collapse = "; ")
+  }, character(1))
+  steps$product_evidence <- vapply(steps$reaction_id, function(id) {
+    sub <- summary_hits[summary_hits$reaction_id == id, , drop = FALSE]
+    if (!nrow(sub)) return("")
+    paste(paste0(sub$locus_tag, ": ", sub$product), collapse = "; ")
+  }, character(1))
+  steps$components <- vapply(steps$reaction_id, function(id) {
+    sub <- summary_hits[summary_hits$reaction_id == id, , drop = FALSE]
+    if (!nrow(sub)) return("")
+    paste(unique(paste0(sub$component, "=", sub$locus_tag)), collapse = "; ")
+  }, character(1))
+  list(steps = steps, hits = hits, display_hits = summary_hits)
+}
+
+# Build compact gene/locus labels beside conservatively supported central-
+# carbon reactions.  Positions are deterministic so the labels remain tied to
+# the same reaction rather than drifting into unrelated pathway lanes.
+.dnmb_cct_core_direct_labels <- function(core_steps, display_hits, nodes) {
+  empty <- data.frame(
+    reaction_id = character(), pathway = character(), x = numeric(), y = numeric(),
+    label = character(), hjust = numeric(), vjust = numeric(), size = numeric(),
+    status = character(), stringsAsFactors = FALSE
+  )
+  if (is.null(core_steps) || !is.data.frame(core_steps) || !nrow(core_steps) ||
+      is.null(display_hits) || !is.data.frame(display_hits) || !nrow(display_hits) ||
+      is.null(nodes) || !is.data.frame(nodes) || !nrow(nodes)) {
+    return(empty)
+  }
+
+  node_x <- stats::setNames(nodes$x, nodes$id)
+  node_y <- stats::setNames(nodes$y, nodes$id)
+  detected <- core_steps[
+    core_steps$status %in% c("active", "partial") &
+      core_steps$from %in% names(node_x) & core_steps$to %in% names(node_x),
+    , drop = FALSE
+  ]
+  if (!nrow(detected)) return(empty)
+
+  label_for <- function(reaction_id) {
+    sub <- display_hits[display_hits$reaction_id == reaction_id, , drop = FALSE]
+    if (!nrow(sub)) return("")
+    sub <- sub[order(sub$component, sub$locus_tag), , drop = FALSE]
+    sub <- sub[!duplicated(sub$locus_tag), , drop = FALSE]
+    genes <- trimws(as.character(sub$gene_name))
+    missing_gene <- is.na(genes) | !nzchar(genes) | genes == "unassigned"
+    genes[missing_gene] <- trimws(as.character(sub$component[missing_gene]))
+    paste(paste(genes, sub$locus_tag, sep = "  "), collapse = "\n")
+  }
+
+  rows <- list()
+  tca_ids <- c("OAA", "Citrate", "Isocit", "AKG", "SucCoA",
+               "Succinate", "Fumarate", "Malate")
+  tca_nodes <- nodes[nodes$id %in% tca_ids, , drop = FALSE]
+  tca_cx <- if (nrow(tca_nodes)) mean(tca_nodes$x) else NA_real_
+  tca_cy <- if (nrow(tca_nodes)) mean(tca_nodes$y) else NA_real_
+  tca_r <- if (nrow(tca_nodes)) {
+    max(sqrt((tca_nodes$x - tca_cx)^2 + (tca_nodes$y - tca_cy)^2))
+  } else {
+    NA_real_
+  }
+
+  for (i in seq_len(nrow(detected))) {
+    step <- detected[i, , drop = FALSE]
+    label <- label_for(step$reaction_id)
+    if (!nzchar(label)) next
+    x_from <- unname(node_x[step$from]); y_from <- unname(node_y[step$from])
+    x_to <- unname(node_x[step$to]); y_to <- unname(node_y[step$to])
+    x <- mean(c(x_from, x_to)); y <- mean(c(y_from, y_to))
+    hjust <- 0.5; vjust <- 0.5
+
+    if (identical(step$pathway, "TCA cycle") && is.finite(tca_r)) {
+      a_from <- atan2(y_from - tca_cy, x_from - tca_cx)
+      a_to <- atan2(y_to - tca_cy, x_to - tca_cx)
+      delta <- ((a_to - a_from + pi) %% (2 * pi)) - pi
+      mid_angle <- a_from + delta / 2
+      label_r <- if (step$reaction_id %in% c("C01", "C08")) {
+        max(0.65, tca_r - 0.40)
+      } else {
+        tca_r + 0.33
+      }
+      x <- tca_cx + label_r * cos(mid_angle)
+      y <- tca_cy + label_r * sin(mid_angle)
+      hjust <- if (step$reaction_id %in% c("C01", "C02", "C03", "C04")) 0 else 1
+      if (step$reaction_id %in% c("C01", "C08")) y <- y - 0.28
+      if (step$reaction_id %in% c("C04", "C05")) y <- y - 0.06
+    } else if (identical(step$pathway, "Glyoxylate shunt")) {
+      y <- y - if (identical(step$reaction_id, "C09")) 0.30 else 0.22
+    } else if (identical(step$pathway, "Glycolysis")) {
+      if (step$reaction_id %in% c("C11", "C12", "C13")) {
+        x <- min(x_from, x_to) - 0.28
+        hjust <- 1
+      } else if (identical(step$reaction_id, "C14")) {
+        x <- max(x_from, x_to) + 0.24
+        hjust <- 0
+      } else if (identical(step$reaction_id, "C15")) {
+        y <- y - 0.20
+      } else {
+        x <- max(x_from, x_to) + 0.26
+        hjust <- 0
+      }
+    }
+
+    label_lines <- strsplit(label, "\n", fixed = TRUE)[[1L]]
+    longest <- max(nchar(label_lines), na.rm = TRUE)
+    size <- max(0.88, min(1.12, 1.16 - 0.055 * (length(label_lines) - 1L) -
+      0.010 * max(0, longest - 24L)))
+    rows[[length(rows) + 1L]] <- data.frame(
+      reaction_id = step$reaction_id, pathway = step$pathway,
+      x = x, y = y, label = label, hjust = hjust, vjust = vjust,
+      size = size, status = step$status,
+      stringsAsFactors = FALSE
+    )
+  }
+  if (length(rows)) dplyr::bind_rows(rows) else empty
+}
+
 #'
 #' @param genbank_table The combined genbank/annotation table
 #' @param output_dir Output directory
@@ -6038,6 +9024,9 @@
   # ====================================================================
   step_status <- .dnmb_gapmind_carbon_step_status(genbank_table, output_dir = output_dir)
   if (is.null(step_status)) return(NULL)
+  core_metabolism <- .dnmb_cct_core_metabolism_evidence(genbank_table)
+  core_steps <- core_metabolism$steps
+  core_display_hits <- core_metabolism$display_hits
   valid_locus_tags <- unique(as.character(genbank_table$locus_tag))
   valid_locus_tags <- valid_locus_tags[!is.na(valid_locus_tags) & nzchar(valid_locus_tags)]
   if ("locus_tag" %in% names(step_status)) {
@@ -6075,15 +9064,7 @@
   cascades     <- .dnmb_cct_3zone_glycan_cascades()
   conf_colors  <- c(high = "#2CA25F", medium = "#FEC44F", low = "#F03B20", none = "#CCCCCC")
   conf_rank    <- c(none = 0L, low = 1L, medium = 2L, high = 3L)
-  pathway_to_cs <- c(
-    maltose = "Maltose", cellobiose = "Cellobiose", galactose = "Galactose",
-    trehalose = "Trehalose", lactose = "Lactose", mannose = "Mannose",
-    NAG = "NAG", glucosamine = "Glucosamine", fructose = "Fructose",
-    sucrose = "Sucrose", mannitol = "Mannitol", glycerol = "Glycerol",
-    xylose = "Xylose", arabinose = "Arabinose", ribose = "Ribose",
-    fucose = "Fucose", rhamnose = "Rhamnose", gluconate = "Gluconate",
-    glucose = "Maltose", deoxyribose = "Ribose", deoxyribonate = "Gluconate"
-  )
+  pathway_to_cs <- .dnmb_cct_transporter_pathway_map()
 
   # Filter step_status to ONLY carbon source pathways (exclude amino acid, organic acid, etc.)
   matched_steps <- step_status[
@@ -6094,8 +9075,39 @@
   if (nrow(matched_steps) > 0) {
     matched_steps$rank <- conf_rank[matched_steps$confidence]
     matched_steps$rank[is.na(matched_steps$rank)] <- 0L
+    # score-0 GapMind assignments are candidate references, not foreground
+    # evidence.  They remain available in the module tables but do not turn an
+    # entire utilization route on in this map.
+    matched_steps <- matched_steps[matched_steps$rank >= 2L, , drop = FALSE]
   }
   matched_pathway_ids <- unique(tolower(matched_steps$pathway_id))
+  pathway_presence <- .dnmb_cct_pathway_presence(
+    step_status = step_status,
+    pstats = pstats,
+    valid_pathways = valid_carbon_pathways
+  )
+  cytoplasm_status <- stats::setNames(
+    pathway_presence$cytoplasm_status,
+    pathway_presence$pathway_id
+  )
+  pathway_state_for <- function(path_ids) {
+    states <- unname(cytoplasm_status[tolower(as.character(path_ids))])
+    states <- states[!is.na(states)]
+    if (any(states == "active")) return("active")
+    if (any(states == "partial")) return("partial")
+    "reference"
+  }
+  pathway_alpha_for <- function(path_ids, zone = c("route", "node", "label")) {
+    zone <- match.arg(zone)
+    state <- pathway_state_for(path_ids)
+    values <- switch(
+      zone,
+      route = c(reference = 0.12, partial = 0.34, active = 0.82),
+      node = c(reference = 0.22, partial = 0.58, active = 1.00),
+      label = c(reference = 0.28, partial = 0.65, active = 1.00)
+    )
+    unname(values[state])
+  }
 
   route_group_members <- list(
     starch = c("maltose", "trehalose"),
@@ -6107,6 +9119,7 @@
     sucrose = c("sucrose"),
     xylan = c("xylose", "arabinose"),
     pentose = c("ribose"),
+    deoxyribose = c("deoxyribose"),
     gluconate = c("gluconate"),
     glycerol = c("glycerol"),
     fucose = c("fucose"),
@@ -6147,22 +9160,23 @@
   cs_ids_ordered <- c("Maltose","Cellobiose","Galactose","Trehalose","Lactose",
                       "Mannose","NAG","Glucosamine","Fructose","Sucrose",
                       "Mannitol","Glycerol","Xylose","Arabinose","Ribose",
-                      "Fucose","Rhamnose","Gluconate")
+                      "Deoxyribose","Fucose","Rhamnose","Gluconate")
   # Classify each carbon source by evidence level
   cs_evidence <- stats::setNames(rep("none", length(cs_ids_ordered)), cs_ids_ordered)
-  # Check pathway stats for transport/gapmind evidence (require >= 25% steps matched)
-  if (!is.null(pstats) && nrow(pstats) > 0) {
-    for (csid in cs_ids_ordered) {
-      pid <- tolower(csid)
-      if (pid %in% pstats$pathway_id && any(pstats$fraction[pstats$pathway_id == pid] >= 0.25))
-        cs_evidence[csid] <- "transport"
-    }
+  # Cytoplasmic support is deliberately separate from transport and GH
+  # support.  A membrane hit alone must not foreground a metabolic route.
+  for (csid in cs_ids_ordered) {
+    pid <- tolower(csid)
+    state <- unname(cytoplasm_status[pid])
+    if (is.na(state)) next
+    if (state == "active") cs_evidence[csid] <- "transport"
+    if (state == "partial") cs_evidence[csid] <- "enzyme"
   }
   # Check for CAZy enzyme evidence (active cascades target substrates)
   # Map cascade keys to carbon source IDs
   cascade_to_cs <- c(starch = "Maltose", cellulose = "Cellobiose",
                      xylan = "Xylose", chitin = "NAG",
-                     pectin = "Gluconate", mannan = "Mannose",
+                     pectin = "Galacturonate", mannan = "Mannose",
                      inulin = "Fructose", raffinose = "Sucrose",
                      sucrose = "Sucrose", maltose = "Maltose",
                      lactose = "Lactose", cellobiose = "Cellobiose",
@@ -6203,22 +9217,9 @@
       cs_evidence[csid] <- "enzyme"
   }
 
-  # FILTER: keep only substrates with any evidence
-  cs_has_evidence <- cs_evidence != "none"
-  if (!any(cs_has_evidence)) {
-    # No carbon utilization evidence — return placeholder
-    p <- ggplot2::ggplot() +
-      ggplot2::annotate("text", x = 0.5, y = 0.5,
-        label = "No CAZy / transport / CGC-PUL carbon utilization evidence detected",
-        size = 5, color = "#888888") +
-      ggplot2::theme_void()
-    plot_dir <- .dnmb_module_plot_dir(output_dir)
-    pdf_path <- file.path(plot_dir, paste0(file_stub, ".pdf"))
-    .dnmb_module_plot_save(p, pdf_path, width = 10, height = 6)
-    return(list(pdf = pdf_path))
-  }
-  cs_ids_ordered <- cs_ids_ordered[cs_has_evidence]
-  cs_evidence <- cs_evidence[cs_has_evidence]
+  # Retain the full biochemical reference frame. Unsupported substrates are
+  # rendered at low opacity instead of being deleted, so presence/absence is
+  # visible without implying that a missing route was never assessed.
 
   cs_priority <- stats::setNames(rep(1, length(cs_ids_ordered)), cs_ids_ordered)
   if (!is.null(pstats) && nrow(pstats) > 0) {
@@ -6238,7 +9239,7 @@
   }
   if (!is.null(transporters) && nrow(transporters) > 0) {
     tr_priority <- transporters
-    tr_priority$cs_id <- unname(pathway_to_cs[tr_priority$pathway])
+    tr_priority$cs_id <- unname(pathway_to_cs[tolower(tr_priority$pathway)])
     tr_priority <- tr_priority[!is.na(tr_priority$cs_id) & tr_priority$cs_id %in% cs_ids_ordered, , drop = FALSE]
     if (nrow(tr_priority) > 0) {
       if (!"step_score" %in% names(tr_priority)) tr_priority$step_score <- NA_real_
@@ -6335,6 +9336,54 @@
 
   node_x <- stats::setNames(cyto_nodes$x, cyto_nodes$id)
   node_y <- stats::setNames(cyto_nodes$y, cyto_nodes$id)
+  cyto_node_status <- stats::setNames(rep("reference", nrow(cyto_nodes)), cyto_nodes$id)
+  continuity_seed_routes <- .dnmb_cct_continuity_routes()
+  status_rank <- c(reference = 0L, partial = 1L, active = 2L)
+  for (pid in names(cytoplasm_status)) {
+    state <- unname(cytoplasm_status[pid])
+    if (is.na(state) || state == "reference") next
+    path_nodes <- unique(c(
+      .dnmb_cct_entry_route_nodes(pid, node_ids = cyto_nodes$id),
+      if (pid %in% names(continuity_seed_routes)) continuity_seed_routes[[pid]] else character()
+    ))
+    path_nodes <- intersect(path_nodes, names(cyto_node_status))
+    if (!length(path_nodes)) next
+    upgrade <- status_rank[state] > status_rank[cyto_node_status[path_nodes]]
+    cyto_node_status[path_nodes[upgrade]] <- state
+  }
+  if (!is.null(core_steps) && nrow(core_steps)) {
+    for (i in seq_len(nrow(core_steps))) {
+      step_state <- core_steps$status[i]
+      step_nodes <- intersect(
+        c(core_steps$from[i], core_steps$to[i]),
+        names(cyto_node_status)
+      )
+      if (!length(step_nodes)) next
+      upgrade <- status_rank[step_state] > status_rank[cyto_node_status[step_nodes]]
+      cyto_node_status[step_nodes[upgrade]] <- step_state
+    }
+  }
+  exact_edge_hits <- .dnmb_cct_exact_step_edge_matches(
+    step_evidence = matched_steps,
+    cyto_edges = cyto_edges
+  )
+  if (nrow(exact_edge_hits)) {
+    for (i in seq_len(nrow(exact_edge_hits))) {
+      hit_rank <- suppressWarnings(as.integer(exact_edge_hits$rank[i]))
+      if (!is.finite(hit_rank) || hit_rank < 2L) next
+      hit_state <- if (hit_rank >= 3L) "active" else "partial"
+      hit_nodes <- intersect(
+        c(exact_edge_hits$mapped_from[i], exact_edge_hits$mapped_to[i]),
+        names(cyto_node_status)
+      )
+      if (!length(hit_nodes)) next
+      upgrade <- status_rank[hit_state] > status_rank[cyto_node_status[hit_nodes]]
+      cyto_node_status[hit_nodes[upgrade]] <- hit_state
+    }
+  }
+  cyto_node_alpha <- vapply(cyto_node_status, function(state) {
+    switch(state, active = 1, partial = 0.58, reference = 0.22)
+  }, numeric(1))
 
   # Assign confidence to carbon source nodes
   carbon_src <- cyto_nodes[cyto_nodes$type == "carbon_source", , drop = FALSE]
@@ -6353,9 +9402,16 @@
       }
     }
   }
-  sugar_lane_x <- vapply(split(carbon_src$x, carbon_src$sugar_type), function(xs) {
-    .dnmb_cct_snap_to_grid(mean(xs), step = glyco_grid_step)
-  }, numeric(1))
+  sugar_lane_ids <- unique(carbon_src$sugar_type[order(carbon_src$x)])
+  sugar_lane_x <- stats::setNames(vapply(sugar_lane_ids, function(st) {
+    .dnmb_cct_snap_to_grid(
+      mean(carbon_src$x[carbon_src$sugar_type == st]),
+      step = glyco_grid_step / 2
+    )
+  }, numeric(1)), sugar_lane_ids)
+  sugar_lane_x <- .dnmb_cct_separate_lanes(
+    sugar_lane_x, min_gap = glyco_grid_step, snap_step = glyco_grid_step / 2
+  )
 
   backbone_nodes <- cyto_nodes[cyto_nodes$type == "backbone", , drop = FALSE]
   entry_inter    <- cyto_nodes[cyto_nodes$type == "entry_intermediate", , drop = FALSE]
@@ -6472,7 +9528,8 @@
   extra_branches <- extra_branches[intersect(names(extra_branches), extra_substrates$id)]
 
   n_extra  <- nrow(extra_substrates)
-  sym_size <- 0.075
+  sugar_icon_r <- .dnmb_cct_sugar_icon_radius()
+  sym_size <- sugar_icon_r
   chain_gap <- 0.18
   chain_step <- .dnmb_cct_extra_chain_step(sym_size = sym_size, gap = chain_gap)
   extra_trim <- .dnmb_cct_extra_route_trim(sym_size = sym_size)
@@ -6497,7 +9554,7 @@
   y_4mer <- y_memb + 3.5  # 4-mer polymers (Chitin, Xylan, Pectin, Mannan, Cellulose)
   y_3mer <- y_memb + 3.0  # 3-mer (Raffinose, Inulin)
   y_2mer <- y_memb + 2.0  # 2-mer dimers
-  y_mono <- y_memb + 1.0  # 1-mer monomers
+  y_mono <- y_memb + 1.4  # reserve a clear gutter above transporter buses
   y_extra_top <- y_6mer + 0.5
 
   row_y_map <- c(`6` = y_6mer, `5` = y_5mer, `4` = y_4mer, `3` = y_3mer, `2` = y_2mer)
@@ -6515,6 +9572,19 @@
   extra_y_map <- stats::setNames(extra_layout$y, extra_layout$id)
   extra_top_actual <- if (nrow(extra_layout) > 0) max(extra_layout$y, na.rm = TRUE) + 0.35 else (y_memb + 1.0)
 
+  # Monomer aliases can share a preferred sugar lane (for example GlcA/GalA).
+  # Reserve the positions after deterministic lane separation when sizing the
+  # membrane, otherwise the outer alias can sit just beyond the bilayer.
+  monomer_lane_ids <- .dnmb_cct_extracellular_monomer_ids()
+  monomer_lane_keys <- unname(.dnmb_cct_monomer_lane_map()[monomer_lane_ids])
+  monomer_bound_x <- unname(sugar_lane_x[monomer_lane_keys])
+  names(monomer_bound_x) <- monomer_lane_ids
+  monomer_bound_x <- .dnmb_cct_separate_lanes(
+    monomer_bound_x,
+    min_gap = glyco_grid_step,
+    snap_step = glyco_grid_step / 2
+  )
+
   # x_max adapts to both cytoplasm lanes and extracellular chain width
   x_max <- max(max(cs_x_pos) + 0.6, max(extra_layout$x_right) + 0.2)
 
@@ -6522,13 +9592,19 @@
   pw_colors <- .dnmb_cct_pathway_colors()
   node_sugar_type <- stats::setNames(cyto_nodes$sugar_type, cyto_nodes$id)
   mem_xmin <- min(
-    c(extra_layout$x_left, extra_layout$x_center, carbon_src$x, cyto_nodes$x),
+    c(
+      extra_layout$x_left, extra_layout$x_center,
+      carbon_src$x, cyto_nodes$x, monomer_bound_x
+    ),
     na.rm = TRUE
   ) - 0.20
   mem_xmax <- max(
-    c(extra_layout$x_right, extra_layout$x_center, carbon_src$x, cyto_nodes$x),
+    c(
+      extra_layout$x_right, extra_layout$x_center,
+      carbon_src$x, cyto_nodes$x, monomer_bound_x
+    ),
     na.rm = TRUE
-  ) + 0.20
+  ) + 0.45
 
   # ====================================================================
   # BUILD THE PLOT — clean canvas
@@ -6570,15 +9646,16 @@
       stroke = 0.25, inherit.aes = FALSE)
 
   # --- Zone labels ---
+  zone_label_x <- mem_xmax + 0.14
   p <- p +
-    ggplot2::annotate("text", x = x_max + 0.25, y = extra_top_actual + 0.18,
-                      label = "Extracellular", hjust = 1, size = 3,
+    ggplot2::annotate("text", x = zone_label_x, y = extra_top_actual + 0.18,
+                      label = "Extracellular", hjust = 0, size = 3,
                       fontface = "italic", color = "#BDBDBD") +
-    ggplot2::annotate("text", x = x_max + 0.3, y = y_memb,
-                      label = "Membrane", hjust = 1, size = 2.5,
+    ggplot2::annotate("text", x = zone_label_x, y = y_memb,
+                      label = "Membrane", hjust = 0, size = 2.5,
                       fontface = "italic", color = "#A1887F") +
-    ggplot2::annotate("text", x = x_max + 0.3, y = y_memb - 0.5,
-                      label = "Cytoplasm", hjust = 1, size = 3,
+    ggplot2::annotate("text", x = zone_label_x, y = y_memb - 0.5,
+                      label = "Cytoplasm", hjust = 0, size = 3,
                       fontface = "italic", color = "#BDBDBD")
 
   # ====================================================================
@@ -6593,14 +9670,10 @@
   cs_hub_x <- sugar_lane_x
   composite_product_ids <- c("sucrose", "trehalose", "lactose", "maltose", "cellobiose", "raffinose")
   # Map monomer IDs to their carbon source hub x
-  mono_ids <- c("glucose","galactose","mannose","fructose","glcnac",
-                "xylose","arabinose","ribose","fucose","rhamnose","glca","gala")
+  mono_ids <- monomer_lane_ids
   mono_ids <- unique(c(mono_ids, setdiff(all_prods, composite_product_ids)))
   # Sugar type → monomer ID mapping
-  mono_to_sugar <- c(glucose="glucose", galactose="galactose", mannose="mannose",
-    fructose="fructose", glcnac="glcnac", xylose="xylose", arabinose="arabinose",
-    ribose="ribose", fucose="fucose", rhamnose="fucose", glca="glca", gala="glca",
-    glycerol="glycerol", glucosamine="glcnac")
+  mono_to_sugar <- .dnmb_cct_monomer_lane_map()
   mono_to_csid <- c(
     sucrose = "Sucrose",
     trehalose = "Trehalose",
@@ -6626,28 +9699,50 @@
     gap_xs <- seq(max(used) + 1.5, max(used) + 1.5 + length(na_idx) * 1.5, length.out = length(na_idx))
     mono_xs[na_idx] <- gap_xs
   }
+  mono_xs <- .dnmb_cct_separate_lanes(
+    mono_xs, min_gap = glyco_grid_step, snap_step = glyco_grid_step / 2
+  )
   mono_x_map <- stats::setNames(mono_xs, mono_ids)
   extra_target_id_map <- stats::setNames(extra_substrates$id, tolower(extra_substrates$id))
 
   for (mi in seq_along(mono_ids)) {
     mid <- mono_ids[mi]
     mx <- mono_xs[mi]
-    mono_col <- .dnmb_cct_sugar_route_color(mid)
+    mono_st <- unname(mono_to_sugar[mid])
+    mono_paths <- if (!is.na(mono_st)) {
+      tolower(carbon_src$id[carbon_src$sugar_type == mono_st])
+    } else {
+      tolower(unname(mono_to_csid[mid]))
+    }
+    mono_alpha <- pathway_alpha_for(mono_paths, zone = "node")
     # First render: no label (final overlay at end will add labels above route lines)
-    p <- .dnmb_snfg_render_symbol_v2(p, mx, y_mono, mid, r = 0.10, label = NULL)
-    # Arrow from monomer to membrane
-    p <- p + ggplot2::geom_segment(
-      data = data.frame(x = mx, xend = mx,
-                        y = y_mono, yend = y_memb + 0.25),
-      ggplot2::aes(x=.data$x, xend=.data$xend, y=.data$y, yend=.data$yend),
-      arrow = ggplot2::arrow(length = grid::unit(0.02, "inches"), type = "closed"),
-      linewidth = 0.2, color = mono_col, alpha = 0.7, inherit.aes = FALSE)
+    p <- .dnmb_snfg_render_symbol_v2(
+      p, mx, y_mono, mid, r = sugar_icon_r,
+      label = NULL, alpha = mono_alpha
+    )
   }
 
   # ====================================================================
   # ZONE 1: EXTRACELLULAR — SNFG chains + GH scissors on chain
   # ====================================================================
   gh_label_rows <- list()
+  extra_label_rows <- list()
+  scissor_specs <- list()
+  gh_label_df <- NULL
+  gh_ledger_df <- NULL
+  extra_release_specs <- list()
+  extra_route_anchor_rows <- list(
+    data.frame(
+      kind = "monosaccharide", id = names(mono_x_map),
+      x = unname(mono_x_map), y = rep(y_mono, length(mono_x_map)),
+      stringsAsFactors = FALSE
+    ),
+    data.frame(
+      kind = "complex_chain", id = names(extra_center_map),
+      x = unname(extra_center_map), y = unname(extra_y_map[names(extra_center_map)]),
+      stringsAsFactors = FALSE
+    )
+  )
   for (ri in seq_len(n_extra)) {
     sub   <- extra_substrates[ri, , drop = FALSE]
     ry    <- extra_y_map[sub$id]
@@ -6655,10 +9750,15 @@
     chain_cx <- extra_center_map[sub$id]
     chain <- extra_chains[[sub$id]]
     bond_type <- extra_bonds[[sub$id]]
+    branches <- extra_branches[[sub$id]]
 
-    # Substrate name (above chain)
-    p <- p + ggplot2::annotate("text", x = chain_cx, y = ry + 0.25, label = sub$label,
-                                hjust = 0.5, size = 1.5, color = "#333333", fontface = "bold")
+    extra_label_rows[[length(extra_label_rows) + 1L]] <- data.frame(
+      x = chain_cx, y = ry + 0.30, label = sub$label,
+      color = "#333333", size = 1.7, fontface = "bold", hjust = 0.5,
+      priority = 30, nudge_x = 0, nudge_y = 0,
+      label_kind = "title", anchor_x = chain_cx, anchor_y = ry,
+      stringsAsFactors = FALSE
+    )
 
     # SNFG glycan chain
     n_mono <- length(chain)
@@ -6666,11 +9766,29 @@
       bonds_vec <- if (n_mono > 1 && !is.null(bond_type)) rep(bond_type, n_mono - 1) else NULL
       chain_layers <- .dnmb_draw_sugar_chain_v2(
         x_start = chain_x, y = ry, monomers = chain,
-        bonds = bonds_vec, size = sym_size, gap = chain_gap, show_label = FALSE)
+        bonds = bonds_vec, size = sym_size, gap = chain_gap, show_label = FALSE,
+        show_bond_label = FALSE)
       for (ly in chain_layers) p <- p + ly
+      if (!is.null(bonds_vec) && length(bonds_vec)) {
+        for (bond_i in seq_along(bonds_vec)) {
+          parts <- strsplit(bonds_vec[bond_i], "-")[[1L]]
+          anomer <- if (identical(parts[1L], "alpha")) "\u03b1" else "\u03b2"
+          positions <- if (length(parts) >= 2L) strsplit(parts[2L], ",")[[1L]] else c("1", "4")
+          bond_label <- paste0(anomer, paste(positions, collapse = "-"))
+          extra_label_rows[[length(extra_label_rows) + 1L]] <- data.frame(
+            x = chain_x + (bond_i - 0.5) * chain_step,
+            y = ry + 0.13,
+            label = bond_label,
+            color = "#777777", size = 1.30, fontface = "plain", hjust = 0.5,
+            priority = 8, nudge_x = 0, nudge_y = 0,
+            label_kind = "bond", anchor_x = chain_x + (bond_i - 0.5) * chain_step,
+            anchor_y = ry,
+            stringsAsFactors = FALSE
+          )
+        }
+      }
 
       # Draw branches (side chains hanging below the backbone)
-      branches <- extra_branches[[sub$id]]
       if (!is.null(branches)) {
         for (bi in seq_along(branches)) {
           br <- branches[[bi]]
@@ -6686,7 +9804,7 @@
           lty <- if (is_beta) "dashed" else "solid"
           # Parse bond label: "alpha-1,6" → "α1–6"
           br_label <- sub("^alpha-", "\u03b1", sub("^beta-", "\u03b2", br$bond))
-          br_label <- gsub(",", "\u2013", br_label)  # comma → en-dash
+          br_label <- gsub(",", "-", br_label)
           p <- p + ggplot2::geom_segment(
             data = data.frame(x = br_x, xend = br_x, y = ry - sym_size, yend = br_y + sym_size),
             ggplot2::aes(x=.data$x, xend=.data$xend, y=.data$y, yend=.data$yend),
@@ -6694,10 +9812,15 @@
           # Branch sugar symbol
           abbr_br <- .dnmb_snfg_abbreviation_v2(br$sugar)
           p <- .dnmb_snfg_render_symbol_v2(p, br_x, br_y, br$sugar, r = sym_size, label = abbr_br)
-          # Bond label
-          p <- p + ggplot2::annotate("text", x = br_x + 0.05, y = (ry + br_y)/2,
-                                      label = br_label, size = 0.9, color = "#795548",
-                                      hjust = 0, fontface = "plain")
+          extra_label_rows[[length(extra_label_rows) + 1L]] <- data.frame(
+            x = br_x + 0.05, y = (ry + br_y) / 2,
+            label = br_label, color = "#795548", size = 0.9,
+            fontface = "plain", hjust = 0,
+            priority = 10, nudge_x = 0, nudge_y = 0,
+            label_kind = "branch_bond", anchor_x = br_x,
+            anchor_y = (ry + br_y) / 2,
+            stringsAsFactors = FALSE
+          )
 
           # Debranching enzyme: scissors on the branch bond + GH label + arrow to monomer hub
           debranch_ghs <- br$debranch_gh
@@ -6706,39 +9829,63 @@
             if (nrow(db_matched) > 0) {
               # Small scissors on the branch bond midpoint
               sc_y <- (ry + br_y) / 2
-              sc <- .dnmb_scissors_grob_v2(br_x - 0.1, sc_y, size = 0.03)
-              for (ly in sc) p <- p + ly
-              # Debranching enzyme label
-              db_lab <- db_matched$gh_family[1]
-              if (!is.na(db_matched$gene_name[1]) && nzchar(db_matched$gene_name[1]))
-                db_lab <- .dnmb_cct_short_gh_label(db_matched$gh_family[1], db_matched$gene_name[1])
-              db_priority <- 12 + min(4, nrow(db_matched)) +
-                ifelse(sub$id %in% c("Pectin", "Mannan"), 2, 0)
-              gh_label_rows[[length(gh_label_rows) + 1L]] <- data.frame(
-                x = br_x - 0.18, y = sc_y,
-                label = db_lab, color = "#1565C0", priority = db_priority,
+              scissor_specs[[length(scissor_specs) + 1L]] <- data.frame(
+                x = br_x - 0.055, y = sc_y, size = 0.05, angle = 0,
                 stringsAsFactors = FALSE
               )
+              # Debranching enzyme label
+              for (db_i in seq_len(nrow(db_matched))) {
+                db_lab <- .dnmb_cct_short_gh_label(
+                  db_matched$gh_family[db_i], db_matched$gene_name[db_i]
+                )
+                db_lab <- paste0(db_lab, "\n", db_matched$locus_tag[db_i])
+                db_priority <- 12 + min(4, nrow(db_matched)) +
+                  ifelse(sub$id %in% c("Pectin", "Mannan"), 2, 0)
+                gh_label_rows[[length(gh_label_rows) + 1L]] <- data.frame(
+                  x = br_x - 0.18, y = br_y - 0.13,
+                  label = db_lab, color = "#1565C0", priority = db_priority,
+                  label_kind = "gh", anchor_x = br_x - 0.055, anchor_y = sc_y,
+                  locus_tag = db_matched$locus_tag[db_i],
+                  gh_family = db_matched$gh_family[db_i],
+                  gene_name = db_matched$gene_name[db_i],
+                  substrate = sub$label,
+                  pul_substrate = "",
+                  stringsAsFactors = FALSE
+                )
+              }
               # Arrow from detached branch to monomer hub
               if (tolower(br$sugar) %in% names(mono_x_map)) {
                 target_mx <- unname(mono_x_map[tolower(br$sugar)])
-                mid_y2 <- y_mono + sym_size * 1.5
+                branch_anchor_id <- paste("branch", sub$id, bi, sep = ":")
+                extra_route_anchor_rows[[length(extra_route_anchor_rows) + 1L]] <- data.frame(
+                  kind = "branch_sugar", id = branch_anchor_id,
+                  x = br_x, y = br_y, stringsAsFactors = FALSE
+                )
+                # Leave the branch locally before taking a horizontal lane.
+                # The shared lane packer below separates same-row products.
+                mid_y2 <- br_y - max(0.14, sym_size * 1.6)
                 branch_col <- .dnmb_cct_sugar_route_color(br$sugar, fallback = "#1565C0")
                 branch_imp <- min(1.0, 0.45 + 0.18 * nrow(db_matched))
-                branch_path <- .dnmb_cct_rounded_route_points(
-                  data.frame(
+                extra_release_specs[[length(extra_release_specs) + 1L]] <- list(
+                  route_id = paste("branch", sub$id, bi, tolower(br$sugar), sep = ":"),
+                  source_kind = "branch_sugar",
+                  source_id = branch_anchor_id,
+                  target_kind = "monosaccharide",
+                  target_id = tolower(br$sugar),
+                  group = paste0("release:", tolower(br$sugar)),
+                  priority = branch_imp,
+                  points = data.frame(
                     x = c(br_x, br_x, target_mx, target_mx),
                     y = c(br_y, mid_y2, mid_y2, y_mono)
                   ),
-                  radius = 0.2
-                )
-                for (ly in .dnmb_cct_gradient_path_layers(
-                  branch_path, color = branch_col,
+                  color = branch_col,
                   linewidth = 0.18 + 0.18 * branch_imp,
                   alpha = 0.22 + 0.28 * branch_imp,
-                  linetype = "dashed", arrow_last = TRUE, arrow_length = 0.015,
-                  trim_start = extra_trim, trim_end = 0.11
-                )) p <- p + ly
+                  linetype = "dashed",
+                  gradient = TRUE,
+                  trim_start = extra_trim,
+                  trim_end = 0.11
+                )
               }
             }
           }
@@ -6761,14 +9908,28 @@
         step = chain_step,
         matched_families = matched$gh_family
       )
-      sc <- .dnmb_scissors_grob_v2(cut_x, ry, size = 0.04)
-      for (ly in sc) p <- p + ly
+      scissor_specs[[length(scissor_specs) + 1L]] <- data.frame(
+        x = cut_x, y = ry, size = 0.067, angle = 0,
+        stringsAsFactors = FALSE
+      )
+      scissor_anchor_id <- paste("scissor", sub$id, ckey, sep = ":")
+      extra_route_anchor_rows[[length(extra_route_anchor_rows) + 1L]] <- data.frame(
+        kind = "scissor", id = scissor_anchor_id,
+        x = cut_x, y = ry, stringsAsFactors = FALSE
+      )
 
       # GH label below scissors (with CGC/PUL annotation if available)
-      show_n <- min(if (n_mono >= 4) 2L else 1L, nrow(matched))
-      for (j in seq_len(show_n)) {
+      gh_primary_y <- ry - 0.22
+      if (!is.null(branches) && length(branches)) {
+        branch_ys <- vapply(seq_along(branches), function(branch_i) {
+          ry - sym_size * (2.5 + 1.4 * (branch_i - 1L))
+        }, numeric(1))
+        gh_primary_y <- min(gh_primary_y, min(branch_ys) - 0.13)
+      }
+      for (j in seq_len(nrow(matched))) {
         enz <- matched[j, , drop = FALSE]
         gh_lab <- .dnmb_cct_short_gh_label(enz$gh_family, enz$gene_name)
+        gh_lab <- paste0(gh_lab, "\n", enz$locus_tag)
         # Append PUL substrate or CGC ID if available
         pul_sub <- NULL
         for (pc in intersect(c("dbCAN_dbcan_pul_substrate", "dbcan_pul_substrate"), names(enz))) {
@@ -6782,15 +9943,21 @@
           }
         }
         if (!is.null(pul_sub)) {
-          pul_short <- substr(trimws(strsplit(pul_sub, ";")[[1]][1]), 1, 12)
-          gh_lab <- paste0(gh_lab, " [", pul_short, "]")
+          gh_lab <- paste0(gh_lab, "\nPUL substrate: ", trimws(pul_sub))
         }
         main_priority <- 10 - j + ifelse(sub$id %in% c("Pectin", "Mannan"), 2, 0) +
           ifelse(grepl("GH28|GH35|GH42|GH78|GH106|GH27|GH36|GH26|GH113", enz$gh_family), 1, 0)
         gh_label_rows[[length(gh_label_rows) + 1L]] <- data.frame(
-          x = cut_x, y = ry - 0.15 - (j - 1) * 0.10,
+          x = cut_x, y = gh_primary_y,
           label = gh_lab, color = "#C62828",
-          priority = main_priority, stringsAsFactors = FALSE
+          priority = main_priority,
+          label_kind = "gh", anchor_x = cut_x, anchor_y = ry,
+          locus_tag = enz$locus_tag,
+          gh_family = enz$gh_family,
+          gene_name = enz$gene_name,
+          substrate = sub$label,
+          pul_substrate = if (is.null(pul_sub)) "" else trimws(pul_sub),
+          stringsAsFactors = FALSE
         )
       }
 
@@ -6844,52 +10011,129 @@
           # for endo-acting enzymes, cut is internal. The monomer exits from
           # the cleavage position, not from an arbitrary chain match.
           exit_x <- cut_x
-          # Snap mid_y to 0.5 grid with micro-stagger to avoid overlapping horizontal lines
-          ps_idx <- match(ps, prod_sugars_u)
-          if (is.na(ps_idx)) ps_idx <- 1L
-          micro_stagger <- (ps_idx - 1L) * 0.06 + (ri - 1L) * 0.04
-          mid_y3 <- round(((target_y + extra_trim) + 0.5) * 2) / 2 + micro_stagger
-          cascade_path <- .dnmb_cct_rounded_route_points(
-            data.frame(
+          # Exit just below the cleavage site. Same-row release routes receive
+          # deterministic horizontal lanes after every cascade is collected.
+          mid_y3 <- ry - max(0.14, sym_size * 1.8)
+          extra_release_specs[[length(extra_release_specs) + 1L]] <- list(
+            route_id = paste("cascade", sub$id, ckey, ps, sep = ":"),
+            source_kind = "scissor",
+            source_id = scissor_anchor_id,
+            target_kind = if (ps %in% names(mono_x_map)) {
+              "monosaccharide"
+            } else {
+              "complex_chain"
+            },
+            target_id = if (ps %in% names(mono_x_map)) ps else target_id,
+            group = paste0("release:", ps),
+            priority = route_wt,
+            points = data.frame(
               x = c(exit_x, exit_x, target_x, target_x),
               y = c(ry, mid_y3, mid_y3, target_y)
             ),
-            radius = 0.5
-          )
-          # Simple colored path (no gradient, unified width)
-          p <- p + .dnmb_cct_single_path_layer(
-            cascade_path, color = route_col,
+            color = route_col,
             linewidth = 0.35,
             alpha = 0.45,
-            arrow_last = TRUE, arrow_length = 0.02,
-            trim_start = extra_trim, trim_end = trim_end_val
+            linetype = "solid",
+            gradient = FALSE,
+            trim_start = extra_trim,
+            trim_end = trim_end_val
           )
         }
       }
 
-    } else {
-      # No cascade match — just draw product arrow to membrane if chain exists
-      chain_end_x <- chain_x + max(0, n_mono - 1) * chain_step
-      p <- p + ggplot2::geom_segment(
-        data = data.frame(x = chain_end_x, xend = chain_end_x,
-                          y = ry, yend = y_memb + 0.25),
-        ggplot2::aes(x=.data$x, xend=.data$xend, y=.data$y, yend=.data$yend),
-        arrow = ggplot2::arrow(length = grid::unit(0.02, "inches"), type = "closed"),
-        linewidth = 0.2, color = "#999999", inherit.aes = FALSE)
+    }
+  }
+
+  if (length(extra_release_specs)) {
+    extra_release_specs <- .dnmb_cct_validate_extracellular_routes(
+      specs = extra_release_specs,
+      anchors = dplyr::bind_rows(extra_route_anchor_rows),
+      tolerance = 1e-6
+    )
+  }
+  if (length(extra_release_specs)) {
+    release_metadata <- data.frame(
+      route_id = vapply(extra_release_specs, `[[`, character(1), "route_id"),
+      priority = vapply(extra_release_specs, `[[`, numeric(1), "priority"),
+      group = vapply(extra_release_specs, `[[`, character(1), "group"),
+      stringsAsFactors = FALSE
+    )
+    release_paths <- .dnmb_cct_separate_route_lanes(
+      routes = lapply(extra_release_specs, `[[`, "points"),
+      metadata = release_metadata,
+      lane_step = 0.065,
+      max_offset = 0.22,
+      horizontal_tolerance = 0.01,
+      y_tolerance = 0.18,
+      min_overlap = 0.14,
+      connection_mode = "move_internal",
+      round_radius = 0.08
+    )
+    for (route_index in seq_along(extra_release_specs)) {
+      spec <- extra_release_specs[[route_index]]
+      release_path <- release_paths[[route_index]]
+      if (isTRUE(spec$gradient)) {
+        for (ly in .dnmb_cct_gradient_path_layers(
+          release_path, color = spec$color,
+          linewidth = spec$linewidth, alpha = spec$alpha,
+          linetype = spec$linetype,
+          arrow_last = TRUE, arrow_length = 0.015,
+          trim_start = spec$trim_start, trim_end = spec$trim_end
+        )) p <- p + ly
+      } else {
+        p <- p + .dnmb_cct_single_path_layer(
+          release_path, color = spec$color,
+          linewidth = spec$linewidth, alpha = spec$alpha,
+          linetype = spec$linetype,
+          arrow_last = TRUE, arrow_length = 0.02,
+          trim_start = spec$trim_start, trim_end = spec$trim_end
+        )
+      }
     }
   }
 
   if (length(gh_label_rows) > 0) {
     gh_label_df <- do.call(rbind, gh_label_rows)
-    gh_label_df <- .dnmb_cct_thin_labels(gh_label_df, x_thresh = 0.55, y_thresh = 0.14)
-    gh_label_df <- .dnmb_cct_place_small_labels(gh_label_df, x_thresh = 0.55, y_thresh = 0.14)
-    p <- p + ggplot2::geom_text(
-      data = gh_label_df,
-      ggplot2::aes(x = .data$x_lab, y = .data$y_lab, label = .data$label),
-      size = 0.82, color = gh_label_df$color,
-      fontface = "bold", hjust = gh_label_df$hjust,
-      lineheight = 0.82, inherit.aes = FALSE
+    gh_label_df$locus_tag <- as.character(gh_label_df$locus_tag)
+    gh_label_df <- gh_label_df[
+      !is.na(gh_label_df$locus_tag) & nzchar(gh_label_df$locus_tag),
+      , drop = FALSE
+    ]
+    gh_loci <- sort(unique(gh_label_df$locus_tag))
+    gh_anchor_map <- stats::setNames(sprintf("G%02d", seq_along(gh_loci)), gh_loci)
+    gh_label_df$label <- unname(gh_anchor_map[gh_label_df$locus_tag])
+    gh_ledger_rows <- lapply(gh_loci, function(locus) {
+      rows <- gh_label_df[gh_label_df$locus_tag == locus, , drop = FALSE]
+      families <- unique(as.character(rows$gh_family))
+      genes <- unique(as.character(rows$gene_name))
+      genes <- genes[!is.na(genes) & nzchar(genes)]
+      substrates <- unique(as.character(rows$substrate))
+      substrates <- substrates[!is.na(substrates) & nzchar(substrates)]
+      pul <- unique(as.character(rows$pul_substrate))
+      pul <- pul[!is.na(pul) & nzchar(pul)]
+      data.frame(
+        anchor_id = unname(gh_anchor_map[locus]),
+        locus_tag = locus,
+        gh_family = paste(families, collapse = " | "),
+        gene_name = if (length(genes)) paste(genes, collapse = " | ") else "Gene symbol not annotated",
+        substrate_names = paste(substrates, collapse = " | "),
+        pul_substrate = if (length(pul)) paste(pul, collapse = " | ") else "No direct PUL substrate call",
+        stringsAsFactors = FALSE
+      )
+    })
+    gh_ledger_df <- dplyr::bind_rows(gh_ledger_rows)
+    gh_ledger_df$ledger_text <- paste0(
+      gh_ledger_df$anchor_id, "  ", gh_ledger_df$locus_tag,
+      " | dbCAN family: ", gh_ledger_df$gh_family,
+      " | Gene: ", gh_ledger_df$gene_name,
+      " | Cleavage context: ", gh_ledger_df$substrate_names,
+      " | PUL substrate: ", gh_ledger_df$pul_substrate
     )
+    gh_label_df$size <- 1.55
+    gh_label_df$fontface <- "bold"
+    gh_label_df$hjust <- 0.5
+    gh_label_df$nudge_x <- 0
+    gh_label_df$nudge_y <- 0
   }
 
   # ====================================================================
@@ -6897,190 +10141,310 @@
   # PTS transporters (orange dashed), non-PTS (solid colored arrows)
   # ====================================================================
   # Map carbon source IDs to x positions for alignment
-  cs_x_map <- stats::setNames(carbon_src$x, carbon_src$id)
+  transport_source_nodes <- carbon_src
+  glucose_node <- cyto_nodes[
+    cyto_nodes$id == "Glucose",
+    c("id", "x", "y", "label", "type", "sugar_type"),
+    drop = FALSE
+  ]
+  if (nrow(glucose_node) && !"Glucose" %in% transport_source_nodes$id) {
+    transport_source_nodes <- dplyr::bind_rows(
+      transport_source_nodes, glucose_node[1L, , drop = FALSE]
+    )
+  }
+  cs_x_map <- stats::setNames(
+    transport_source_nodes$x, transport_source_nodes$id
+  )
   # Also map pathway names to carbon source IDs
-  pathway_to_cs <- c(
-    maltose = "Maltose", cellobiose = "Cellobiose", galactose = "Galactose",
-    trehalose = "Trehalose", lactose = "Lactose", mannose = "Mannose",
-    NAG = "NAG", glucosamine = "Glucosamine", fructose = "Fructose",
-    sucrose = "Sucrose", mannitol = "Mannitol", glycerol = "Glycerol",
-    xylose = "Xylose", arabinose = "Arabinose", ribose = "Ribose",
-    fucose = "Fucose", rhamnose = "Rhamnose", gluconate = "Gluconate",
-    glucose = "Maltose", deoxyribose = "Ribose", deoxyribonate = "Gluconate")
+  pathway_to_cs <- .dnmb_cct_transporter_pathway_map()
 
+  transporter_label_df <- NULL
+  transporter_ledger_df <- NULL
+  transporter_entities_df <- NULL
+  transporter_bus_layout <- NULL
+  transporter_source_anchors <- NULL
+  transporter_interior_routes <- list()
   if (!is.null(transporters) && nrow(transporters) > 0) {
-    transporters <- transporters[!duplicated(transporters$locus_tag), , drop = FALSE]
-    # Determine if PTS
-    transporters$is_pts <- grepl("pts|PTS|EIIC|EIIB|crr", transporters$step, ignore.case = TRUE) |
-      grepl("pts|PTS", transporters$gene_name, ignore.case = TRUE)
-    transporters$cs_id <- unname(pathway_to_cs[transporters$pathway])
-    transporters <- transporters[!is.na(transporters$cs_id) & transporters$cs_id %in% names(cs_x_map), , drop = FALSE]
+    transporters$is_pts <- grepl(
+      "pts|EIIC|EIIB|crr", transporters$step, ignore.case = TRUE
+    ) | grepl("pts", transporters$gene_name, ignore.case = TRUE)
+    transporters$cs_id <- unname(pathway_to_cs[tolower(transporters$pathway)])
+    transporters <- transporters[
+      !is.na(transporters$cs_id) & transporters$cs_id %in% names(cs_x_map),
+      , drop = FALSE
+    ]
     if (nrow(transporters) > 0) {
       if (!"step_score" %in% names(transporters)) transporters$step_score <- NA_real_
       transporters <- .dnmb_cct_annotate_transport_context(transporters, genbank_table)
-      transporters$tx <- unname(cs_x_map[transporters$cs_id])
-      tr_entry_map <- .dnmb_cct_auto_entry_map()
-      tr_target_nodes <- rbind(
-        entry_inter,
-        backbone_nodes,
-        ppp_nodes,
-        cyto_nodes[cyto_nodes$type == "ed", , drop = FALSE]
-      )
-      tr_target_x <- stats::setNames(tr_target_nodes$x, tr_target_nodes$id)
-      transporters$entry_target <- unname(tr_entry_map[tolower(transporters$cs_id)])
-      transporters$center_x <- transporters$tx
-      transporters$desired_x <- transporters$tx
-      has_target <- !is.na(transporters$entry_target) & transporters$entry_target %in% names(tr_target_x)
-      if (any(has_target)) {
-        tx_target <- unname(tr_target_x[transporters$entry_target[has_target]])
-        delta_x <- tx_target - transporters$tx[has_target]
-        transporters$center_x[has_target] <- transporters$tx[has_target] +
-          pmax(-0.75, pmin(0.75, 0.18 * delta_x))
-        transporters$desired_x[has_target] <- transporters$tx[has_target] +
-          pmax(-1.00, pmin(1.00, 0.32 * delta_x))
-      }
-      transporters$matched <- !is.na(transporters$locus_tag) & nzchar(transporters$locus_tag)
-      transporters$conf_rank <- conf_rank[transporters$confidence]
+      transporters$conf_rank <- unname(conf_rank[tolower(transporters$confidence)])
       transporters$conf_rank[is.na(transporters$conf_rank)] <- 0L
-      if (!"kind" %in% names(transporters)) {
-        transporters$kind <- mapply(.dnmb_cct_transporter_kind, transporters$step, transporters$gene_name, is_pts)
-      }
-      transporters <- .dnmb_cct_select_transporters(transporters, max_per_lane = 8L)
-      split_lane <- split(seq_len(nrow(transporters)), paste(transporters$cs_id, round(transporters$tx, 3)))
-      transporters$lane_rank <- 1L
-      transporters$lane_top_score <- transporters$display_score
-      lane_center_ref <- stats::median(cs_x_map, na.rm = TRUE)
-      transporters$central_lane <- abs(transporters$tx - lane_center_ref) <= 2.2
-      for (grp in split_lane) {
-        ord <- grp[order(transporters$display_score[grp], transporters$matched[grp], transporters$conf_rank[grp],
-                         transporters$gene_name[grp], decreasing = TRUE, na.last = TRUE)]
-        transporters$lane_rank[ord] <- seq_along(ord)
-        transporters$lane_top_score[grp] <- max(transporters$display_score[grp], na.rm = TRUE)
-      }
-      transporters$show_ctx <- !is.na(transporters$context_score) &
-        transporters$context_score >= 1.0 &
-        (transporters$lane_rank == 1L | transporters$context_score >= 2.2)
-      transporters$show_label <- transporters$matched | transporters$lane_rank == 1L
-      transporters$ctx_lab <- ifelse(
-        transporters$show_ctx,
-        vapply(transporters$context_hits, .dnmb_cct_short_context_summary, character(1)),
-        ""
+      transporters$kind <- mapply(
+        .dnmb_cct_transporter_kind,
+        transporters$step, transporters$gene_name, transporters$is_pts
       )
-      transporters$label_text <- vapply(seq_len(nrow(transporters)), function(i) {
-        tr <- transporters[i, , drop = FALSE]
-        human_lab <- .dnmb_cct_prefer_human_label(tr$step, tr$gene_name, pathway_id = tr$pathway)
-        if (tr$lane_rank == 1L) {
-          if (!is.na(human_lab) && nzchar(human_lab)) {
-            paste0(
-              human_lab,
-              ifelse(tr$is_pts, " (PTS)", ""),
-              ifelse(tr$matched, paste0("\n", tr$locus_tag), ""),
-              ifelse(nzchar(tr$ctx_lab), paste0("\n", tr$ctx_lab), "")
-            )
-          } else if (tr$matched) {
-            paste0(tr$locus_tag, ifelse(nzchar(tr$ctx_lab), paste0("\n", tr$ctx_lab), ""))
-          } else {
-            paste0(.dnmb_cct_short_step_label(tr$step, tr$pathway),
-                   ifelse(nzchar(tr$ctx_lab), paste0("\n", tr$ctx_lab), ""))
-          }
-        } else {
-          if (tr$matched) {
-            paste0(human_lab, ifelse(nzchar(human_lab), "\n", ""), tr$locus_tag)
-          } else if (!is.na(human_lab) && nzchar(human_lab)) {
-            paste0(human_lab, ifelse(tr$is_pts, " (PTS)", ""))
-          } else if (tr$matched) {
-            tr$locus_tag
-          } else {
-            .dnmb_cct_short_step_label(tr$step, tr$pathway)
-          }
-        }
-      }, character(1))
-      transporters$label_width <- vapply(transporters$label_text, .dnmb_cct_estimate_text_width, numeric(1))
-      transporters$seg_half <- mapply(.dnmb_cct_transporter_half_span, transporters$step, transporters$gene_name, transporters$is_pts)
-      transporters$label_dx <- 0
-      transporters$tx_draw <- transporters$tx
-      transporters$ty_draw <- 8.56
-      transporters$row_draw <- 1L
-      global_cs_center <- stats::median(carbon_src$x, na.rm = TRUE)
-      for (grp in split_lane) {
-        ord <- grp[order(transporters$lane_rank[grp])]
-        lane_dir <- sign(mean(transporters$tx[ord], na.rm = TRUE) - global_cs_center)
-        if (!is.finite(lane_dir) || lane_dir == 0) {
-          lane_dir <- sign(mean(transporters$desired_x[ord] - transporters$tx[ord], na.rm = TRUE))
-        }
-        ord_dx <- .dnmb_cct_lane_label_offsets(length(ord), lane_dir = lane_dir)
-        transporters$label_dx[ord] <- ord_dx
-        packed <- .dnmb_cct_pack_transporters_lane(
-          center_x = transporters$center_x[ord[1]],
-          half_spans = transporters$seg_half[ord],
-          lane_ranks = transporters$display_score[ord],
-          label_widths = transporters$label_width[ord],
-          label_dx = ord_dx,
-          desired_x = transporters$desired_x[ord]
-        )
-        transporters$tx_draw[ord] <- packed$tx
-        transporters$ty_draw[ord] <- packed$ty
-        transporters$row_draw[ord] <- packed$row_id
+
+      positive <- transporters$conf_rank >= 2L |
+        (!is.na(transporters$step_score) & transporters$step_score >= 1)
+      transporters <- transporters[positive, , drop = FALSE]
+    }
+    if (nrow(transporters) > 0) {
+      # Keep every high-confidence locus. Medium calls are ranked within each
+      # substrate lane and contribute only the strongest additional locus.
+      high_loci <- unique(transporters$locus_tag[
+        transporters$conf_rank >= 3L |
+          (!is.na(transporters$step_score) & transporters$step_score >= 2)
+      ])
+      medium_pool <- transporters[!transporters$locus_tag %in% high_loci, , drop = FALSE]
+      if (nrow(medium_pool)) {
+        medium_pool <- .dnmb_cct_select_transporters(medium_pool, max_per_lane = 1L)
       }
-      transporter_label_rows <- list()
+      selected_loci <- unique(c(high_loci, medium_pool$locus_tag))
+      transporters <- transporters[transporters$locus_tag %in% selected_loci, , drop = FALSE]
 
-      for (i in seq_len(nrow(transporters))) {
-        tr <- transporters[i, , drop = FALSE]
-        tx <- tr$tx_draw
-        conf <- if (!is.na(tr$confidence)) tr$confidence else "medium"
-        sugar_type <- tolower(as.character(carbon_src$sugar_type[match(tr$cs_id, carbon_src$id)]))
-        frac_val <- if (!is.null(pstats) && tolower(tr$pathway) %in% pstats$pathway_id) {
-          pstats$fraction[pstats$pathway_id == tolower(tr$pathway)][1]
-        } else {
-          NA_real_
-        }
-        tr_importance <- .dnmb_cct_path_importance(confidence = conf, fraction = frac_val, sink_weight = 1)
-        arr_col <- if (isTRUE(tr$matched)) {
-          .dnmb_cct_sugar_route_color(sugar_type, fallback = "#666666")
-        } else {
-          "#BDBDBD"
-        }
-        seg_alpha <- switch(conf, high = 0.9, medium = 0.75, low = 0.55, 0.4)
-        tr_kind <- tr$kind
-        seg_half <- tr$seg_half
-        ty <- tr$ty_draw
-        lbl_dx <- tr$label_dx
-        base_lbl_y <- if (tr$row_draw == 1) y_memb + 0.28 else y_memb - 0.28
-        lbl_y <- base_lbl_y + if (tr$row_draw == 1) 0.04 * ((tr$lane_rank - 1) %/% 2) else -0.04 * ((tr$lane_rank - 1) %/% 2)
+      entity_result <- .dnmb_cct_transporter_entities(transporters)
+      transporter_entities_df <- entity_result$entities
+      transporters <- entity_result$memberships
+      if (nrow(transporter_entities_df)) {
+        transporter_entities_df$anchor_id <- sprintf(
+          "T%02d", seq_len(nrow(transporter_entities_df))
+        )
+        transporters$anchor_id <- transporter_entities_df$anchor_id[
+          match(transporters$locus_tag, transporter_entities_df$locus_tag)
+        ]
+        transporter_source_anchors <- .dnmb_cct_transporter_source_anchors(
+          cs_ids = unique(transporters$cs_id), carbon_src = transport_source_nodes,
+          mono_x_map = mono_x_map, y_mono = y_mono,
+          extra_center_map = extra_center_map, extra_y_map = extra_y_map
+        )
+        source_idx <- match(
+          transporters$cs_id, transporter_source_anchors$cs_id
+        )
+        transporters$source_x <- transporter_source_anchors$source_x[source_idx]
+        transporters$source_y <- transporter_source_anchors$source_y[source_idx]
+        transporters$source_kind <- transporter_source_anchors$source_kind[source_idx]
+        transporters$source_trim <- ifelse(
+          transporters$source_kind == "complex_chain", extra_trim, sugar_icon_r
+        )
+        transporters$cyto_x <- transporter_source_anchors$cyto_x[source_idx]
+        transporters$cyto_y <- transporter_source_anchors$cyto_y[source_idx]
+        transporters$lane_x <- transporters$source_x
+        transporters <- transporters[
+          is.finite(transporters$source_x) &
+            is.finite(transporters$source_y) &
+            is.finite(transporters$cyto_x) &
+            is.finite(transporters$cyto_y),
+          , drop = FALSE
+        ]
 
-        for (ly in .dnmb_cct_transporter_glyph_layers(
-          tx = tx, ty = ty, half_span = seg_half, core_color = arr_col,
-          confidence = conf, is_pts = tr$is_pts, kind = tr_kind
-        )) p <- p + ly
-        if (isTRUE(tr$matched)) {
+        product_col <- .dnmb_pick_column(genbank_table, c("product", "description"))
+        product_map <- if (!is.null(product_col) && "locus_tag" %in% names(genbank_table)) {
+          stats::setNames(as.character(genbank_table[[product_col]]), genbank_table$locus_tag)
+        } else {
+          character()
+        }
+        transporter_entities_df$product <- unname(product_map[transporter_entities_df$locus_tag])
+        missing_product <- is.na(transporter_entities_df$product) |
+          !nzchar(transporter_entities_df$product)
+        transporter_entities_df$product[missing_product] <- "Product not annotated"
+
+        entity_members <- split(seq_len(nrow(transporters)), transporters$locus_tag)
+        transporter_entities_df$anchor_x <- vapply(
+          transporter_entities_df$locus_tag,
+          function(locus) stats::median(unique(transporters$lane_x[entity_members[[locus]]]), na.rm = TRUE),
+          numeric(1)
+        )
+        transporter_entities_df$confidence <- vapply(
+          transporter_entities_df$locus_tag,
+          function(locus) {
+            rows <- transporters[entity_members[[locus]], , drop = FALSE]
+            if (any(rows$confidence == "high")) "high" else "medium"
+          }, character(1)
+        )
+        transporter_entities_df$is_pts <- vapply(
+          transporter_entities_df$locus_tag,
+          function(locus) any(transporters$is_pts[entity_members[[locus]]]),
+          logical(1)
+        )
+        transporter_entities_df$kind <- vapply(
+          transporter_entities_df$locus_tag,
+          function(locus) {
+            kinds <- transporters$kind[entity_members[[locus]]]
+            kinds[order(match(kinds, c("PTS", "ABC", "MFS", "GEN")))][1]
+          }, character(1)
+        )
+        transporter_entities_df$seg_half <- vapply(
+          transporter_entities_df$locus_tag,
+          function(locus) {
+            rows <- transporters[entity_members[[locus]], , drop = FALSE]
+            max(mapply(
+              .dnmb_cct_transporter_half_span,
+              rows$step, rows$gene_name, rows$is_pts
+            ))
+          }, numeric(1)
+        )
+        transporter_entities_df$anchor_y <- y_memb
+        transporter_entities_df$row_draw <- 1L
+        packed <- .dnmb_cct_pack_transporters_lane(
+          center_x = mean(transporter_entities_df$anchor_x),
+          half_spans = transporter_entities_df$seg_half,
+          lane_ranks = ifelse(
+            transporter_entities_df$confidence == "high", 2, 1
+          ),
+          desired_x = transporter_entities_df$anchor_x,
+          stable_ids = transporter_entities_df$locus_tag,
+          y_memb = y_memb,
+          xlim = c(mem_xmin, mem_xmax),
+          min_gap = 0.08,
+          row_step = 0.12,
+          max_rows = 3L
+        )
+        transporter_entities_df$anchor_x <- packed$tx
+        transporter_entities_df$anchor_y <- packed$ty
+        transporter_entities_df$row_draw <- packed$row_id
+
+        transporters$tx_draw <- transporter_entities_df$anchor_x[
+          match(transporters$locus_tag, transporter_entities_df$locus_tag)
+        ]
+        transporters$ty_draw <- transporter_entities_df$anchor_y[
+          match(transporters$locus_tag, transporter_entities_df$locus_tag)
+        ]
+
+        # Many substrate lanes may converge on the same physical transporter.
+        # Consolidate them into one bus per substrate and one trunk per locus;
+        # the evidence ledger still retains every selected membership.
+        connector_rows <- unique(transporters[, c(
+          "anchor_id", "locus_tag", "cs_id", "lane_x", "source_x", "source_y",
+          "source_kind", "source_trim",
+          "cyto_x", "cyto_y", "tx_draw", "ty_draw", "confidence"
+        ), drop = FALSE])
+        connector_rows$color <- vapply(seq_len(nrow(connector_rows)), function(i) {
+          member <- connector_rows[i, , drop = FALSE]
+          sugar_type <- transporter_source_anchors$sugar_type[
+            match(member$cs_id, transporter_source_anchors$cs_id)
+          ]
+          .dnmb_cct_sugar_route_color(sugar_type, fallback = "#78909C")
+        }, character(1))
+        transporter_bus_layout <- .dnmb_cct_transporter_bus_layout(
+          connector_rows,
+          y_memb = y_memb,
+          bus_offset = 0.70,
+          tier_step = 0.065,
+          max_bus_offset = 1.12,
+          source_offset = 0.76,
+          glyph_clearance = 0.11,
+          membrane_half_height = 0.20,
+          route_gap = 0.10,
+          interval_gap = 0.05,
+          corner_radius = 0.08,
+          suppress_redundant_medium = TRUE
+        )
+        for (route in transporter_bus_layout$exterior_render_routes) {
+          p <- p + .dnmb_cct_single_path_layer(
+            route$points, color = route$color,
+            linewidth = route$linewidth, alpha = route$alpha,
+            linetype = route$linetype,
+            arrow_last = isTRUE(route$arrow_last),
+            arrow_length = 0.015, trim_start = route$trim_start
+          )
+        }
+
+        draw_members <- transporter_bus_layout$memberships[
+          transporter_bus_layout$memberships$draw, , drop = FALSE
+        ]
+        draw_keys <- paste(draw_members$cs_id, draw_members$target_key, sep = "\r")
+        connector_keys <- paste(connector_rows$cs_id, connector_rows$locus_tag, sep = "\r")
+        drawn_connector_rows <- connector_rows[connector_keys %in% draw_keys, , drop = FALSE]
+        transporter_interior_routes <- .dnmb_cct_transporter_interior_routes(
+          drawn_connector_rows, y_memb = y_memb,
+          glyph_clearance = 0.11, source_clearance = 0.11,
+          membrane_half_height = 0.20, route_gap = 0.10,
+          lane_step = 0.045, max_lane_offset = 0.18,
+          corner_radius = 0.08
+        )
+        for (route in transporter_interior_routes) {
+          p <- p + .dnmb_cct_single_path_layer(
+            route$points, color = route$color,
+            linewidth = route$linewidth, alpha = route$alpha,
+            linetype = route$linetype, arrow_last = TRUE,
+            arrow_length = 0.015
+          )
+        }
+
+        drawn_source_ids <- unique(drawn_connector_rows$cs_id)
+        explicit_sources <- transporter_source_anchors[
+          transporter_source_anchors$create_glyph &
+            transporter_source_anchors$cs_id %in% drawn_source_ids,
+          , drop = FALSE
+        ]
+        for (i in seq_len(nrow(explicit_sources))) {
+          src <- explicit_sources[i, , drop = FALSE]
+          p <- .dnmb_cct_render_carbon_source_node(
+            p, src$source_x, src$source_y, src$glyph_source_id,
+            r = sugar_icon_r
+          )
+        }
+
+        transporter_ledger_df <- transporter_entities_df
+        transporter_ledger_df$evidence_label <- ifelse(
+          transporter_ledger_df$confidence == "high",
+          "high confidence",
+          "medium candidate"
+        )
+        transporter_ledger_df$shared_label <- ifelse(
+          transporter_ledger_df$shared,
+          "shared predicted transporter",
+          "predicted transporter"
+        )
+        transporter_ledger_df$ledger_text <- paste0(
+          transporter_ledger_df$anchor_id, "  ",
+          transporter_ledger_df$locus_tag,
+          " | Product: ", transporter_ledger_df$product,
+          " | GapMind models: ", transporter_ledger_df$model_names,
+          " | Supported substrates: ", transporter_ledger_df$substrate_names,
+          " | Evidence: ", transporter_ledger_df$evidence_label,
+          " | ", transporter_ledger_df$shared_label
+        )
+        transporter_entities_df <- .dnmb_cct_drawn_transporter_entities(
+          transporter_entities_df, transporter_bus_layout$memberships
+        )
+
+        for (i in seq_len(nrow(transporter_entities_df))) {
+          entity <- transporter_entities_df[i, , drop = FALSE]
+          core_color <- if (isTRUE(entity$shared)) "#455A64" else {
+            first_member <- transporters[transporters$locus_tag == entity$locus_tag, , drop = FALSE][1, ]
+            sugar_type <- transporter_source_anchors$sugar_type[
+              match(first_member$cs_id, transporter_source_anchors$cs_id)
+            ]
+            .dnmb_cct_sugar_route_color(sugar_type, fallback = "#607D8B")
+          }
+          for (ly in .dnmb_cct_transporter_glyph_layers(
+            tx = entity$anchor_x, ty = entity$anchor_y,
+            half_span = entity$seg_half, core_color = core_color,
+            confidence = entity$confidence, is_pts = entity$is_pts,
+            kind = entity$kind
+          )) p <- p + ly
           for (ly in .dnmb_cct_junction_glyph_layers(
-            x = tx, y = if (tr$row_draw == 1) y_memb + 0.18 else y_memb - 0.18, color = arr_col,
-            size = 1.4 + 0.8 * tr_importance, alpha = 0.65 + 0.2 * tr_importance
+            x = entity$anchor_x, y = entity$anchor_y,
+            color = core_color,
+            size = if (isTRUE(entity$shared)) 2.4 else 1.8,
+            alpha = if (entity$confidence == "high") 0.9 else 0.65
           )) p <- p + ly
         }
 
-        if (isTRUE(tr$show_label)) {
-          transporter_label_rows[[length(transporter_label_rows) + 1L]] <- data.frame(
-            x = tx + lbl_dx * ifelse(tr$lane_rank == 1L, 0.75, 0.55),
-            y = lbl_y,
-            label = tr$label_text,
-            color = arr_col,
-            lane_rank = tr$lane_rank,
-            priority = if (isTRUE(tr$matched)) 10 * tr_importance + tr$display_score else tr$display_score,
-            stringsAsFactors = FALSE
-          )
-        }
-      }
-
-      if (length(transporter_label_rows) > 0) {
-        tlab_df <- do.call(rbind, transporter_label_rows)
-        tlab_df <- .dnmb_cct_place_small_labels(tlab_df, x_thresh = 0.34, y_thresh = 0.08)
-        p <- p + ggplot2::geom_text(
-          data = tlab_df,
-          ggplot2::aes(x = .data$x_lab, y = .data$y_lab, label = .data$label),
-          size = 0.58, color = tlab_df$color,
-          fontface = "bold", lineheight = 0.84,
-          inherit.aes = FALSE
+        transporter_label_df <- data.frame(
+          x = transporter_entities_df$anchor_x,
+          y = transporter_entities_df$anchor_y,
+          anchor_x = transporter_entities_df$anchor_x,
+          anchor_y = transporter_entities_df$anchor_y,
+          label = transporter_entities_df$anchor_id,
+          color = ifelse(transporter_entities_df$confidence == "high", "#102A43", "#52616B"),
+          size = 1.60,
+          fontface = "bold",
+          hjust = 0.5,
+          priority = ifelse(transporter_entities_df$confidence == "high", 20, 10),
+          nudge_x = 0,
+          nudge_y = ifelse(transporter_entities_df$anchor_y >= y_memb, 0.26, -0.26),
+          stringsAsFactors = FALSE
         )
       }
     }
@@ -7141,37 +10505,22 @@
         }
         p <- p + ggplot2::geom_segment(data = seg_df,
           ggplot2::aes(x=.data$x, xend=.data$xend, y=.data$y, yend=.data$yend),
-          color="#999999", linewidth=0.35, alpha=0.5,
+          color="#B8B8B8", linewidth=0.24, alpha=0.15,
           lineend="round", inherit.aes=FALSE)
       } else {
-        # Non-backbone: L-shaped routing
-        stagger <- (i %% 5 - 2) * 0.25
-        if (is_straight) {
-          edge_pts <- data.frame(x = c(x1, x2), y = c(y1, y2))
-        } else {
-          is_mostly_vertical <- abs(y2 - y1) >= abs(x2 - x1)
-          if (is_mostly_vertical) {
-            mid_y <- round((y2 + stagger) * 4) / 4
-            route_pts <- data.frame(
-              x = c(x1, x1, x2, x2),
-              y = c(y1, mid_y, mid_y, y2)
-            )
-          } else {
-            mid_x <- round((x2 + stagger) * 4) / 4
-            route_pts <- data.frame(
-              x = c(x1, mid_x, mid_x, x2),
-              y = c(y1, y1, y2, y2)
-            )
-          }
-          edge_pts <- .dnmb_cct_rounded_route_points(route_pts, radius = glyco_grid_step)
-        }
+        # Keep orthogonal routes inside their endpoint bounding box.  The old
+        # target-based stagger could overshoot short PPP edges and fold back
+        # into pale circular loops around Xu-5-P/R-5-P/S-7-P/E-4-P.
+        edge_pts <- .dnmb_cct_edge_points_from_row(
+          ce, edge_idx = i, grid_step = glyco_grid_step
+        )
         # Adaptive trim: at least node radius (0.10) so lines don't pass through symbols
         edge_total_len <- sqrt((x2 - x1)^2 + (y2 - y1)^2)
         edge_trim <- min(0.12, max(0.10, edge_total_len * 0.15))
         # Simple gray line with arrow (unified width)
         p <- p + .dnmb_cct_single_path_layer(
-          edge_pts, color = "#AAAAAA",
-          linewidth = 0.35, alpha = 0.5,
+          edge_pts, color = "#B8B8B8",
+          linewidth = 0.24, alpha = 0.12,
           arrow_last = TRUE, arrow_length = 0.015,
           trim_start = edge_trim, trim_end = edge_trim
         )
@@ -7183,7 +10532,11 @@
   # draw a single continuous route from entry through central metabolism.
   continuity_routes <- .dnmb_cct_continuity_routes()
   continuity_entry_map <- .dnmb_cct_auto_entry_map()
-  active_continuity <- intersect(tolower(names(continuity_entry_map)), matched_pathway_ids)
+  active_continuity <- intersect(
+    tolower(names(continuity_entry_map)),
+    names(cytoplasm_status)[cytoplasm_status %in% c("active", "partial")]
+  )
+  continuity_specs <- list()
   if (length(active_continuity) > 0) {
     for (pid in active_continuity) {
       best_hit <- route_best_match(pid)
@@ -7201,13 +10554,18 @@
       )
       fallback_nodes <- if (pid %in% names(continuity_routes)) continuity_routes[[pid]] else NULL
       cont_node_ids <- if (!is.null(generic_nodes)) generic_nodes else fallback_nodes
-      cont_pts <- .dnmb_cct_route_overlay_points(
+      # Substrate colour ends at the first shared central-carbon merge. The
+      # shared glycolysis/PPP reaction remains a single core/reference edge,
+      # rather than becoming one parallel coloured line per carbon source.
+      cont_node_ids <- .dnmb_cct_route_to_first_core_merge(cont_node_ids)
+      if (is.null(cont_node_ids)) next
+      cont_edges <- .dnmb_cct_route_overlay_edges(
         node_ids = cont_node_ids,
         node_x = node_x,
         node_y = node_y,
         grid_step = glyco_grid_step
       )
-      if (is.null(cont_pts) || nrow(cont_pts) < 2) next
+      if (!length(cont_edges)) next
       frac <- if (!is.null(pstats) && pid %in% pstats$pathway_id) {
         pstats$fraction[pstats$pathway_id == pid][1]
       } else {
@@ -7219,56 +10577,222 @@
         fraction = frac,
         sink_weight = if (!is.null(generic_nodes) && !is.null(attr(generic_nodes, "sink_weight"))) attr(generic_nodes, "sink_weight") else 1
       )
-      cont_alpha <- 0.25 + 0.15 * cont_imp
-      cont_lw <- 0.35  # unified with all other edges
-      # Simple colored line (no gradient)
+      cont_state <- pathway_state_for(pid)
+      cont_alpha <- pathway_alpha_for(pid, zone = "route")
+      cont_lw <- if (cont_state == "active") 0.50 else 0.34
+      cont_lty <- if (cont_state == "active") "solid" else "dashed"
+      for (edge_index in seq_along(cont_edges)) {
+        edge_points <- cont_edges[[edge_index]]
+        continuity_specs[[length(continuity_specs) + 1L]] <- list(
+          route_id = paste0("continuity:", pid, ":", edge_index),
+          group = .dnmb_cct_route_group_for_pathway(pid, route_group_members),
+          priority = cont_imp,
+          points = edge_points,
+          from_id = attr(edge_points, "from_id"),
+          to_id = attr(edge_points, "to_id"),
+          color = cont_col,
+          linewidth = cont_lw,
+          alpha = cont_alpha,
+          linetype = cont_lty
+        )
+      }
+    }
+  }
+  if (length(continuity_specs)) {
+    continuity_metadata <- data.frame(
+      route_id = vapply(continuity_specs, `[[`, character(1), "route_id"),
+      priority = vapply(continuity_specs, `[[`, numeric(1), "priority"),
+      group = vapply(continuity_specs, function(spec) {
+        group <- as.character(spec$group)[1L]
+        if (is.na(group) || !nzchar(group)) "ungrouped" else group
+      }, character(1)),
+      stringsAsFactors = FALSE
+    )
+    continuity_paths <- .dnmb_cct_separate_route_lanes(
+      routes = lapply(continuity_specs, `[[`, "points"),
+      metadata = continuity_metadata,
+      lane_step = 0.04,
+      max_offset = 0.16,
+      horizontal_tolerance = 0.01,
+      y_tolerance = 0.035,
+      min_overlap = 0.20,
+      connection_mode = "move_internal",
+      round_radius = 0.04
+    )
+    for (route_index in seq_along(continuity_specs)) {
+      spec <- continuity_specs[[route_index]]
       p <- p + .dnmb_cct_single_path_layer(
-        cont_pts, color = cont_col, linewidth = cont_lw, alpha = cont_alpha,
+        continuity_paths[[route_index]],
+        color = spec$color, linewidth = spec$linewidth,
+        alpha = spec$alpha, linetype = spec$linetype,
         trim_start = 0.12, trim_end = 0.12
       )
     }
   }
 
-  # Draw TCA cycle arc (smooth circle behind TCA nodes)
+  # Foreground every reaction that has an exact directed step mapping. This
+  # includes branches that a single continuity path cannot represent, such as
+  # the two products of deoxyribose-phosphate aldolase.
+  if (nrow(exact_edge_hits)) {
+    exact_by_edge <- split(seq_len(nrow(exact_edge_hits)), exact_edge_hits$edge_index)
+    for (idx in exact_by_edge) {
+      edge_index <- exact_edge_hits$edge_index[idx[1L]]
+      if (!is.finite(edge_index) || edge_index < 1L || edge_index > nrow(cyto_edges)) next
+      ce <- cyto_edges[edge_index, , drop = FALSE]
+      edge_pts <- .dnmb_cct_edge_points_from_row(
+        ce, edge_idx = edge_index, grid_step = glyco_grid_step
+      )
+      if (nrow(edge_pts) < 2L) next
+      ranks <- suppressWarnings(as.integer(exact_edge_hits$rank[idx]))
+      ranks <- ranks[is.finite(ranks)]
+      if (!length(ranks) || max(ranks) < 2L) next
+      edge_rank <- max(ranks)
+      edge_color <- unname(pw_colors[as.character(ce$pathway[1L])])
+      if (is.na(edge_color) || !nzchar(edge_color)) edge_color <- "#52616B"
+      p <- p + .dnmb_cct_single_path_layer(
+        edge_pts,
+        color = edge_color,
+        linewidth = if (edge_rank >= 3L) 0.56 else 0.38,
+        alpha = if (edge_rank >= 3L) 0.88 else 0.64,
+        linetype = if (edge_rank >= 3L) "solid" else "dashed",
+        arrow_last = TRUE,
+        arrow_length = 0.016,
+        trim_start = 0.11,
+        trim_end = 0.11
+      )
+    }
+  }
+
+  # Draw a faint biochemical reference ring, then foreground each TCA
+  # reaction independently from the conservative genome-annotation scan.
   tca_nodes <- cyto_nodes[cyto_nodes$type == "tca", , drop = FALSE]
   tca_shunt_nodes <- cyto_nodes[cyto_nodes$type == "tca_shunt", , drop = FALSE]
+  core_state_color <- function(state) {
+    switch(state, active = "#2B6F77", partial = "#C78932", "#B8B8B8")
+  }
+  core_state_alpha <- function(state) {
+    switch(state, active = 0.90, partial = 0.66, reference = 0.12, 0.12)
+  }
+
+  glycolysis_steps <- core_steps[core_steps$pathway == "Glycolysis", , drop = FALSE]
+  if (nrow(glycolysis_steps)) {
+    for (i in seq_len(nrow(glycolysis_steps))) {
+      step <- glycolysis_steps[i, , drop = FALSE]
+      if (identical(step$status, "reference") ||
+          !all(c(step$from, step$to) %in% names(node_x))) next
+      endpoint_pairs <- list(c(step$from, step$to))
+      if (identical(step$reaction_id, "C14") && "DHAP" %in% names(node_x)) {
+        endpoint_pairs[[2L]] <- c(step$from, "DHAP")
+      }
+      for (pair in endpoint_pairs) {
+        x1 <- unname(node_x[pair[1]]); y1 <- unname(node_y[pair[1]])
+        x2 <- unname(node_x[pair[2]]); y2 <- unname(node_y[pair[2]])
+        edge_len <- sqrt((x2 - x1)^2 + (y2 - y1)^2)
+        trim <- min(0.12, edge_len * 0.22)
+        frac <- if (edge_len > 0) trim / edge_len else 0
+        seg <- data.frame(
+          x = x1 + (x2 - x1) * frac,
+          y = y1 + (y2 - y1) * frac,
+          xend = x2 - (x2 - x1) * frac,
+          yend = y2 - (y2 - y1) * frac
+        )
+        p <- p + ggplot2::geom_segment(
+          data = seg,
+          ggplot2::aes(x = .data$x, y = .data$y,
+                       xend = .data$xend, yend = .data$yend),
+          color = core_state_color(step$status),
+          linewidth = if (step$status == "active") 0.60 else 0.46,
+          alpha = core_state_alpha(step$status),
+          linetype = if (step$status == "partial") "dashed" else "solid",
+          lineend = "round", inherit.aes = FALSE
+        )
+      }
+    }
+  }
+
   if (nrow(tca_nodes) >= 3) {
     tca_cx <- mean(tca_nodes$x)
     tca_cy <- mean(tca_nodes$y)
     tca_r  <- max(sqrt((tca_nodes$x - tca_cx)^2 + (tca_nodes$y - tca_cy)^2))
-    # Step 1: Draw perfect circle (gapmind_aa style — thick grey dashed)
     theta_seq <- seq(0, 2 * pi, length.out = 200)
     tca_circle <- data.frame(x = tca_cx + tca_r * cos(theta_seq),
                               y = tca_cy + tca_r * sin(theta_seq))
     p <- p + ggplot2::geom_path(
       data = tca_circle,
       ggplot2::aes(x = .data$x, y = .data$y),
-      color = "#CCCCCC", linewidth = 1.5, linetype = "solid", inherit.aes = FALSE)
+      color = "#B8B8B8", linewidth = 0.70, alpha = 0.16,
+      linetype = "solid", inherit.aes = FALSE)
+
+    tca_step_rows <- core_steps[core_steps$pathway == "TCA cycle", , drop = FALSE]
+    for (i in seq_len(nrow(tca_step_rows))) {
+      step <- tca_step_rows[i, , drop = FALSE]
+      if (!all(c(step$from, step$to) %in% names(node_x))) next
+      a_from <- atan2(unname(node_y[step$from]) - tca_cy,
+                      unname(node_x[step$from]) - tca_cx)
+      a_to <- atan2(unname(node_y[step$to]) - tca_cy,
+                    unname(node_x[step$to]) - tca_cx)
+      delta <- ((a_to - a_from + pi) %% (2 * pi)) - pi
+      trim_angle <- min(0.055, abs(delta) * 0.18)
+      theta <- seq(
+        a_from + sign(delta) * trim_angle,
+        a_from + delta - sign(delta) * trim_angle,
+        length.out = 28
+      )
+      arc <- data.frame(x = tca_cx + tca_r * cos(theta),
+                        y = tca_cy + tca_r * sin(theta))
+      state <- step$status[1]
+      p <- p + ggplot2::geom_path(
+        data = arc,
+        ggplot2::aes(x = .data$x, y = .data$y),
+        color = core_state_color(state),
+        linewidth = if (state == "active") 0.82 else if (state == "partial") 0.64 else 0.34,
+        alpha = core_state_alpha(state),
+        linetype = if (state == "partial") "dashed" else "solid",
+        lineend = "round", inherit.aes = FALSE
+      )
+    }
   }
 
-  if (nrow(tca_shunt_nodes) > 0 &&
-      all(c("Isocit", "Malate") %in% names(node_x))) {
-    p <- p + ggplot2::geom_curve(
-      data = data.frame(
-        x = unname(node_x["Isocit"]),
-        y = unname(node_y["Isocit"]),
-        xend = unname(node_x["Malate"]),
-        yend = unname(node_y["Malate"])
-      ),
-      ggplot2::aes(x = .data$x, y = .data$y, xend = .data$xend, yend = .data$yend),
-      color = "#B8B8B8", linewidth = 0.45, linetype = "dashed",
-      curvature = -0.30, inherit.aes = FALSE
-    )
+  shunt_steps <- core_steps[core_steps$pathway == "Glyoxylate shunt", , drop = FALSE]
+  if (nrow(tca_shunt_nodes) > 0 && nrow(shunt_steps)) {
+    for (i in seq_len(nrow(shunt_steps))) {
+      step <- shunt_steps[i, , drop = FALSE]
+      if (!all(c(step$from, step$to) %in% names(node_x))) next
+      state <- step$status[1]
+      p <- p + ggplot2::geom_curve(
+        data = data.frame(
+          x = unname(node_x[step$from]), y = unname(node_y[step$from]),
+          xend = unname(node_x[step$to]), yend = unname(node_y[step$to])
+        ),
+        ggplot2::aes(x = .data$x, y = .data$y, xend = .data$xend, yend = .data$yend),
+        color = core_state_color(state),
+        linewidth = if (state == "active") 0.62 else 0.46,
+        linetype = if (state == "active") "solid" else "dashed",
+        alpha = core_state_alpha(state),
+        curvature = if (step$reaction_id == "C09") 0.12 else -0.12,
+        lineend = "round", inherit.aes = FALSE
+      )
+    }
   }
+  core_direct_label_df <- .dnmb_cct_core_direct_labels(
+    core_steps = core_steps,
+    display_hits = core_display_hits,
+    nodes = cyto_nodes
+  )
 
   # Draw SNFG nodes for all cytoplasm node types (symbols only, no labels)
-  node_r <- 0.10  # unified size
+  node_r <- sugar_icon_r
   for (ntype in c("backbone", "ppp", "entry_intermediate", "tca", "tca_shunt", "ed", "pyruvate_branch")) {
     nset <- cyto_nodes[cyto_nodes$type == ntype, , drop = FALSE]
     for (i in seq_len(nrow(nset))) {
       nd <- nset[i, , drop = FALSE]
       # Symbol only — full name labels are rendered separately below
-      p <- .dnmb_snfg_render_symbol_v2(p, nd$x, nd$y, nd$sugar_type, r = node_r, label = NULL)
+      node_alpha_i <- unname(cyto_node_alpha[nd$id])
+      if (!is.finite(node_alpha_i)) node_alpha_i <- 0.22
+      p <- .dnmb_snfg_render_symbol_v2(
+        p, nd$x, nd$y, nd$sugar_type, r = node_r, label = NULL,
+        alpha = node_alpha_i
+      )
     }
   }
 
@@ -7279,9 +10803,10 @@
   # 2) Draw converging arrows from each substrate label → hub SNFG symbol
   # 3) Hub connects onward to entry intermediate
   cs_groups <- split(seq_len(nrow(carbon_src)), carbon_src$sugar_type)
-  hidden_secondary_cs_labels <- c("Lactose")
   hub_positions <- list()  # sugar_type -> list(x, y)
   route_label_rows <- list()
+  metabolic_ledger_df <- NULL
+  hub_guide_specs <- list()
   for (st in names(cs_groups)) {
     idx <- cs_groups[[st]]
     hub_x <- if (st %in% names(sugar_lane_x)) {
@@ -7290,40 +10815,86 @@
       .dnmb_cct_snap_to_grid(mean(carbon_src$x[idx]), step = glyco_grid_step)
     }
     hub_y <- .dnmb_cct_snap_to_grid(carbon_src$y[idx[1]], step = glyco_grid_step)
-    hub_positions[[st]] <- list(x = hub_x, y = hub_y)
-    # Draw hub SNFG symbol (no label — final overlay adds label above route lines)
-    p <- .dnmb_snfg_render_symbol_v2(p, hub_x, hub_y, st, r = 0.10, label = NULL)
+    hub_path_ids <- tolower(carbon_src$id[idx])
+    hub_alpha <- pathway_alpha_for(hub_path_ids, zone = "node")
+    source_at_hub <- any(
+      abs(carbon_src$x[idx] - hub_x) < 0.02 &
+        abs(carbon_src$y[idx] - hub_y) < 0.02
+    )
+    hub_positions[[st]] <- list(
+      x = hub_x, y = hub_y, alpha = hub_alpha, path_ids = hub_path_ids,
+      source_at_hub = source_at_hub
+    )
+    # A source exactly on the convergence coordinate doubles as the hub. Its
+    # substrate-specific glyph is drawn in the final overlay instead of
+    # stacking a generic family glyph underneath it.
+    if (!source_at_hub) {
+      p <- .dnmb_snfg_render_symbol_v2(
+        p, hub_x, hub_y, st, r = sugar_icon_r,
+        label = NULL, alpha = hub_alpha
+      )
+    }
     # Draw converging lines from each substrate to hub
     for (i in idx) {
       nd <- carbon_src[i, , drop = FALSE]
       if (abs(nd$x - hub_x) > 0.2) {
-        # Substrate label at its original x, slightly above
-        if (!nd$id %in% hidden_secondary_cs_labels) {
-          p <- p + ggplot2::annotate("text", x = nd$x, y = nd$y + 0.20,
-            label = nd$label, size = 0.8, color = "#111111", hjust = 0.5, angle = 0)
-        }
-        # Orthogonal guide segments snapped to the glycolysis grid
-        guide_y <- .dnmb_cct_snap_to_grid(hub_y + glyco_grid_step, step = glyco_grid_step)
+        # Keep source-to-hub convergence in its own cytoplasmic band instead
+        # of letting it merge with the membrane centerline and T-ID glyphs.
+        guide_y <- .dnmb_cct_snap_to_grid(
+          hub_y + glyco_grid_step / 2,
+          step = glyco_grid_step / 2
+        )
         guide_col <- route_color_for(path_ids = tolower(nd$id), sugar_type = st)
-        guide_path <- .dnmb_cct_rounded_route_points(
-          data.frame(
-            x = c(nd$x, nd$x, hub_x, hub_x),
-            y = c(nd$y + 0.15, guide_y, guide_y, hub_y)
-          ),
-          radius = glyco_grid_step
+        guide_path <- data.frame(
+          x = c(nd$x, nd$x, hub_x, hub_x),
+          y = c(nd$y + 0.15, guide_y, guide_y, hub_y)
         )
-        p <- p + .dnmb_cct_single_path_layer(
-          guide_path, color = .dnmb_cct_reference_gray("light"), linewidth = 0.16, alpha = 0.26
+        guide_state <- pathway_state_for(tolower(nd$id))
+        hub_guide_specs[[length(hub_guide_specs) + 1L]] <- list(
+          route_id = paste("source", st, nd$id, sep = ":"),
+          group = paste0("hub:", st),
+          priority = if (guide_state == "active") 2 else if (guide_state == "partial") 1 else 0,
+          points = guide_path,
+          color = guide_col,
+          state = guide_state,
+          supported = !is.null(route_best_match(tolower(nd$id))) && guide_state != "reference",
+          path_id = nd$id
         )
-        if (!is.null(route_best_match(tolower(nd$id)))) {
-          for (ly in .dnmb_cct_gradient_path_layers(
-            guide_path, color = guide_col, linewidth = 0.18, alpha = 0.40
-          )) p <- p + ly
-        }
-      } else {
-        # Single substrate = same as hub, just label below
-        p <- p + ggplot2::annotate("text", x = nd$x, y = nd$y - 0.20,
-          label = nd$label, size = 0.9, fontface = "bold", color = "#111111", hjust = 0.5)
+      }
+    }
+  }
+  if (length(hub_guide_specs)) {
+    guide_metadata <- data.frame(
+      route_id = vapply(hub_guide_specs, `[[`, character(1), "route_id"),
+      priority = vapply(hub_guide_specs, `[[`, numeric(1), "priority"),
+      group = vapply(hub_guide_specs, `[[`, character(1), "group"),
+      stringsAsFactors = FALSE
+    )
+    hub_guide_paths <- .dnmb_cct_separate_route_lanes(
+      routes = lapply(hub_guide_specs, `[[`, "points"),
+      metadata = guide_metadata,
+      lane_step = 0.04,
+      max_offset = 0.12,
+      horizontal_tolerance = 0.01,
+      y_tolerance = 0.04,
+      min_overlap = 0.16,
+      connection_mode = "move_internal",
+      round_radius = 0.04
+    )
+    for (route_index in seq_along(hub_guide_specs)) {
+      spec <- hub_guide_specs[[route_index]]
+      guide_path <- hub_guide_paths[[route_index]]
+      p <- p + .dnmb_cct_single_path_layer(
+        guide_path, color = .dnmb_cct_reference_gray("light"),
+        linewidth = 0.16, alpha = 0.12
+      )
+      if (isTRUE(spec$supported)) {
+        for (ly in .dnmb_cct_gradient_path_layers(
+          guide_path, color = spec$color,
+          linewidth = if (spec$state == "active") 0.34 else 0.22,
+          alpha = pathway_alpha_for(spec$path_id, zone = "route"),
+          linetype = if (spec$state == "active") "solid" else "dashed"
+        )) p <- p + ly
       }
     }
   }
@@ -7342,16 +10913,30 @@
   for (st in names(hub_positions)) {
     hp <- hub_positions[[st]]
     cs_of_type <- carbon_src$id[carbon_src$sugar_type == st]
-    route_key <- vapply(cs_of_type, function(csid) {
-      paste(.dnmb_cct_entry_route_nodes(tolower(csid), node_ids = names(target_x)), collapse = "|")
-    }, character(1))
-    route_groups <- split(cs_of_type, route_key)
-    for (rk in names(route_groups)) {
-      route_csids <- route_groups[[rk]]
-      route_nodes <- unlist(strsplit(rk, "|", fixed = TRUE))
-      route_nodes <- route_nodes[nzchar(route_nodes)]
+    target_rows <- dplyr::bind_rows(lapply(cs_of_type, function(csid) {
+      targets <- .dnmb_cct_initial_entry_targets(
+        tolower(csid), node_ids = names(target_x)
+      )
+      if (!length(targets)) {
+        fallback <- unname(entry_map[tolower(csid)])
+        targets <- fallback[!is.na(fallback) & fallback %in% names(target_x)]
+      }
+      if (!length(targets)) return(NULL)
+      data.frame(
+        cs_id = rep(csid, length(targets)),
+        target_id = targets,
+        stringsAsFactors = FALSE
+      )
+    }))
+    if (!nrow(target_rows)) next
+    target_groups <- split(target_rows$cs_id, target_rows$target_id)
+    for (entry_target in names(target_groups)) {
+      route_csids <- sort(unique(target_groups[[entry_target]]))
+      route_nodes <- entry_target
       rep_csid <- route_csids[1]
-      entry_target <- if (length(route_nodes) > 0) tail(route_nodes, 1) else unname(entry_map[tolower(rep_csid)])
+      # The hub owns only the connection to the first intracellular node.
+      # Substrate-specific continuity then carries that node to the first core
+      # merge, avoiding a duplicate foreground path over the same reactions.
       if (is.na(entry_target) || !entry_target %in% names(target_x)) next
       best_hit <- route_best_match(tolower(route_csids))
       route_col <- route_color_for(path_ids = tolower(route_csids), sugar_type = st)
@@ -7398,7 +10983,9 @@
       hub_route_df$target_rank[ord] <- seq_along(ord)
       hub_route_df$target_count[grp] <- length(grp)
     }
-
+    route_obstacle_x <- c(target_x, carbon_src$x, hub_route_df$hub_x)
+    route_obstacle_y <- c(target_y, carbon_src$y, hub_route_df$hub_y)
+    hub_paths <- vector("list", nrow(hub_route_df))
     for (i in seq_len(nrow(hub_route_df))) {
       rr <- hub_route_df[i, , drop = FALSE]
       route_nodes <- unlist(strsplit(rr$route_nodes, "|", fixed = TRUE))
@@ -7411,7 +10998,9 @@
         node_y = target_y,
         grid_step = glyco_grid_step,
         lane_rank = rr$target_rank,
-        lane_count = rr$target_count
+        lane_count = rr$target_count,
+        obstacle_x = route_obstacle_x,
+        obstacle_y = route_obstacle_y
       )
       if (is.null(main_path)) {
         main_path <- .dnmb_cct_hub_entry_path(
@@ -7421,176 +11010,140 @@
           target_y = rr$target_y,
           lane_rank = rr$target_rank,
           target_count = rr$target_count,
-          grid_step = glyco_grid_step
+          grid_step = glyco_grid_step,
+          rounded = FALSE
         )
       }
-      # Simple colored line from hub to entry intermediate
-      hub_col <- if (rr$label_rank > 0) rr$route_col else "#AAAAAA"
-      hub_alpha <- if (rr$label_rank > 0) 0.55 else 0.35
+      hub_paths[[i]] <- main_path
+    }
+    hub_metadata <- data.frame(
+      route_id = paste0(
+        "hub:", seq_len(nrow(hub_route_df)), ":",
+        hub_route_df$path_ids, ":", hub_route_df$target_id
+      ),
+      priority = hub_route_df$route_imp,
+      group = paste0("target:", hub_route_df$target_id),
+      stringsAsFactors = FALSE
+    )
+    hub_paths <- .dnmb_cct_separate_route_lanes(
+      routes = hub_paths,
+      metadata = hub_metadata,
+      lane_step = 0.045,
+      max_offset = 0.14,
+      horizontal_tolerance = 0.01,
+      y_tolerance = 0.04,
+      min_overlap = 0.18,
+      connection_mode = "move_internal",
+      round_radius = 0.04
+    )
+
+    for (i in seq_len(nrow(hub_route_df))) {
+      rr <- hub_route_df[i, , drop = FALSE]
+      main_path <- hub_paths[[i]]
+      # Keep the biochemical reference route faint, then foreground only
+      # pathways with positive intracellular evidence.
+      hub_state <- pathway_state_for(hit_ids <- unlist(strsplit(rr$path_ids, "|", fixed = TRUE)))
       p <- p + .dnmb_cct_single_path_layer(
-        main_path, color = hub_col,
-        linewidth = 0.35,
-        alpha = hub_alpha,
+        main_path, color = "#B8B8B8",
+        linewidth = 0.22,
+        alpha = 0.12,
         arrow_last = TRUE, arrow_length = 0.02,
         trim_end = 0.08
       )
-      for (ly in .dnmb_cct_junction_glyph_layers(
-        x = rr$target_x, y = rr$target_y, color = .dnmb_cct_reference_gray("dark"),
-        size = 1.3 + 0.5 * rr$route_imp, alpha = 0.45
-      )) p <- p + ly
-      if (rr$label_rank > 0) {
-        for (ly in .dnmb_cct_junction_glyph_layers(
-          x = rr$target_x, y = rr$target_y, color = rr$route_col,
-          size = 1.5 + 0.7 * rr$route_imp, alpha = 0.7
-        )) p <- p + ly
-      }
-
-      hit_ids <- unlist(strsplit(rr$path_ids, "|", fixed = TRUE))
-      route_hits <- matched_steps[tolower(matched_steps$pathway_id) %in% hit_ids, , drop = FALSE]
-      if (nrow(route_hits) > 0) {
-        keep_tr_like <- unlist(mapply(
-          .dnmb_cct_is_transport_like_step,
-          step_id = route_hits$step_id,
-          gene_name = route_hits$step_id,
-          is_pts = FALSE,
-          SIMPLIFY = TRUE
-        ))
-        route_hits <- route_hits[keep_tr_like, , drop = FALSE]
-      }
-      if (nrow(route_hits) == 0 && nzchar(rr$label_step) && nzchar(rr$label_locus)) {
-        route_hits <- data.frame(
-          step_id = rr$best_step_id,
-          locus_tag = rr$label_locus,
-          rank = rr$label_rank,
-          stringsAsFactors = FALSE
+      if (hub_state != "reference") {
+        p <- p + .dnmb_cct_single_path_layer(
+          main_path, color = rr$route_col,
+          linewidth = if (hub_state == "active") 0.48 else 0.32,
+          alpha = pathway_alpha_for(hit_ids, zone = "route"),
+          linetype = if (hub_state == "active") "solid" else "dashed",
+          arrow_last = TRUE, arrow_length = 0.02,
+          trim_end = 0.08
         )
       }
-      if (nrow(route_hits) > 0) {
-        route_hits <- route_hits[order(-route_hits$rank, route_hits$step_id, route_hits$locus_tag), , drop = FALSE]
-        route_hits <- utils::head(route_hits, 3L)  # max 3 labels per route
-        for (hi in seq_len(nrow(route_hits))) {
-          # Place label at midpoint of the path (between two metabolites)
-          path_idx <- .dnmb_cct_route_label_index(
-            main_path,
-            frac = 0.50 + 0.12 * (hi - 1L)
-          )
-          path_mid <- main_path[path_idx, , drop = FALSE]
-          route_label_rows[[length(route_label_rows) + 1L]] <- data.frame(
-            x = path_mid$x + 0.12,
-            y = path_mid$y,
-            label = paste0(.dnmb_cct_short_step_label(route_hits$step_id[hi], rr$cs_id), "\n", route_hits$locus_tag[hi]),
-            step_id = route_hits$step_id[hi],
-            locus_tag = route_hits$locus_tag[hi],
-            color = rr$route_col,
-            target_id = rr$target_id,
-            target_rank = rr$target_rank,
-            priority = 10 * rr$route_imp + route_hits$rank[hi] + 0.01 * (nrow(route_hits) - hi),
-            angle = 0,
-            stringsAsFactors = FALSE
-          )
-        }
-      }
+      # The SNFG metabolite at the route target already marks the junction.
+      # A second circular junction glyph creates a false ring behind stars such
+      # as Xu-5-P and R-5-P, so metabolic targets use the native symbol only.
+      # Step labels are added only through the exact directed-edge mapping
+      # below. A pathway-level best hit is not a biochemical reaction anchor.
     }
   }
 
-  shown_route_keys <- character(0)
-  if (length(route_label_rows) > 0) {
-    shown_route_keys <- unique(vapply(route_label_rows, function(x) {
-      paste(x$step_id[1], x$locus_tag[1], sep = "::")
-    }, character(1)))
-  }
-  edge_label_count <- integer(if (!is.null(cyto_edges)) nrow(cyto_edges) else 0L)
-  if (!is.null(cyto_edges) && nrow(cyto_edges) > 0 && nrow(matched_steps) > 0) {
-    # Only label high/medium confidence steps to reduce clutter
-    ms_ord <- matched_steps[matched_steps$rank >= 2L, , drop = FALSE]
-    ms_ord <- ms_ord[order(-ms_ord$rank, ms_ord$pathway_id, ms_ord$step_id), , drop = FALSE]
-    for (mi in seq_len(nrow(ms_ord))) {
-      ms <- ms_ord[mi, , drop = FALSE]
-      key <- paste(ms$step_id, ms$locus_tag, sep = "::")
-      if (key %in% shown_route_keys) next
-      # Also skip if this locus_tag was already shown (different step, same gene)
-      if (ms$locus_tag %in% sub("^.*::", "", shown_route_keys)) next
+  # Map labels require an exact, directed (pathway, step) -> reaction-edge
+  # mapping. There is intentionally no nearest-node or pathway-level fallback.
+  route_label_df <- .dnmb_cct_exact_step_labels(
+    step_evidence = matched_steps,
+    cyto_edges = cyto_edges
+  )
+  if (!nrow(route_label_df)) route_label_df <- NULL
 
-      tgt_nodes <- .dnmb_cct_step_target_nodes(ms$step_id, ms$pathway_id)
-      hint_nodes <- unique(c(
-        tgt_nodes,
-        .dnmb_cct_pathway_hint_nodes(
-          path_ids = ms$pathway_id,
-          matched_steps = ms,
-          transporters = transporters,
-          entry_map = entry_map
-        )
+  # The ledger is deliberately broader than the map: every high/medium
+  # intracellular hit remains reviewable even when no displayed edge can
+  # localize it without ambiguity.
+  ledger_hits <- matched_steps[
+    !is.na(matched_steps$locus_tag) & nzchar(matched_steps$locus_tag) &
+      matched_steps$rank >= 2L,
+    , drop = FALSE
+  ]
+  if (nrow(ledger_hits)) {
+    localized_matches <- .dnmb_cct_exact_step_edge_matches(
+      step_evidence = ledger_hits,
+      cyto_edges = cyto_edges
+    )
+    localized_keys <- if (nrow(localized_matches)) {
+      unique(paste(
+        localized_matches$.path_step_key,
+        localized_matches$locus_tag,
+        sep = "\r"
       ))
-      cand_idx <- integer(0)
-      if (length(hint_nodes) > 0) {
-        cand_idx <- which(cyto_edges$from %in% hint_nodes | cyto_edges$to %in% hint_nodes)
+    } else {
+      character()
+    }
+    ledger_hits$.path_step_key <- .dnmb_cct_path_step_key(
+      ledger_hits$pathway_id, ledger_hits$step_id
+    )
+    ledger_hits$.localized <- paste(
+      ledger_hits$.path_step_key, ledger_hits$locus_tag, sep = "\r"
+    ) %in% localized_keys
+    metabolic_loci <- sort(unique(as.character(ledger_hits$locus_tag)))
+    product_col <- .dnmb_pick_column(genbank_table, c("product", "description"))
+    metabolic_product_map <- if (!is.null(product_col) && "locus_tag" %in% names(genbank_table)) {
+      stats::setNames(as.character(genbank_table[[product_col]]), genbank_table$locus_tag)
+    } else {
+      character()
+    }
+    metabolic_ledger_df <- dplyr::bind_rows(lapply(metabolic_loci, function(locus) {
+      rows <- ledger_hits[ledger_hits$locus_tag == locus, , drop = FALSE]
+      steps <- unique(as.character(rows$step_id))
+      pathways <- unique(as.character(rows$pathway_id))
+      steps <- steps[!is.na(steps) & nzchar(steps)]
+      pathways <- pathways[!is.na(pathways) & nzchar(pathways)]
+      product <- unname(metabolic_product_map[locus])
+      if (is.na(product) || !nzchar(product)) product <- "Product not annotated"
+      evidence <- if (any(rows$confidence == "high" | rows$rank >= 3L)) {
+        "high confidence"
+      } else {
+        "medium confidence"
       }
-      if (length(cand_idx) == 0) {
-        cand_idx <- which(cyto_edges$pathway %in% c(
-          .dnmb_cct_route_group_for_pathway(ms$pathway_id, route_group_members),
-          "ppp", "ed", "backbone"
-        ))
-      }
-      if (length(cand_idx) == 0) next
-
-      score_edge <- function(ii) {
-        ce <- cyto_edges[ii, , drop = FALSE]
-        score <- 0
-        if (ce$to %in% tgt_nodes) score <- score + 3
-        if (ce$from %in% tgt_nodes) score <- score + 2
-        if (ce$to %in% hint_nodes || ce$from %in% hint_nodes) score <- score + 1
-        if (ce$pathway == .dnmb_cct_route_group_for_pathway(ms$pathway_id, route_group_members)) score <- score + 0.8
-        score - 0.05 * edge_label_count[ii]
-      }
-      edge_scores <- vapply(cand_idx, score_edge, numeric(1))
-      best_idx <- cand_idx[which.max(edge_scores)]
-      edge_label_count[best_idx] <- edge_label_count[best_idx] + 1L
-      if (edge_label_count[best_idx] > 2L) next  # max 2 labels per edge
-      ce <- cyto_edges[best_idx, , drop = FALSE]
-      edge_pts <- .dnmb_cct_edge_points_from_row(ce, edge_idx = best_idx, grid_step = glyco_grid_step)
-      if (is.null(edge_pts) || nrow(edge_pts) == 0) next
-      tgt_node <- if (length(tgt_nodes) > 0) tgt_nodes[1] else ce$to
-      edge_sugar <- unname(node_sugar_type[tgt_node])
-      if (is.na(edge_sugar) || !nzchar(edge_sugar) || edge_sugar == "intermediate") {
-        edge_sugar <- unname(node_sugar_type[ce$to])
-      }
-      # Place label at midpoint of the edge (between two metabolites)
-      path_idx <- .dnmb_cct_route_label_index(
-        edge_pts,
-        frac = 0.50 + 0.15 * (edge_label_count[best_idx] - 1L)
-      )
-      path_mid <- edge_pts[path_idx, , drop = FALSE]
-      route_label_rows[[length(route_label_rows) + 1L]] <- data.frame(
-        x = path_mid$x + 0.12,
-        y = path_mid$y,
-        label = paste0(.dnmb_cct_short_step_label(ms$step_id, ms$pathway_id), "\n", ms$locus_tag),
-        step_id = ms$step_id,
-        locus_tag = ms$locus_tag,
-        color = route_color_for(path_ids = ms$pathway_id, sugar_type = edge_sugar, fallback = "#8C8C8C"),
-        target_id = tgt_node,
-        target_rank = edge_label_count[best_idx],
-        priority = 8 + ms$rank,
-        angle = 0,
+      data.frame(
+        locus_tag = locus,
+        evidence_label = evidence,
+        ledger_text = paste0(
+          locus, " | Product: ", product,
+          " | GapMind intracellular steps: ", paste(steps, collapse = " | "),
+          " | Supported pathways: ", paste(pathways, collapse = " | "),
+          " | Evidence: ", evidence,
+          " | Map localization: ",
+          if (any(rows$.localized)) "exact directed reaction edge" else "ledger only"
+        ),
         stringsAsFactors = FALSE
       )
-      shown_route_keys <- c(shown_route_keys, key)
-    }
-  }
-
-  # Route labels (gene/locus_tag) are deferred to render LAST — see below after metabolite labels
-  if (length(route_label_rows) > 0) {
-    route_label_df <- do.call(rbind, route_label_rows)
-    route_label_df <- route_label_df[order(-route_label_df$priority), , drop = FALSE]
-    route_label_df <- route_label_df[!duplicated(route_label_df$locus_tag), , drop = FALSE]
-    center_ref <- stats::median(backbone_nodes$x, na.rm = TRUE)
-    route_label_df$priority <- route_label_df$priority -
-      2.1 * pmax(0, 1.6 - abs(route_label_df$x - center_ref))
-    route_label_df <- .dnmb_cct_layout_route_labels(route_label_df, center_x = center_ref)
+    }))
   } else {
-    route_label_df <- NULL
+    metabolic_ledger_df <- NULL
   }
 
   # ---- Final extracellular symbol overlay: keep polymer/branch nodes above route lines ----
+  extra_obstacle_rows <- list()
   for (ri in seq_len(n_extra)) {
     sub <- extra_substrates[ri, , drop = FALSE]
     ry <- extra_y_map[sub$id]
@@ -7598,6 +11151,10 @@
     chain <- extra_chains[[sub$id]]
     if (length(chain) > 0) {
       chain_xs <- chain_x + (seq_along(chain) - 1) * chain_step
+      extra_obstacle_rows[[length(extra_obstacle_rows) + 1L]] <- .dnmb_cct_obstacle_perimeter(
+        x = chain_xs, y = rep(ry, length(chain_xs)),
+        rx = sym_size * 1.15, ry = sym_size * 1.15
+      )
       for (ci in seq_along(chain)) {
         sug <- chain[[ci]]
         abbr <- .dnmb_snfg_abbreviation_v2(sug)
@@ -7615,6 +11172,9 @@
           gap = chain_gap
         )
         br_y <- ry - sym_size * (2.5 + 1.4 * (bi - 1))
+        extra_obstacle_rows[[length(extra_obstacle_rows) + 1L]] <- .dnmb_cct_obstacle_perimeter(
+          x = br_x, y = br_y, rx = sym_size * 1.15, ry = sym_size * 1.15
+        )
         abbr_br <- .dnmb_snfg_abbreviation_v2(br$sugar)
         p <- .dnmb_snfg_render_symbol_v2(p, br_x, br_y, br$sugar, r = sym_size, label = abbr_br)
       }
@@ -7626,37 +11186,92 @@
     mid <- mono_ids[mi]
     mx <- mono_xs[mi]
     abbr <- .dnmb_snfg_abbreviation_v2(mid)
-    p <- .dnmb_snfg_render_symbol_v2(p, mx, y_mono, mid, r = 0.10, label = abbr)
+    mono_st <- unname(mono_to_sugar[mid])
+    mono_paths <- if (!is.na(mono_st)) {
+      tolower(carbon_src$id[carbon_src$sugar_type == mono_st])
+    } else {
+      tolower(unname(mono_to_csid[mid]))
+    }
+    p <- .dnmb_snfg_render_symbol_v2(
+      p, mx, y_mono, mid, r = sugar_icon_r, label = abbr,
+      alpha = pathway_alpha_for(mono_paths, zone = "node")
+    )
   }
 
   for (st in names(hub_positions)) {
     hp <- hub_positions[[st]]
-    abbr <- .dnmb_snfg_abbreviation_v2(st)
-    p <- .dnmb_snfg_render_symbol_v2(p, hp$x, hp$y, st, r = 0.10, label = abbr)
+    if (!isTRUE(hp$source_at_hub)) {
+      abbr <- .dnmb_snfg_abbreviation_v2(st)
+      p <- .dnmb_snfg_render_symbol_v2(
+        p, hp$x, hp$y, st, r = sugar_icon_r, label = abbr,
+        alpha = hp$alpha %||% 0.22
+      )
+    }
+  }
+
+  # Draw every cytoplasmic source after all route lines. Source abbreviations
+  # are embedded in their glyphs, including composite disaccharide symbols.
+  for (i in seq_len(nrow(carbon_src))) {
+    nd <- carbon_src[i, , drop = FALSE]
+    p <- .dnmb_cct_render_carbon_source_node(
+      p, nd$x, nd$y, nd$id, r = sugar_icon_r,
+      alpha = pathway_alpha_for(tolower(nd$id), zone = "node")
+    )
   }
 
   for (ntype in c("backbone", "ppp", "entry_intermediate", "tca", "tca_shunt", "ed", "pyruvate_branch")) {
     nset <- cyto_nodes[cyto_nodes$type == ntype, , drop = FALSE]
     for (i in seq_len(nrow(nset))) {
       nd <- nset[i, , drop = FALSE]
-      # Symbol only — full name labels are rendered below
-      p <- .dnmb_snfg_render_symbol_v2(p, nd$x, nd$y, nd$sugar_type, r = node_r, label = NULL)
+      inside_label <- .dnmb_cct_cytoplasmic_inside_label(
+        nd$id, nd$label, nd$type, nd$sugar_type
+      )
+      node_alpha_i <- unname(cyto_node_alpha[nd$id])
+      if (!is.finite(node_alpha_i)) node_alpha_i <- 0.22
+      p <- .dnmb_snfg_render_symbol_v2(
+        p, nd$x, nd$y, nd$sugar_type, r = node_r,
+        label = if (nzchar(inside_label)) inside_label else NULL,
+        alpha = node_alpha_i
+      )
     }
   }
 
-  # ---- Metabolite labels: unified bold style, rendered LAST (above all symbols) ----
+  # Cleavage marks are annotations, so draw them only after every route and
+  # extracellular symbol. This keeps the blades, handles, and pivot visible.
+  scissor_df <- if (length(scissor_specs)) dplyr::bind_rows(scissor_specs) else data.frame()
+  if (nrow(scissor_df)) {
+    for (i in seq_len(nrow(scissor_df))) {
+      scissor_layers <- .dnmb_scissors_grob_v2(
+        scissor_df$x[i], scissor_df$y[i],
+        size = scissor_df$size[i], angle = scissor_df$angle[i]
+      )
+      for (layer in scissor_layers) p <- p + layer
+    }
+  }
+
+  # ---- External labels for non-sugar metabolites only ----
   all_metab_labels <- data.frame(
     x = numeric(0), y = numeric(0), label = character(0),
     nudge_x = numeric(0), nudge_y = numeric(0),
+    alpha = numeric(0),
     stringsAsFactors = FALSE
   )
-  # All cytoplasmic metabolites: unified style
+  # Sugar and sugar-phosphate abbreviations are already inside their glyphs.
   for (ntype in c("backbone", "ppp", "entry_intermediate", "ed", "pyruvate_branch")) {
     nset <- cyto_nodes[cyto_nodes$type == ntype, , drop = FALSE]
+    if (nrow(nset) > 0) {
+      inside_labels <- mapply(
+        .dnmb_cct_cytoplasmic_inside_label,
+        nset$id, nset$label, nset$type, nset$sugar_type,
+        USE.NAMES = FALSE
+      )
+      nset <- nset[!nzchar(inside_labels), , drop = FALSE]
+    }
     if (nrow(nset) > 0) {
       all_metab_labels <- rbind(all_metab_labels, data.frame(
         x = nset$x, y = nset$y, label = nset$label,
         nudge_x = 0, nudge_y = 0.16,
+        alpha = unname(cyto_node_alpha[nset$id]),
         stringsAsFactors = FALSE
       ))
     }
@@ -7674,6 +11289,7 @@
       all_metab_labels <- rbind(all_metab_labels, data.frame(
         x = tca_ring$x, y = tca_ring$y, label = tca_ring$label,
         nudge_x = tca_ring$ux * 0.20, nudge_y = tca_ring$uy * 0.20,
+        alpha = unname(cyto_node_alpha[tca_ring$id]),
         stringsAsFactors = FALSE
       ))
     }
@@ -7685,84 +11301,158 @@
       label = tca_shunt_nodes$label,
       nudge_x = 0,
       nudge_y = 0,
+      alpha = unname(cyto_node_alpha[tca_shunt_nodes$id]),
       stringsAsFactors = FALSE
     ))
   }
-  # Single unified ggrepel layer — bold, size 1.3, dark gray
-  if (nrow(all_metab_labels) > 0) {
-    p <- p + ggrepel::geom_text_repel(
-      data = all_metab_labels,
-      ggplot2::aes(x = .data$x, y = .data$y, label = .data$label),
-      size = 1.3, fontface = "bold", color = "#333333",
-      nudge_x = all_metab_labels$nudge_x,
-      nudge_y = all_metab_labels$nudge_y,
-      segment.size = 0.12, segment.color = "#CCCCCC",
-      segment.alpha = 0.3,
-      box.padding = 0.06, point.padding = 0.04,
-      min.segment.length = 0.12,
-      max.overlaps = 60,
-      force = 1.2, force_pull = 2.5,
-      max.iter = 5000,
-      seed = 42,
+  if (nrow(all_metab_labels)) {
+    all_metab_labels$color <- "#333333"
+    all_metab_labels$size <- 1.50
+    all_metab_labels$fontface <- "bold"
+    all_metab_labels$hjust <- 0.5
+    all_metab_labels$priority <- 20
+  }
+
+  extra_label_df <- dplyr::bind_rows(
+    extra_label_rows,
+    if (!is.null(gh_label_df)) list(gh_label_df) else list()
+  )
+  extra_label_df <- .dnmb_cct_layout_external_labels(
+    extra_label_df,
+    xlim = c(mem_xmin, mem_xmax),
+    row_step = 0.15,
+    max_aux_rows = 2L,
+    min_gap = 0.08
+  )
+  cyto_label_df <- dplyr::bind_rows(all_metab_labels, route_label_df)
+
+  extra_obstacles <- dplyr::bind_rows(
+    extra_obstacle_rows,
+    .dnmb_cct_obstacle_perimeter(
+      x = mono_xs, y = rep(y_mono, length(mono_xs)), rx = 0.12, ry = 0.12
+    ),
+    if (nrow(scissor_df)) {
+      .dnmb_cct_obstacle_perimeter(
+        x = scissor_df$x, y = scissor_df$y,
+        rx = scissor_df$size * 1.25, ry = scissor_df$size * 0.75
+      )
+    } else NULL
+  )
+  membrane_obstacles <- if (!is.null(transporter_entities_df) &&
+      nrow(transporter_entities_df) &&
+      all(c("anchor_x", "anchor_y", "seg_half") %in% names(transporter_entities_df))) {
+    .dnmb_cct_obstacle_perimeter(
+      x = transporter_entities_df$anchor_x,
+      y = transporter_entities_df$anchor_y,
+      rx = pmax(0.12, transporter_entities_df$seg_half + 0.03), ry = 0.10
+    )
+  } else {
+    data.frame(x = numeric(), y = numeric())
+  }
+  hub_obstacles <- dplyr::bind_rows(lapply(hub_positions, function(hp) {
+    .dnmb_cct_obstacle_perimeter(hp$x, hp$y, rx = 0.12, ry = 0.12)
+  }))
+  cyto_obstacles <- dplyr::bind_rows(
+    .dnmb_cct_obstacle_perimeter(cyto_nodes$x, cyto_nodes$y, rx = 0.12, ry = 0.12),
+    .dnmb_cct_obstacle_perimeter(carbon_src$x, carbon_src$y, rx = 0.12, ry = 0.12),
+    hub_obstacles
+  )
+
+  extra_leader_df <- .dnmb_cct_external_label_leaders(extra_label_df)
+  if (nrow(extra_leader_df)) {
+    p <- p + ggplot2::geom_path(
+      data = extra_leader_df,
+      ggplot2::aes(
+        x = .data$x, y = .data$y, group = .data$group
+      ),
+      color = extra_leader_df$color,
+      linewidth = 0.12, alpha = 0.52, lineend = "round",
+      show.legend = FALSE, inherit.aes = FALSE
+    )
+  }
+  if (nrow(extra_label_df)) {
+    p <- p + ggplot2::geom_text(
+      data = extra_label_df,
+      ggplot2::aes(x = .data$x_lab, y = .data$y_lab, label = .data$label),
+      color = extra_label_df$color,
+      size = extra_label_df$size,
+      fontface = extra_label_df$fontface,
+      hjust = extra_label_df$hjust,
+      alpha = if ("alpha" %in% names(extra_label_df)) extra_label_df$alpha else 1,
+      lineheight = 0.9,
+      check_overlap = FALSE,
       inherit.aes = FALSE
     )
   }
 
-  # ---- Route labels (gene/locus_tag): rendered LAST, above all symbols and metabolite labels ----
-  if (!is.null(route_label_df) && nrow(route_label_df) > 0) {
-    # Thin connector segments from label to anchor point
-    conn_df <- route_label_df[abs(route_label_df$x_lab - route_label_df$x) > 0.08 |
-                               abs(route_label_df$y_lab - route_label_df$y) > 0.08, , drop = FALSE]
-    if (nrow(conn_df) > 0) {
-      p <- p + ggplot2::geom_segment(
-        data = conn_df,
-        ggplot2::aes(x = .data$x, y = .data$y, xend = .data$x_lab, yend = .data$y_lab),
-        linewidth = 0.10, color = "#BBBBBB", alpha = 0.4,
-        inherit.aes = FALSE
-      )
-    }
-    p <- p + ggplot2::geom_text(
-      data = route_label_df,
-      ggplot2::aes(x = .data$x_lab, y = .data$y_lab, label = .data$label),
-      size = 0.72, color = "#111111",
-      fontface = "bold", hjust = route_label_df$hjust,
-      angle = 0,
-      lineheight = 0.85, inherit.aes = FALSE
+  transporter_label_df <- .dnmb_cct_layout_transporter_labels(
+    transporter_label_df,
+    xlim = c(mem_xmin, mem_xmax),
+    y_memb = y_memb,
+    base_offset = 0.26,
+    track_step = 0.11,
+    max_aux_tracks = 2L,
+    min_gap = 0.08
+  )
+  transporter_leader_df <- .dnmb_cct_transporter_label_leaders(
+    transporter_label_df
+  )
+  if (nrow(transporter_leader_df)) {
+    p <- p + ggplot2::geom_path(
+      data = transporter_leader_df,
+      ggplot2::aes(x = .data$x, y = .data$y, group = .data$group),
+      color = transporter_leader_df$color,
+      linewidth = 0.12, alpha = 0.58, lineend = "round",
+      show.legend = FALSE, inherit.aes = FALSE
     )
   }
+  membrane_text_layer <- .dnmb_cct_transporter_text_layer(transporter_label_df)
+  if (!is.null(membrane_text_layer)) p <- p + membrane_text_layer
+
+  cyto_text_layer <- .dnmb_cct_final_text_layer(
+    cyto_label_df,
+    obstacles = cyto_obstacles,
+    xlim = c(mem_xmin, mem_xmax),
+    ylim = c(y_bot - 0.40, y_memb - 0.28),
+    seed = 44L,
+    force = 1.35,
+    force_pull = 2.5
+  )
+  if (!is.null(cyto_text_layer)) p <- p + cyto_text_layer
 
   # ====================================================================
   # LEGENDS
   # ====================================================================
-  p <- p + ggplot2::scale_color_manual(
-    name = "Pathway\nCompleteness",
-    values = c(high = "#2CA25F", medium = "#FEC44F", low = "#F03B20", none = "#CCCCCC"),
-    labels = c(high = "High (\u226575%)", medium = "Medium (50-74%)",
-               low = "Low (<50%)", none = "Not found"),
-    drop = FALSE)
-
-  # SNFG legend — compact, RIGHT side, aligned with TCA circle height
-  snfg_leg <- data.frame(
-    sugar = c("glucose", "galactose", "mannose", "fructose", "glcnac",
-              "fucose", "rhamnose", "xylose", "arabinose", "glca", "gala", "ribose"),
-    label = c("Glc", "Gal", "Man", "Fru", "GlcNAc", "Fuc", "Rha", "Xyl",
-              "Ara", "GlcA", "GalA", "Rib"),
-    stringsAsFactors = FALSE, row.names = NULL)
+  # Build the legend from every sugar type actually rendered in this map.
+  used_snfg_types <- .dnmb_cct_used_snfg_types(
+    cyto_nodes = cyto_nodes,
+    source_ids = carbon_src$id,
+    monomer_ids = mono_ids,
+    extra_chains = extra_chains,
+    extra_branches = extra_branches
+  )
+  snfg_leg <- .dnmb_cct_snfg_legend_data(used_snfg_types)
+  snfg_legend_width <- max(1.02, 0.052 * max(nchar(snfg_leg$label)) + 0.36)
   # Pull the legend into the unused lower-right interior space.
   leg_x <- max(cyto_nodes$x) - 0.28
   # y aligned slightly above the TCA circle center so the block sits tighter.
   tca_cy_leg <- if (nrow(tca_nodes) > 0) mean(tca_nodes$y) + 0.20 else 0.7
-  sp <- 0.19
+  sp <- max(
+    if (nrow(snfg_leg) > 14L) 0.165 else 0.19,
+    sugar_icon_r * 2.35
+  )
   n_snfg <- nrow(snfg_leg)
   leg_y_top <- tca_cy_leg + (n_snfg / 2) * sp
   p <- p + ggplot2::annotate("text", x = leg_x, y = leg_y_top + 0.22,
     hjust = 0, size = 1.9, fontface = "bold", color = "#333333",
-    label = "SNFG Symbols")
+    label = "SNFG / sugar symbols")
   for (i in seq_len(n_snfg)) {
     ly <- leg_y_top - (i - 1) * sp
-    p <- .dnmb_snfg_render_symbol_v2(p, leg_x, ly, snfg_leg$sugar[i], r = 0.08)
+    p <- .dnmb_snfg_render_symbol_v2(
+      p, leg_x, ly, snfg_leg$sugar[i], r = sugar_icon_r
+    )
     p <- p + ggplot2::annotate("text", x = leg_x + 0.19, y = ly,
-      label = snfg_leg$label[i], hjust = 0, size = 1.7, color = "#555555")
+      label = snfg_leg$label[i], hjust = 0, size = 1.35, color = "#555555")
   }
   # Bond legend below SNFG
   bleg_y <- leg_y_top - n_snfg * sp - 0.15
@@ -7781,11 +11471,65 @@
     ggplot2::annotate("text", x = leg_x + 0.33, y = bleg_y - sp,
       label = "\u03b2 bond", hjust = 0, size = 1.45, color = "#555555")
   # Scissors
-  sc_ly <- .dnmb_scissors_grob_v2(leg_x + 0.09, bleg_y - 2 * sp, size = 0.09)
+  sc_ly <- .dnmb_scissors_grob_v2(leg_x + 0.09, bleg_y - 2 * sp, size = 0.10)
   for (l in sc_ly) p <- p + l
   p <- p + ggplot2::annotate("text", x = leg_x + 0.33, y = bleg_y - 2 * sp,
     label = "GH cleavage", hjust = 0, size = 1.45, color = "#555555")
   enz_leg_y <- bleg_y - 3 * sp
+  p <- p + ggplot2::annotate(
+    "text", x = leg_x, y = enz_leg_y,
+    label = "Pathway evidence", hjust = 0, size = 1.75,
+    fontface = "bold", color = "#333333"
+  )
+  evidence_legend <- data.frame(
+    y = enz_leg_y - sp * seq_len(3),
+    color = c("#2A7F62", "#7F8C8D", "#B8B8B8"),
+    alpha = c(0.85, 0.55, 0.25),
+    linewidth = c(0.75, 0.55, 0.35),
+    linetype = c("solid", "dashed", "solid"),
+    label = c("Supported pathway", "Partial evidence", "Reference / not supported"),
+    stringsAsFactors = FALSE
+  )
+  for (i in seq_len(nrow(evidence_legend))) {
+    ev <- evidence_legend[i, , drop = FALSE]
+    p <- p + ggplot2::geom_segment(
+      data = data.frame(
+        x = leg_x, xend = leg_x + 0.24,
+        y = ev$y, yend = ev$y
+      ),
+      ggplot2::aes(x = .data$x, xend = .data$xend, y = .data$y, yend = .data$yend),
+      color = ev$color, alpha = ev$alpha, linewidth = ev$linewidth,
+      linetype = ev$linetype, inherit.aes = FALSE
+    ) + ggplot2::annotate(
+      "text", x = leg_x + 0.33, y = ev$y,
+      label = ev$label, hjust = 0, size = 1.35, color = "#555555"
+    )
+  }
+
+  # Central-carbon loci are written beside the supported reaction itself.
+  # This final overlay keeps them readable without a separate lookup panel.
+  if (nrow(core_direct_label_df)) {
+    direct_colors <- vapply(
+      core_direct_label_df$status, core_state_color, character(1)
+    )
+    direct_alpha <- pmax(
+      0.55,
+      vapply(core_direct_label_df$status, core_state_alpha, numeric(1))
+    )
+    p <- p + ggplot2::geom_text(
+      data = core_direct_label_df,
+      ggplot2::aes(x = .data$x, y = .data$y, label = .data$label),
+      hjust = core_direct_label_df$hjust,
+      vjust = core_direct_label_df$vjust,
+      size = core_direct_label_df$size,
+      color = direct_colors,
+      alpha = direct_alpha,
+      lineheight = 0.90,
+      fontface = "plain",
+      inherit.aes = FALSE,
+      show.legend = FALSE
+    )
+  }
 
   # ====================================================================
   # THEME & OUTPUT
@@ -7793,21 +11537,152 @@
   y_bottom <- y_bot - 0.5
   y_top_plot <- max(extra_top_actual + 0.55, max(cyto_nodes$y) + 1.15)
   x_left <- mem_xmin - 0.05
-  x_right <- max(mem_xmax + 0.10, leg_x + 1.02)
+  x_right <- max(zone_label_x + 1.30, leg_x + snfg_legend_width)
+
+  core_ledger_df <- core_steps[core_steps$status != "reference", , drop = FALSE]
+  if (nrow(core_ledger_df)) {
+    core_ledger_df$ledger_text <- paste0(
+      core_ledger_df$reaction_label,
+      " | Components/loci: ", core_ledger_df$components,
+      " | Products: ", core_ledger_df$product_evidence,
+      " | Status: ", core_ledger_df$status,
+      " | Evidence: conservative gene/product/EC/KO annotation agreement"
+    )
+  }
+  evidence_ledger_df <- dplyr::bind_rows(
+    if (!is.null(transporter_ledger_df) && nrow(transporter_ledger_df)) {
+      data.frame(
+        ledger_text = transporter_ledger_df$ledger_text,
+        ledger_type = "Transporter",
+        ledger_priority = ifelse(
+          transporter_ledger_df$confidence == "high",
+          ifelse(transporter_ledger_df$shared, 4.0, 3.5),
+          ifelse(transporter_ledger_df$shared, 3.0, 2.5)
+        ),
+        ledger_color = ifelse(
+          transporter_ledger_df$confidence == "high", "#102A43", "#52616B"
+        ),
+        ledger_fontface = ifelse(
+          transporter_ledger_df$confidence == "high", "bold", "plain"
+        ),
+        stringsAsFactors = FALSE
+      )
+    } else NULL,
+    if (!is.null(gh_ledger_df) && nrow(gh_ledger_df)) {
+      data.frame(
+        ledger_text = gh_ledger_df$ledger_text,
+        ledger_type = "GH cleavage",
+        ledger_priority = 1.5,
+        ledger_color = "#9B1C1C",
+        ledger_fontface = "plain",
+        stringsAsFactors = FALSE
+      )
+    } else NULL,
+    if (!is.null(metabolic_ledger_df) && nrow(metabolic_ledger_df)) {
+      data.frame(
+        ledger_text = metabolic_ledger_df$ledger_text,
+        ledger_type = "Intracellular",
+        ledger_priority = ifelse(
+          metabolic_ledger_df$evidence_label == "high confidence", 2.0, 1.0
+        ),
+        ledger_color = "#214E3A",
+        ledger_fontface = ifelse(
+          metabolic_ledger_df$evidence_label == "high confidence", "bold", "plain"
+        ),
+        stringsAsFactors = FALSE
+      )
+    } else NULL,
+    if (nrow(core_ledger_df)) {
+      data.frame(
+        ledger_text = core_ledger_df$ledger_text,
+        ledger_type = "Core metabolism",
+        ledger_priority = ifelse(core_ledger_df$status == "active", 2.75, 1.75),
+        ledger_color = vapply(core_ledger_df$status, core_state_color, character(1)),
+        ledger_fontface = ifelse(core_ledger_df$status == "active", "bold", "plain"),
+        stringsAsFactors = FALSE
+      )
+    } else NULL
+  )
+  if (nrow(evidence_ledger_df)) {
+    map_y_bottom <- y_bottom
+    max_rows_per_block <- 24L
+    n_blocks <- ceiling(nrow(evidence_ledger_df) / max_rows_per_block)
+    rows_per_block <- ceiling(nrow(evidence_ledger_df) / n_blocks)
+    evidence_ledger_df$block <- rep(
+      seq_len(n_blocks), each = rows_per_block,
+      length.out = nrow(evidence_ledger_df)
+    )
+    evidence_ledger_df$row_in_block <- ave(
+      seq_len(nrow(evidence_ledger_df)),
+      evidence_ledger_df$block,
+      FUN = seq_along
+    )
+    ledger_x0 <- x_left + 0.30
+    block_width <- (x_right - x_left - 0.60) / n_blocks
+    wrap_chars <- max(60L, floor(block_width / 0.075))
+    evidence_ledger_df$wrapped_text <- vapply(
+      evidence_ledger_df$ledger_text,
+      function(value) paste(strwrap(value, width = wrap_chars), collapse = "\n"),
+      character(1)
+    )
+    evidence_ledger_df$n_lines <- pmax(
+      1L,
+      lengths(strsplit(evidence_ledger_df$wrapped_text, "\n", fixed = TRUE))
+    )
+    evidence_ledger_df$x <- ledger_x0 +
+      (evidence_ledger_df$block - 1L) * block_width
+    ledger_y_title <- map_y_bottom - 0.55
+    ledger_y_top <- ledger_y_title - 0.72
+    evidence_ledger_df$y <- NA_real_
+    ledger_bottom <- ledger_y_top
+    for (block_id in seq_len(n_blocks)) {
+      idx <- which(evidence_ledger_df$block == block_id)
+      row_height <- 0.25 * evidence_ledger_df$n_lines[idx] + 0.20
+      row_bottom <- ledger_y_top - cumsum(row_height)
+      evidence_ledger_df$y[idx] <- row_bottom + row_height / 2
+      ledger_bottom <- min(ledger_bottom, min(row_bottom))
+    }
+    y_bottom <- ledger_bottom - 0.45
+    p <- p + ggplot2::annotate(
+      "text",
+      x = ledger_x0, y = ledger_y_title,
+      label = "Full functional evidence",
+      hjust = 0, size = 2.5,
+      fontface = "bold", color = "#243B53"
+    ) + ggplot2::annotate(
+      "text",
+      x = ledger_x0, y = ledger_y_title - 0.28,
+      label = paste0(
+        "T-ID = membrane transporter locus; G-ID = extracellular GH locus; ",
+        "intracellular and central-carbon genes are labeled beside reactions; ",
+        "all retained evidence is listed below"
+      ),
+      hjust = 0, size = 1.55, color = "#607D8B"
+    ) + ggplot2::geom_text(
+      data = evidence_ledger_df,
+      ggplot2::aes(x = .data$x, y = .data$y, label = .data$wrapped_text),
+      hjust = 0, vjust = 0.5, size = 1.55,
+      color = evidence_ledger_df$ledger_color,
+      fontface = evidence_ledger_df$ledger_fontface,
+      lineheight = 0.95, inherit.aes = FALSE
+    )
+  }
   x_span <- max(1, x_right - x_left)
   y_span <- max(1, y_top_plot - y_bottom)
   n_active <- length(cs_ids_ordered)
-  # Derive dimensions from coordinate span to match coord_fixed(ratio=1)
-  scale_factor <- 0.78
-  plot_height <- max(15.5, min(40, y_span * scale_factor))
+  # Match the device to the fixed-coordinate content so the one-page map does
+  # not retain the large blank band created by the former square minimum.
+  unit_in <- 0.82
+  plot_height <- max(10, min(24, y_span * unit_in + 0.9))
   min_width <- max(8, 5 + n_active * 0.55)
-  plot_width <- max(min_width, min(40, x_span * scale_factor + 0.9))
+  plot_width <- max(min_width, min(30, x_span * unit_in + 0.9))
 
   p <- p +
     ggplot2::coord_fixed(ratio = 1,
-      xlim = c(x_left, x_right), ylim = c(y_bottom, y_top_plot), clip = "off") +
+      xlim = c(x_left, x_right), ylim = c(y_bottom, y_top_plot),
+      expand = FALSE, clip = "off") +
     ggplot2::labs(
-      title = "CAZy Carbon Transport Map (3-Zone)",
+      title = "CAZy Carbon Transport Map",
       subtitle = paste0(
         "Extracellular: SNFG glycan chains + GH cleavage | ",
         "Membrane: transporters | Cytoplasm: grid metabolism")) +
@@ -7831,7 +11706,11 @@
 
   plot_dir <- .dnmb_module_plot_dir(output_dir)
   pdf_path <- file.path(plot_dir, paste0(file_stub, ".pdf"))
-  .dnmb_module_plot_save(p, pdf_path, width = plot_width, height = plot_height)
+  .dnmb_module_plot_save(
+    p, pdf_path,
+    width = plot_width, height = plot_height,
+    device = grDevices::cairo_pdf
+  )
   list(pdf = pdf_path)
 }
 
@@ -7862,6 +11741,8 @@
     xylose = "Xu-5-P", arabinose = "Xu-5-P",
     # → Ribose → R-5-P (PPP)
     ribose = "R-5-P",
+    # → 2-deoxyribose-5-P → GA3P + acetaldehyde
+    deoxyribose = "GA3P",
     # → Gluconate → 6-PG (PPP)
     gluconate = "6-PG",
     # → Glycerol → DHAP
@@ -7894,6 +11775,7 @@
     xylose      = list(c("Xylulose", "xylose", "xylA"), c("Xu-5-P", "xylose", "xylB")),
     arabinose   = list(c("Ribulose", "arabinose", "araA"), c("Ribulose-5-P", "arabinose", "araB"), c("Xu-5-P", "xylose", "araD")),
     ribose      = list(c("R-5-P", "ribose", "rbsK")),
+    deoxyribose = list(c("Deoxyribose-5-P", "deoxyribose", "deoK")),
     gluconate   = list(c("6-PG", "gluconate", "gntK")),
     glycerol    = list(c("Glycerol-3-P", "glycerol", "glpK")),
     fucose      = list(c("Fuculose", "fucose", "fucI"), c("Fuculose-1-P", "fucose", "fucK")),

--- a/R/plot_dbcan.R
+++ b/R/plot_dbcan.R
@@ -1,335 +1,824 @@
-.dnmb_plot_dbcan_module <- function(genbank_table, output_dir) {
+.dnmb_dbcan_plot_palette <- function() {
+  c(
+    CAZyme = "#087F8C",
+    TC = "#D97706",
+    TF = "#7C3AED",
+    STP = "#DC2626",
+    Sulfatase = "#2563EB",
+    Peptidase = "#C026D3",
+    other = "#9CA3AF",
+    null = "#E5E7EB"
+  )
+}
+
+.dnmb_dbcan_class_palette <- function() {
+  c(
+    GH = "#0072B2",
+    GT = "#009E73",
+    CE = "#D55E00",
+    PL = "#CC79A7",
+    AA = "#E69F00",
+    CBM = "#56B4E9",
+    other = "#7A7A7A"
+  )
+}
+
+.dnmb_dbcan_evidence_palette <- function() {
+  c(
+    very_high = "#0B4F6C",
+    high = "#2A7F9E",
+    medium = "#74A9CF",
+    low = "#F2B134",
+    audit = "#D95F59",
+    legacy = "#A0A0A0"
+  )
+}
+
+.dnmb_dbcan_plot_text <- function(x, max_chars = 78L) {
+  x <- as.character(x)
+  x[is.na(x)] <- ""
+  long <- nchar(x) > max_chars
+  x[long] <- paste0(substr(x[long], 1L, max_chars - 3L), "...")
+  x
+}
+
+.dnmb_dbcan_expand_plot_families <- function(tbl, family_col) {
+  if (is.null(family_col) || !family_col %in% names(tbl) || !nrow(tbl)) {
+    return(tibble::tibble())
+  }
+  rows <- lapply(seq_len(nrow(tbl)), function(i) {
+    families <- .dnmb_dbcan_family_tokens(tbl[[family_col]][[i]])
+    if (!length(families)) return(NULL)
+    data.frame(
+      dbcan_gene_row = if ("dbcan_gene_row" %in% names(tbl)) tbl$dbcan_gene_row[[i]] else i,
+      locus_tag = if ("locus_tag" %in% names(tbl)) as.character(tbl$locus_tag[[i]]) else NA_character_,
+      family = families,
+      class = sub("^([A-Za-z]+).*$", "\\1", families),
+      evidence_tier = if ("dbcan_evidence_tier" %in% names(tbl)) as.character(tbl$dbcan_evidence_tier[[i]]) else "legacy",
+      substrate = if ("dbcan_resolved_substrate" %in% names(tbl)) as.character(tbl$dbcan_resolved_substrate[[i]]) else NA_character_,
+      substrate_source = if ("dbcan_substrate_source" %in% names(tbl)) as.character(tbl$dbcan_substrate_source[[i]]) else NA_character_,
+      stringsAsFactors = FALSE
+    )
+  })
+  out <- tibble::as_tibble(dplyr::bind_rows(rows))
+  if (!nrow(out)) return(out)
+  out$class[!out$class %in% c("GH", "GT", "CE", "PL", "AA", "CBM")] <- "other"
+  out$evidence_tier[is.na(out$evidence_tier) | !nzchar(out$evidence_tier)] <- "legacy"
+  out$substrate[is.na(out$substrate) | !nzchar(out$substrate)] <- "unknown"
+  out$substrate_source[is.na(out$substrate_source) | !nzchar(out$substrate_source)] <- "legacy"
+  out$evidence_tier <- factor(out$evidence_tier, levels = c("very_high", "high", "medium", "low", "audit", "legacy"))
+  out$class <- factor(out$class, levels = c("GH", "GT", "CE", "PL", "AA", "CBM", "other"))
+  unique(out)
+}
+
+.dnmb_dbcan_read_plot_inputs <- function(genbank_table, output_dir) {
   tbl <- as.data.frame(genbank_table, stringsAsFactors = FALSE)
+  if (!nrow(tbl)) return(list(genes = tbl, cgc = data.frame(), domains = data.frame()))
+  row_col <- .dnmb_pick_column(tbl, c("dbCAN_dbcan_gene_row", "dbcan_gene_row"))
+  tbl$dbcan_gene_row <- if (!is.null(row_col)) {
+    suppressWarnings(as.integer(tbl[[row_col]]))
+  } else {
+    seq_len(nrow(tbl))
+  }
+
+  family_col <- .dnmb_pick_column(
+    tbl,
+    c(
+      "dbCAN_dbcan_all_families",
+      "dbCAN_dbcan_hit",
+      "dbCAN_family_id",
+      "dbcan_all_families",
+      "dbcan_hit",
+      "family_id"
+    )
+  )
+  evidence_col <- .dnmb_pick_column(tbl, c("dbCAN_dbcan_evidence_tier", "dbcan_evidence_tier"))
+  substrate_source_col <- .dnmb_pick_column(
+    tbl,
+    c("dbCAN_dbcan_substrate_source", "dbcan_substrate_source")
+  )
+  substrate_candidates <- c(
+    "dbCAN_substrate_label",
+    "dbCAN_dbcan_pul_substrate",
+    "dbCAN_dbcan_sub_substrate",
+    "dbCAN_dbcan_overview_substrate",
+    "substrate_label",
+    "dbcan_pul_substrate",
+    "dbcan_sub_substrate",
+    "dbcan_overview_substrate"
+  )
+  substrate_candidates <- substrate_candidates[substrate_candidates %in% names(tbl)]
+
+  tbl$dbcan_all_families <- if (!is.null(family_col)) as.character(tbl[[family_col]]) else rep(NA_character_, nrow(tbl))
+  tbl$dbcan_evidence_tier <- if (!is.null(evidence_col)) as.character(tbl[[evidence_col]]) else rep("legacy", nrow(tbl))
+  tbl$dbcan_substrate_source <- if (!is.null(substrate_source_col)) {
+    as.character(tbl[[substrate_source_col]])
+  } else {
+    rep(NA_character_, nrow(tbl))
+  }
+  tbl$dbcan_resolved_substrate <- rep(NA_character_, nrow(tbl))
+  source_by_column <- c(
+    dbCAN_dbcan_pul_substrate = "dbCAN-PUL",
+    dbCAN_dbcan_sub_substrate = "dbCAN-sub",
+    dbCAN_dbcan_overview_substrate = "overview",
+    dbcan_pul_substrate = "dbCAN-PUL",
+    dbcan_sub_substrate = "dbCAN-sub",
+    dbcan_overview_substrate = "overview"
+  )
+  for (column_name in substrate_candidates) {
+    value <- as.character(tbl[[column_name]])
+    take <- (is.na(tbl$dbcan_resolved_substrate) | !nzchar(tbl$dbcan_resolved_substrate)) &
+      !is.na(value) & nzchar(value) & value != "-"
+    tbl$dbcan_resolved_substrate[take] <- value[take]
+    inferred_source <- unname(source_by_column[column_name])
+    if (!length(inferred_source) || is.na(inferred_source) || !nzchar(inferred_source)) {
+      inferred_source <- "legacy"
+    }
+    source_missing <- is.na(tbl$dbcan_substrate_source) | !nzchar(tbl$dbcan_substrate_source)
+    tbl$dbcan_substrate_source[take & source_missing] <- inferred_source
+  }
+
+  unique_match <- function(target, source) {
+    target <- .dnmb_dbcan_clean_query_id(target)
+    source <- .dnmb_dbcan_clean_query_id(source)
+    source_unique <- !duplicated(source) & !duplicated(source, fromLast = TRUE) & !is.na(source)
+    target_unique <- !duplicated(target) & !duplicated(target, fromLast = TRUE) & !is.na(target)
+    out <- match(target, ifelse(source_unique, source, NA_character_))
+    out[!target_unique] <- NA_integer_
+    out
+  }
+  id_map_path <- file.path(output_dir, "dnmb_module_dbcan", "dbcan_gene_id_map.tsv")
+  id_map <- if (file.exists(id_map_path)) {
+    tryCatch(utils::read.delim(id_map_path, stringsAsFactors = FALSE, check.names = FALSE), error = function(e) NULL)
+  } else NULL
+
+  overview_path <- file.path(output_dir, "dnmb_module_dbcan", "run_dbcan", "overview.tsv")
+  if (file.exists(overview_path)) {
+    overview <- dnmb_dbcan_parse_overview(overview_path, id_map = id_map)
+    idx <- rep(NA_integer_, nrow(tbl))
+    if ("dbcan_gene_row" %in% names(overview) && any(!is.na(overview$dbcan_gene_row)) &&
+        any(!is.na(tbl$dbcan_gene_row))) {
+      idx <- match(tbl$dbcan_gene_row, suppressWarnings(as.integer(overview$dbcan_gene_row)))
+    } else {
+      idx <- unique_match(tbl$locus_tag, overview$query)
+      if ("protein_id" %in% names(tbl)) {
+        unresolved <- is.na(idx)
+        idx[unresolved] <- unique_match(tbl$protein_id, overview$query)[unresolved]
+      }
+    }
+    mapped <- !is.na(idx)
+    tbl$dbcan_all_families[mapped] <- overview$dbcan_all_families[idx[mapped]]
+    tbl$dbcan_evidence_tier[mapped] <- overview$dbcan_evidence_tier[idx[mapped]]
+    overview_substrate <- overview$dbcan_overview_substrate[idx]
+    fill_substrate <- mapped & (
+      is.na(tbl$dbcan_resolved_substrate) | !nzchar(tbl$dbcan_resolved_substrate) |
+        tbl$dbcan_substrate_source == "family_prior"
+    ) &
+      !is.na(overview_substrate) & nzchar(overview_substrate)
+    tbl$dbcan_resolved_substrate[fill_substrate] <- overview_substrate[fill_substrate]
+    tbl$dbcan_substrate_source[fill_substrate] <- "overview"
+  }
+
+  tbl$dbcan_evidence_tier[is.na(tbl$dbcan_evidence_tier) | !nzchar(tbl$dbcan_evidence_tier)] <- "legacy"
+  tbl$dbcan_resolved_substrate <- vapply(
+    tbl$dbcan_resolved_substrate,
+    .dnmb_dbcan_normalize_substrate,
+    character(1)
+  )
+  tbl$dbcan_substrate_source[
+    is.na(tbl$dbcan_substrate_source) | !nzchar(tbl$dbcan_substrate_source)
+  ] <- "legacy"
+
+  contig_key_col <- .dnmb_pick_column(tbl, c("dbCAN_dbcan_contig_key", "dbcan_contig_key"))
+  if (!is.null(contig_key_col)) {
+    tbl$dbcan_contig_key <- as.character(tbl[[contig_key_col]])
+  } else if ("contig_number" %in% names(tbl)) {
+    number <- suppressWarnings(as.integer(tbl$contig_number))
+    tbl$dbcan_contig_key <- ifelse(is.na(number), as.character(tbl$contig), sprintf("replicon_%04d", number))
+  } else {
+    tbl$dbcan_contig_key <- as.character(tbl$contig)
+  }
+  tbl$dbcan_contig_key[is.na(tbl$dbcan_contig_key) | !nzchar(tbl$dbcan_contig_key)] <- "unknown_replicon"
 
   cgc_id_col <- .dnmb_pick_column(tbl, c("dbCAN_dbcan_cgc_id", "dbCAN_cgc_id", "dbcan_cgc_id"))
   cgc_type_col <- .dnmb_pick_column(tbl, c("dbCAN_dbcan_cgc_gene_type", "dbCAN_cgc_gene_type", "dbcan_cgc_gene_type"))
+  cgc_family_col <- .dnmb_pick_column(tbl, c("dbCAN_dbcan_cgc_protein_family", "dbCAN_cgc_protein_family", "dbcan_cgc_protein_family"))
 
-  if (is.null(cgc_id_col) || is.null(cgc_type_col)) {
+  if (!is.null(cgc_id_col) && !is.null(cgc_type_col)) {
+    cgc <- tbl
+    cgc$dbcan_cgc_id <- as.character(cgc[[cgc_id_col]])
+    cgc$dbcan_cgc_gene_type <- as.character(cgc[[cgc_type_col]])
+    cgc$dbcan_cgc_protein_family <- if (!is.null(cgc_family_col)) as.character(cgc[[cgc_family_col]]) else NA_character_
+    cgc <- cgc[!is.na(cgc$dbcan_cgc_id) & nzchar(cgc$dbcan_cgc_id), , drop = FALSE]
+  } else {
     cgc_path <- file.path(output_dir, "dnmb_module_dbcan", "run_dbcan", "cgc_standard_out.tsv")
-    if (!file.exists(cgc_path) || file.info(cgc_path)$size < 100) {
-      stop("dbCAN plot: no CGC data found — neither in genbank_table columns ",
-           "nor in dnmb_module_dbcan/run_dbcan/cgc_standard_out.tsv.",
-           call. = FALSE)
-    }
-    cgc_raw <- utils::read.delim(cgc_path, sep = "\t", header = TRUE,
-                                  stringsAsFactors = FALSE, check.names = FALSE)
-    if (!nrow(cgc_raw)) {
-      stop("dbCAN plot: cgc_standard_out.tsv exists but has no data rows.",
-           call. = FALSE)
-    }
-    col_map <- c("Protein ID" = "locus_tag", "CGC#" = "cgc_num",
-                 "Contig ID" = "contig", "Gene Type" = "dbcan_cgc_gene_type",
-                 "Gene Start" = "start", "Gene Stop" = "end",
-                 "Gene Strand" = "direction", "Gene Annotation" = "dbcan_cgc_protein_family")
-    for (old in names(col_map)) {
-      if (old %in% names(cgc_raw)) names(cgc_raw)[names(cgc_raw) == old] <- col_map[old]
-    }
-    cgc_raw$start <- suppressWarnings(as.numeric(cgc_raw$start))
-    cgc_raw$end <- suppressWarnings(as.numeric(cgc_raw$end))
-    cgc_raw <- cgc_raw[!is.na(cgc_raw$start) & !is.na(cgc_raw$end), , drop = FALSE]
-    if ("contig" %in% names(cgc_raw) && "cgc_num" %in% names(cgc_raw)) {
-      cgc_raw$dbcan_cgc_id <- paste(cgc_raw$contig, cgc_raw$cgc_num, sep = "|")
-    }
-    family_col <- .dnmb_pick_column(tbl, c("dbCAN_family_id", "family_id"))
-    if (!is.null(family_col) && "locus_tag" %in% names(cgc_raw)) {
-      fam_map <- stats::setNames(as.character(tbl[[family_col]]), tbl$locus_tag)
-      cgc_raw$dbCAN_family_id <- unname(fam_map[cgc_raw$locus_tag])
-    } else {
-      cgc_raw$dbCAN_family_id <- NA_character_
-    }
-    cgc_raw$dbcan_pul_substrate <- NA_character_
-    substrate_path <- file.path(output_dir, "dnmb_module_dbcan", "run_dbcan", "substrate_prediction.tsv")
-    if (file.exists(substrate_path) && isTRUE(file.info(substrate_path)$size > 0)) {
-      substrate <- tryCatch(
-        dnmb_dbcan_parse_substrate_table(substrate_path),
-        error = function(e) NULL
-      )
-      if (is.data.frame(substrate) && nrow(substrate) && "dbcan_cgc_id" %in% names(substrate)) {
-        substrate <- as.data.frame(substrate, stringsAsFactors = FALSE)
-        resolved_substrate <- substrate$dbcan_pul_substrate
-        if ("dbcan_sub_substrate" %in% names(substrate)) {
-          resolved_substrate <- ifelse(
-            is.na(resolved_substrate) | !nzchar(resolved_substrate),
-            substrate$dbcan_sub_substrate,
-            resolved_substrate
+    cgc <- data.frame()
+    if (file.exists(cgc_path)) {
+      cgc_raw <- tryCatch(dnmb_dbcan_parse_cgc_standard(cgc_path), error = function(e) NULL)
+      if (is.data.frame(cgc_raw) && nrow(cgc_raw)) {
+        if (is.data.frame(id_map) && nrow(id_map)) {
+          contig_keys <- unique(as.character(id_map$dbcan_contig_key))
+          contig_map <- tibble::tibble(
+            contig = contig_keys,
+            safe_contig = paste0("ctg", seq_along(contig_keys))
           )
+          cgc_raw <- .dnmb_dbcan_restore_cgc_ids(cgc_raw, contig_map)
+          cgc_raw <- .dnmb_dbcan_restore_query_map(cgc_raw, id_map)
         }
-        substrate_map <- stats::setNames(resolved_substrate, substrate$dbcan_cgc_id)
-        cgc_raw$dbcan_pul_substrate <- unname(substrate_map[cgc_raw$dbcan_cgc_id])
+        if ("dbcan_gene_row" %in% names(cgc_raw) && any(!is.na(cgc_raw$dbcan_gene_row))) {
+          idx <- match(suppressWarnings(as.integer(cgc_raw$dbcan_gene_row)), tbl$dbcan_gene_row)
+        } else {
+          idx <- match(unique_match(cgc_raw$query, tbl$locus_tag), seq_len(nrow(tbl)))
+          if ("protein_id" %in% names(tbl)) {
+            unresolved <- is.na(idx)
+            idx[unresolved] <- match(
+              unique_match(cgc_raw$query, tbl$protein_id)[unresolved],
+              seq_len(nrow(tbl))
+            )
+          }
+        }
+        keep <- !is.na(idx)
+        cgc <- tbl[idx[keep], , drop = FALSE]
+        cgc$dbcan_cgc_id <- as.character(cgc_raw$dbcan_cgc_id[keep])
+        cgc$dbcan_cgc_gene_type <- as.character(cgc_raw$dbcan_cgc_gene_type[keep])
+        cgc$dbcan_cgc_protein_family <- as.character(cgc_raw$dbcan_cgc_protein_family[keep])
       }
     }
-    tbl <- cgc_raw[!is.na(cgc_raw$dbcan_cgc_id) & nzchar(cgc_raw$dbcan_cgc_id), , drop = FALSE]
-  } else {
-    cgc_family_col <- .dnmb_pick_column(tbl, c("dbCAN_dbcan_cgc_protein_family", "dbCAN_cgc_protein_family", "dbcan_cgc_protein_family"))
-    substrate_col <- .dnmb_pick_column(tbl, c("dbCAN_dbcan_pul_substrate", "dbCAN_pul_substrate", "dbcan_pul_substrate"))
-    family_col <- .dnmb_pick_column(tbl, c("dbCAN_family_id", "family_id"))
-    tbl$start <- suppressWarnings(as.numeric(tbl$start))
-    tbl$end <- suppressWarnings(as.numeric(tbl$end))
-    tbl <- tbl[!is.na(tbl$start) & !is.na(tbl$end), , drop = FALSE]
-    tbl$dbcan_cgc_id <- as.character(tbl[[cgc_id_col]])
-    tbl$dbcan_cgc_gene_type <- as.character(tbl[[cgc_type_col]])
-    tbl$dbcan_cgc_protein_family <- if (!is.null(cgc_family_col)) as.character(tbl[[cgc_family_col]]) else NA_character_
-    tbl$dbcan_pul_substrate <- if (!is.null(substrate_col)) as.character(tbl[[substrate_col]]) else NA_character_
-    tbl$dbCAN_family_id <- if (!is.null(family_col)) as.character(tbl[[family_col]]) else NA_character_
-    tbl <- tbl[!is.na(tbl$dbcan_cgc_id) & nzchar(tbl$dbcan_cgc_id), , drop = FALSE]
   }
 
-  if (!nrow(tbl)) {
-    stop("dbCAN plot: no CGC data to plot.", call. = FALSE)
+  if (nrow(cgc)) {
+    type <- trimws(as.character(cgc$dbcan_cgc_gene_type))
+    type[tolower(type) %in% c("prodoric", "tf")] <- "TF"
+    type[tolower(type) == "cazyme"] <- "CAZyme"
+    type[tolower(type) == "tc"] <- "TC"
+    type[tolower(type) == "stp"] <- "STP"
+    type[tolower(type) == "sulfatase"] <- "Sulfatase"
+    type[tolower(type) == "peptidase"] <- "Peptidase"
+    type[tolower(type) %in% c("", "na", "null")] <- "null"
+    type[!type %in% names(.dnmb_dbcan_plot_palette())] <- "other"
+    cgc$gene_type <- type
+    cgc$start <- suppressWarnings(as.numeric(cgc$start))
+    cgc$end <- suppressWarnings(as.numeric(cgc$end))
+    cgc <- cgc[is.finite(cgc$start) & is.finite(cgc$end), , drop = FALSE]
   }
 
-  known_types <- c("CAZyme", "TC", "TF", "STP")
-  tbl$gene_type <- ifelse(
-    is.na(tbl$dbcan_cgc_gene_type) | !nzchar(tbl$dbcan_cgc_gene_type) |
-      !tbl$dbcan_cgc_gene_type %in% known_types,
-    "other", tbl$dbcan_cgc_gene_type
+  cazy <- tbl[!is.na(tbl$dbcan_all_families) & nzchar(tbl$dbcan_all_families), , drop = FALSE]
+  cazy$start <- suppressWarnings(as.numeric(cazy$start))
+  cazy$end <- suppressWarnings(as.numeric(cazy$end))
+  cazy <- cazy[is.finite(cazy$start) & is.finite(cazy$end), , drop = FALSE]
+  cazy$primary_family <- vapply(
+    cazy$dbcan_all_families,
+    function(value) .dnmb_dbcan_primary_family(.dnmb_dbcan_family_tokens(value)),
+    character(1)
   )
-
-  type_palette <- c(
-    CAZyme = "#0F766E",
-    TC     = "#D97706",
-    TF     = "#7C3AED",
-    STP    = "#DC2626",
-    other  = "#9CA3AF"
-  )
-
-  # --- Build CGC summary ---
-  cgc_summary <- tbl |>
-    dplyr::group_by(.data$dbcan_cgc_id) |>
-    dplyr::summarise(
-      contig = dplyr::first(.data$contig),
-      n_genes = dplyr::n(),
-      n_cazyme = sum(.data$gene_type == "CAZyme", na.rm = TRUE),
-      cazyme_families = paste(
-        sort(unique(stats::na.omit(.data$dbCAN_family_id[.data$gene_type == "CAZyme"]))),
-        collapse = ", "
-      ),
-      substrate = dplyr::first(stats::na.omit(.data$dbcan_pul_substrate)),
-      start = min(.data$start, na.rm = TRUE),
-      end = max(.data$end, na.rm = TRUE),
-      gene_types = paste(sort(unique(.data$gene_type[.data$gene_type != "other" & .data$gene_type != "null"])), collapse = "+"),
-      .groups = "drop"
-    ) |>
-    dplyr::arrange(dplyr::desc(.data$n_cazyme), dplyr::desc(.data$n_genes))
-
-  cgc_summary$short_id <- sub("^.*\\|", "", cgc_summary$dbcan_cgc_id)
-
-  # --- Panel A: Genome layout (full width, top) ---
-  contigs <- .dnmb_contig_lengths_for_plot(tbl, output_dir = output_dir)
-  hit_contigs <- unique(cgc_summary$contig)
-  contigs <- contigs[contigs$contig %in% hit_contigs, , drop = FALSE]
-
-  cgc_summary$midpoint <- (cgc_summary$start + cgc_summary$end) / 2
-  cgc_summary$has_substrate <- !is.na(cgc_summary$substrate) & nzchar(cgc_summary$substrate)
-  labeled <- cgc_summary[cgc_summary$has_substrate, , drop = FALSE]
-  labeled$cgc_label <- paste0(labeled$short_id, "\n(", labeled$substrate, ")")
-
-  contig_labels <- stats::setNames(
-    paste0(contigs$sector_label, " (", scales::label_comma()(contigs$length_bp), " bp)"),
-    contigs$contig
-  )
-  cgc_summary$contig_facet <- factor(contig_labels[cgc_summary$contig], levels = unname(contig_labels))
-  contigs$contig_facet <- factor(contig_labels[contigs$contig], levels = unname(contig_labels))
-  labeled$contig_facet <- factor(contig_labels[labeled$contig], levels = unname(contig_labels))
-
-  p_layout <- ggplot2::ggplot() +
-    ggplot2::geom_segment(
-      data = contigs,
-      ggplot2::aes(x = 0, xend = .data$length_bp, y = 0.5, yend = 0.5),
-      linewidth = 0.8, color = "grey78"
-    ) +
-    ggplot2::geom_rect(
-      data = cgc_summary,
-      ggplot2::aes(
-        xmin = .data$start, xmax = .data$end,
-        ymin = 0.46, ymax = 0.54,
-        fill = .data$n_cazyme
-      ),
-      color = "grey35", linewidth = 0.25, alpha = 0.95
-    ) +
-    ggplot2::geom_segment(
-      data = labeled,
-      ggplot2::aes(x = .data$midpoint, xend = .data$midpoint, y = 0.54, yend = 0.62),
-      linewidth = 0.3, color = "grey50"
-    ) +
-    ggplot2::geom_label(
-      data = labeled,
-      ggplot2::aes(x = .data$midpoint, y = 0.64, label = .data$cgc_label),
-      size = 2.1, label.size = 0.15, label.padding = ggplot2::unit(0.1, "lines"),
-      fill = "white", color = "grey20", fontface = "bold",
-      lineheight = 0.85, vjust = 0
-    ) +
-    ggplot2::facet_wrap(~contig_facet, ncol = 1, scales = "free_x", strip.position = "top") +
-    ggplot2::scale_fill_gradient(low = "#81C784", high = "#0F766E", name = "CAZymes") +
-    ggplot2::scale_x_continuous(labels = scales::label_comma()) +
-    ggplot2::scale_y_continuous(limits = c(0.42, 0.82), expand = c(0, 0)) +
-    ggplot2::labs(title = "A   dbCAN CGC genome layout", x = "Genome coordinate (bp)", y = NULL) +
-    ggplot2::theme_bw(base_size = 11) +
-    ggplot2::theme(
-      plot.title = ggplot2::element_text(face = "bold", size = 11),
-      plot.title.position = "plot",
-      legend.position = "bottom",
-      panel.grid.minor = ggplot2::element_blank(),
-      panel.grid.major.y = ggplot2::element_blank(),
-      axis.text.y = ggplot2::element_blank(),
-      axis.ticks.y = ggplot2::element_blank(),
-      strip.text = ggplot2::element_text(face = "bold", size = 9)
-    )
-
-  # --- Panel B: Gene arrow tracks per CGC (gggenes) ---
-  track_tbl <- tbl[, intersect(c("dbcan_cgc_id", "locus_tag", "start", "end",
-                                   "gene_type", "dbCAN_family_id", "direction",
-                                   "dbcan_pul_substrate"), names(tbl)), drop = FALSE]
-  track_tbl$short_id <- sub("^.*\\|", "", track_tbl$dbcan_cgc_id)
-  track_tbl$forward <- !grepl("complement|minus|-", as.character(track_tbl$direction), ignore.case = TRUE)
-  track_tbl$gene_label <- ifelse(
-    track_tbl$gene_type == "CAZyme" & !is.na(track_tbl$dbCAN_family_id) & nzchar(track_tbl$dbCAN_family_id),
-    as.character(track_tbl$dbCAN_family_id),
-    ""
-  )
-
-  cgc_order <- cgc_summary$short_id
-  facet_labels <- stats::setNames(
-    vapply(cgc_order, function(sid) {
-      row <- cgc_summary[cgc_summary$short_id == sid, , drop = FALSE]
-      parts <- sid
-      if (nrow(row) && nzchar(row$cazyme_families[1])) parts <- paste0(parts, " | ", row$cazyme_families[1])
-      if (nrow(row) && !is.na(row$substrate[1]) && nzchar(row$substrate[1])) parts <- paste0(parts, " | ", row$substrate[1])
-      parts
-    }, character(1)),
-    cgc_order
-  )
-  track_tbl$facet <- factor(facet_labels[track_tbl$short_id], levels = facet_labels)
-
-  # Normalize coordinates: each CGC starts at 0
-  cgc_offsets <- stats::setNames(cgc_summary$start, cgc_summary$short_id)
-  track_tbl$xmin_rel <- track_tbl$start - cgc_offsets[track_tbl$short_id]
-  track_tbl$xmax_rel <- track_tbl$end - cgc_offsets[track_tbl$short_id]
-
-  p_genes <- ggplot2::ggplot(track_tbl,
-    ggplot2::aes(xmin = .data$xmin_rel, xmax = .data$xmax_rel, y = .data$facet,
-                 fill = .data$gene_type, forward = .data$forward)) +
-    gggenes::geom_gene_arrow(
-      arrowhead_height = grid::unit(3, "mm"),
-      arrowhead_width = grid::unit(2, "mm"),
-      arrow_body_height = grid::unit(3, "mm"),
-      color = "grey30", linewidth = 0.15
-    ) +
-    ggplot2::geom_text(
-      data = track_tbl[nzchar(track_tbl$gene_label), , drop = FALSE],
-      ggplot2::aes(
-        x = (.data$xmin_rel + .data$xmax_rel) / 2, y = .data$facet,
-        label = .data$gene_label
-      ),
-      size = 1.8, color = "white", fontface = "bold",
-      inherit.aes = FALSE
-    ) +
-    ggplot2::scale_fill_manual(values = type_palette, drop = FALSE, name = "Gene type") +
-    ggplot2::scale_x_continuous(labels = function(x) paste0(round(x / 1000, 1), " kb")) +
-    gggenes::theme_genes() +
-    ggplot2::labs(
-      title = paste0("B   CGC gene structure (", nrow(cgc_summary), " clusters)"),
-      x = "Cluster size", y = NULL
-    ) +
-    ggplot2::theme(
-      plot.title = ggplot2::element_text(face = "bold", size = 11),
-      plot.title.position = "plot",
-      axis.text.y = ggplot2::element_text(size = 6),
-      legend.position = "bottom",
-      legend.key.size = ggplot2::unit(0.3, "cm"),
-      legend.text = ggplot2::element_text(size = 7),
-      legend.title = ggplot2::element_text(size = 8),
-      plot.margin = ggplot2::margin(4, 4, 4, 4)
-    )
-
-  # --- Panel C: Substrate-CAZyme family network ---
-  p_network <- .dnmb_dbcan_substrate_cazyme_plot(cgc_summary, tbl, type_palette)
-
-  # --- Composite: A top, B+C bottom side by side ---
-  plot_dir <- .dnmb_module_plot_dir(output_dir)
-  pdf_path <- file.path(plot_dir, "dbcan_cgc_overview.pdf")
-  n_contigs <- nrow(contigs)
-  n_cgc <- nrow(cgc_summary)
-
-  bottom_row <- cowplot::plot_grid(
-    p_genes, p_network,
-    ncol = 2, rel_widths = c(1.1, 0.9)
-  )
-
-  composite <- cowplot::plot_grid(
-    p_layout,
-    bottom_row,
-    ncol = 1,
-    rel_heights = c(0.20, 0.80)
-  )
-
-  page_h <- max(11, min(16, 3 + 0.22 * n_cgc))
-  .dnmb_module_plot_save(composite, pdf_path, width = 14, height = page_h)
-  list(pdf = pdf_path)
+  cazy$class <- sub("^([A-Za-z]+).*$", "\\1", cazy$primary_family)
+  cazy$class[!cazy$class %in% c("GH", "GT", "CE", "PL", "AA", "CBM")] <- "other"
+  cazy$class <- factor(cazy$class, levels = c("GH", "GT", "CE", "PL", "AA", "CBM", "other"))
+  cazy$dbcan_evidence_tier <- factor(cazy$dbcan_evidence_tier, levels = c("very_high", "high", "medium", "low", "audit", "legacy"))
+  domains <- .dnmb_dbcan_expand_plot_families(tbl, "dbcan_all_families")
+  list(genes = tbl, cazy = cazy, cgc = cgc, domains = domains)
 }
 
+.dnmb_dbcan_contig_summary <- function(tbl) {
+  if (!nrow(tbl)) return(tibble::tibble())
+  display <- if ("contig" %in% names(tbl)) as.character(tbl$contig) else tbl$dbcan_contig_key
+  data.frame(
+    dbcan_contig_key = tbl$dbcan_contig_key,
+    display = display,
+    end = suppressWarnings(as.numeric(tbl$end)),
+    stringsAsFactors = FALSE
+  ) |>
+    dplyr::group_by(.data$dbcan_contig_key) |>
+    dplyr::summarise(
+      display = dplyr::first(.data$display),
+      length_bp = max(.data$end, na.rm = TRUE),
+      .groups = "drop"
+    ) |>
+    dplyr::mutate(
+      display = ifelse(is.na(.data$display) | !nzchar(.data$display), .data$dbcan_contig_key, .data$display),
+      label = paste0(.dnmb_dbcan_plot_text(.data$display, 62L), " [", .data$dbcan_contig_key, "]")
+    )
+}
 
-# Substrate → CAZyme family alluvial / tile plot
-.dnmb_dbcan_substrate_cazyme_plot <- function(cgc_summary, tbl, type_palette) {
-  caz_genes <- tbl[tbl$gene_type == "CAZyme" & !is.na(tbl$dbCAN_family_id) & nzchar(tbl$dbCAN_family_id), , drop = FALSE]
-  if (!nrow(caz_genes)) {
-    return(ggplot2::ggplot() + ggplot2::theme_void() +
-             ggplot2::annotate("text", x = 0.5, y = 0.5, label = "No CAZyme families detected",
-                               size = 3.5, color = "grey50"))
+.dnmb_dbcan_hit_contig_groups <- function(inputs, contigs_per_page = 8L) {
+  gene_order <- unique(as.character(inputs$genes$dbcan_contig_key))
+  hit_keys <- unique(c(
+    as.character(inputs$cazy$dbcan_contig_key),
+    as.character(inputs$cgc$dbcan_contig_key)
+  ))
+  hit_keys <- hit_keys[!is.na(hit_keys) & nzchar(hit_keys)]
+  keys <- c(gene_order[gene_order %in% hit_keys], setdiff(hit_keys, gene_order))
+  if (!length(keys)) return(list())
+  n_pages <- ceiling(length(keys) / max(1L, as.integer(contigs_per_page)))
+  if (n_pages <= 1L) return(list(keys))
+  unname(split(keys, cut(seq_along(keys), breaks = n_pages, labels = FALSE)))
+}
+
+.dnmb_dbcan_summary_page <- function(inputs, contig_keys = NULL,
+                                     map_page = 1L, map_pages = 1L,
+                                     include_details = TRUE,
+                                     contig_ncol = 1L) {
+  cazy <- inputs$cazy
+  domains <- inputs$domains
+  contigs <- .dnmb_dbcan_contig_summary(inputs$genes)
+  if (!is.null(contig_keys)) {
+    contigs <- contigs[contigs$dbcan_contig_key %in% contig_keys, , drop = FALSE]
+    cazy <- cazy[cazy$dbcan_contig_key %in% contig_keys, , drop = FALSE]
+  }
+  class_palette <- .dnmb_dbcan_class_palette()
+  evidence_palette <- .dnmb_dbcan_evidence_palette()
+
+  contigs$contig_label <- factor(contigs$label, levels = contigs$label)
+  cazy$midpoint <- (cazy$start + cazy$end) / 2
+  cazy$contig_label <- factor(
+    contigs$label[match(cazy$dbcan_contig_key, contigs$dbcan_contig_key)],
+    levels = contigs$label
+  )
+  if (nrow(cazy)) {
+    cazy <- cazy[!is.na(cazy$contig_label), , drop = FALSE]
+  }
+  p_map <- ggplot2::ggplot() +
+    ggplot2::geom_segment(
+      data = contigs,
+      ggplot2::aes(x = 0, xend = .data$length_bp, y = 0, yend = 0),
+      linewidth = 0.8,
+      color = "#C7CDD4"
+    ) +
+    ggplot2::facet_wrap(
+      ~contig_label,
+      ncol = max(1L, as.integer(contig_ncol)[1L]),
+      scales = "free_x"
+    ) +
+    ggplot2::scale_x_continuous(labels = scales::label_number(scale_cut = scales::cut_short_scale())) +
+    ggplot2::scale_y_continuous(limits = c(-0.25, 0.25), breaks = NULL) +
+    ggplot2::labs(
+      title = paste0(
+        "A  Genome-wide CAZyme positions",
+        if (map_pages > 1L) paste0("  ", map_page, "/", map_pages) else ""
+      ),
+      x = "Genome coordinate",
+      y = NULL
+    ) +
+    ggplot2::theme_bw(base_size = 10) +
+    ggplot2::theme(
+      plot.title = ggplot2::element_text(face = "bold", size = 12),
+      plot.title.position = "plot",
+      strip.text = ggplot2::element_text(face = "bold", size = 8),
+      panel.grid.minor = ggplot2::element_blank(),
+      panel.grid.major.y = ggplot2::element_blank(),
+      legend.position = "bottom",
+      legend.direction = "horizontal",
+      legend.box = "horizontal",
+      legend.box.just = "center",
+      legend.key.height = grid::unit(0.28, "cm"),
+      legend.spacing.x = grid::unit(0.10, "cm"),
+      plot.margin = ggplot2::margin(5.5, 5.5, 5.5, 2)
+    )
+  if (nrow(cazy)) {
+    p_map <- p_map +
+      ggplot2::geom_rect(
+        data = cazy,
+        ggplot2::aes(xmin = .data$start, xmax = .data$end, ymin = -0.16, ymax = 0.16, fill = .data$class, alpha = .data$dbcan_evidence_tier),
+        color = "#2F3B45",
+        linewidth = 0.15
+      ) +
+      ggplot2::geom_point(
+        data = cazy,
+        ggplot2::aes(x = .data$midpoint, y = 0, fill = .data$class, alpha = .data$dbcan_evidence_tier),
+        shape = 21,
+        size = 2.2,
+        color = "#263238",
+        stroke = 0.2
+      ) +
+      ggplot2::scale_fill_manual(values = class_palette, drop = FALSE, name = "CAZy class") +
+      ggplot2::scale_alpha_manual(values = c(very_high = 1, high = 0.9, medium = 0.72, low = 0.5, audit = 0.28, legacy = 0.65), drop = FALSE, name = "Evidence") +
+      ggplot2::guides(
+        alpha = ggplot2::guide_legend(nrow = 1L, byrow = TRUE, order = 1L),
+        fill = ggplot2::guide_legend(nrow = 1L, byrow = TRUE, order = 2L)
+      )
   }
 
-  caz_genes$short_id <- sub("^.*\\|", "", caz_genes$dbcan_cgc_id)
-  sub_map <- stats::setNames(cgc_summary$substrate, cgc_summary$short_id)
-  caz_genes$substrate <- sub_map[caz_genes$short_id]
-  caz_genes$substrate <- ifelse(
-    is.na(caz_genes$substrate) | !nzchar(caz_genes$substrate),
-    "unknown", caz_genes$substrate
-  )
-
-  links <- caz_genes |>
-    dplyr::group_by(.data$substrate, .data$dbCAN_family_id) |>
-    dplyr::summarise(n = dplyr::n(), .groups = "drop") |>
-    dplyr::arrange(dplyr::desc(.data$n))
-
-  all_substrates <- unique(links$substrate)
-  all_families <- unique(links$dbCAN_family_id)
-
-  sub_pal <- stats::setNames(
-    c(grDevices::hcl.colors(max(length(all_substrates), 3), palette = "Set 2"))[seq_along(all_substrates)],
-    all_substrates
-  )
-  if ("unknown" %in% names(sub_pal)) sub_pal["unknown"] <- "#BDBDBD"
-
-  # Tile heatmap: substrate (x) vs CAZyme family (y)
-  links$substrate <- factor(links$substrate, levels = c(setdiff(all_substrates, "unknown"), "unknown"))
-  fam_order <- links |>
-    dplyr::group_by(.data$dbCAN_family_id) |>
-    dplyr::summarise(total = sum(.data$n), .groups = "drop") |>
-    dplyr::arrange(dplyr::desc(.data$total))
-  links$dbCAN_family_id <- factor(links$dbCAN_family_id, levels = rev(fam_order$dbCAN_family_id))
-
-  ggplot2::ggplot(links, ggplot2::aes(x = .data$substrate, y = .data$dbCAN_family_id)) +
-    ggplot2::geom_point(
-      ggplot2::aes(size = .data$n, fill = .data$substrate),
-      shape = 21, color = "grey30", stroke = 0.3, alpha = 0.85
-    ) +
-    ggplot2::geom_text(
-      ggplot2::aes(label = .data$n),
-      size = 2.3, color = "grey20"
-    ) +
-    ggplot2::scale_size_continuous(range = c(3, 12), name = "Genes", guide = "none") +
-    ggplot2::scale_fill_manual(values = sub_pal, name = "Substrate", guide = "none") +
-    ggplot2::labs(
-      title = "C   Substrate \u2013 CAZyme family",
-      x = NULL, y = NULL
-    ) +
-    ggplot2::theme_bw(base_size = 9) +
+  class_counts <- if (nrow(domains)) {
+    domains |>
+      dplyr::count(.data$class, .data$evidence_tier, name = "genes")
+  } else tibble::tibble(class = character(), evidence_tier = character(), genes = integer())
+  p_class <- ggplot2::ggplot(class_counts, ggplot2::aes(x = .data$class, y = .data$genes, fill = .data$evidence_tier)) +
+    ggplot2::geom_col(width = 0.72, color = "white", linewidth = 0.2) +
+    ggplot2::labs(title = "B  CAZy evidence by class", x = NULL, y = "Gene-family calls") +
+    ggplot2::theme_bw(base_size = 10) +
     ggplot2::theme(
-      plot.title = ggplot2::element_text(face = "bold", size = 11),
+      plot.title = ggplot2::element_text(face = "bold", size = 12),
+      plot.title.position = "plot",
+      legend.position = "none",
+      panel.grid.minor = ggplot2::element_blank(),
+      plot.margin = ggplot2::margin(5.5, 5.5, 5.5, 2)
+    )
+  if (nrow(class_counts)) {
+    p_class <- p_class + ggplot2::scale_fill_manual(values = evidence_palette, drop = FALSE, name = "Evidence")
+  }
+
+  substrate_counts <- if (nrow(domains)) {
+    domains |>
+      dplyr::filter(
+        .data$substrate != "unknown",
+        .data$substrate_source != "family_prior"
+      ) |>
+      tidyr::separate_rows("substrate", sep = ";\\s*") |>
+      dplyr::count(.data$substrate, name = "genes", sort = TRUE) |>
+      utils::head(15L)
+  } else tibble::tibble(substrate = character(), genes = integer())
+  if (nrow(substrate_counts)) {
+    substrate_counts$substrate <- factor(substrate_counts$substrate, levels = rev(substrate_counts$substrate))
+  }
+  p_substrate <- ggplot2::ggplot(substrate_counts, ggplot2::aes(x = .data$genes, y = .data$substrate)) +
+    ggplot2::geom_col(width = 0.68, fill = "#2A9D8F") +
+    ggplot2::geom_text(ggplot2::aes(label = .data$genes), hjust = -0.2, size = 3) +
+    ggplot2::scale_x_continuous(expand = ggplot2::expansion(mult = c(0, 0.12))) +
+    ggplot2::labs(title = "C  Supported substrates", x = "Gene-family calls", y = NULL) +
+    ggplot2::theme_bw(base_size = 10) +
+    ggplot2::theme(
+      plot.title = ggplot2::element_text(face = "bold", size = 12),
       plot.title.position = "plot",
       panel.grid.minor = ggplot2::element_blank(),
-      axis.text.x = ggplot2::element_text(angle = 45, hjust = 1, size = 8),
-      axis.text.y = ggplot2::element_text(size = 7),
-      plot.margin = ggplot2::margin(4, 8, 4, 4)
+      plot.margin = ggplot2::margin(5.5, 5.5, 5.5, 2)
     )
+
+  title <- cowplot::ggdraw() +
+    cowplot::draw_label(
+      paste0(
+        "dbCAN CAZyme/CGC overview  |  ",
+        nrow(inputs$cazy), " mapped genes  |  ",
+        length(unique(inputs$cgc$dbcan_cgc_id)), " CGCs"
+      ),
+      x = 0,
+      hjust = 0,
+      fontface = "bold",
+      size = 15
+    )
+  if (!isTRUE(include_details)) {
+    return(cowplot::plot_grid(title, p_map, ncol = 1, rel_heights = c(0.06, 0.94)))
+  }
+  bottom <- cowplot::plot_grid(p_class, p_substrate, ncol = 2, rel_widths = c(1, 1.15))
+  page <- cowplot::plot_grid(p_map, bottom, ncol = 1, rel_heights = c(0.58, 0.42))
+  cowplot::plot_grid(title, page, ncol = 1, rel_heights = c(0.06, 0.94))
+}
+
+.dnmb_dbcan_cgc_pages <- function(cgc, clusters_per_page = 12L) {
+  if (!nrow(cgc)) return(list())
+  palette <- .dnmb_dbcan_plot_palette()
+  summary <- cgc |>
+    dplyr::group_by(.data$dbcan_cgc_id) |>
+    dplyr::summarise(
+      dbcan_contig_key = dplyr::first(.data$dbcan_contig_key),
+      start = min(.data$start, na.rm = TRUE),
+      end = max(.data$end, na.rm = TRUE),
+      families = paste(sort(unique(unlist(lapply(.data$dbcan_all_families[.data$gene_type == "CAZyme"], .dnmb_dbcan_family_tokens)))), collapse = ", "),
+      substrate = dplyr::first(stats::na.omit(.data$dbcan_resolved_substrate), default = NA_character_),
+      .groups = "drop"
+    ) |>
+    dplyr::arrange(.data$dbcan_contig_key, .data$start)
+  summary$local_id <- sub("^.*\\|", "", summary$dbcan_cgc_id)
+  summary$facet_label <- paste0(summary$dbcan_contig_key, " - ", summary$local_id)
+  summary$facet_label <- ifelse(
+    nzchar(summary$families),
+    paste0(summary$facet_label, " | ", summary$families),
+    summary$facet_label
+  )
+  summary$facet_label <- ifelse(
+    !is.na(summary$substrate) & nzchar(summary$substrate),
+    paste0(summary$facet_label, " | ", summary$substrate),
+    summary$facet_label
+  )
+  summary$facet_label <- .dnmb_dbcan_plot_text(summary$facet_label, 105L)
+
+  n_pages <- ceiling(nrow(summary) / max(1L, as.integer(clusters_per_page)))
+  page_groups <- if (n_pages <= 1L) {
+    list(seq_len(nrow(summary)))
+  } else {
+    split(seq_len(nrow(summary)), cut(seq_len(nrow(summary)), breaks = n_pages, labels = FALSE))
+  }
+  lapply(seq_along(page_groups), function(page_index) {
+    selected <- summary[page_groups[[page_index]], , drop = FALSE]
+    track <- cgc[cgc$dbcan_cgc_id %in% selected$dbcan_cgc_id, , drop = FALSE]
+    track$facet_label <- selected$facet_label[match(track$dbcan_cgc_id, selected$dbcan_cgc_id)]
+    track$facet_label <- factor(track$facet_label, levels = rev(selected$facet_label))
+    offsets <- stats::setNames(selected$start, selected$dbcan_cgc_id)
+    track$xmin_rel <- track$start - offsets[track$dbcan_cgc_id]
+    track$xmax_rel <- track$end - offsets[track$dbcan_cgc_id]
+    track$forward <- !grepl("complement|minus|^-|^-1$", as.character(track$direction), ignore.case = TRUE)
+    family_label <- vapply(track$dbcan_all_families, function(value) {
+      family <- .dnmb_dbcan_family_tokens(value)
+      if (length(family)) paste(family, collapse = "/") else ""
+    }, character(1))
+    width <- abs(track$xmax_rel - track$xmin_rel)
+    track$gene_label <- ifelse(track$gene_type == "CAZyme" & width >= 450, .dnmb_dbcan_plot_text(family_label, 18L), "")
+
+    ggplot2::ggplot(
+      track,
+      ggplot2::aes(
+        xmin = .data$xmin_rel,
+        xmax = .data$xmax_rel,
+        y = .data$facet_label,
+        fill = .data$gene_type,
+        forward = .data$forward
+      )
+    ) +
+      gggenes::geom_gene_arrow(
+        arrowhead_height = grid::unit(4, "mm"),
+        arrowhead_width = grid::unit(2, "mm"),
+        arrow_body_height = grid::unit(4, "mm"),
+        color = "#334155",
+        size = 0.2
+      ) +
+      ggplot2::geom_text(
+        data = track[nzchar(track$gene_label), , drop = FALSE],
+        ggplot2::aes(x = (.data$xmin_rel + .data$xmax_rel) / 2, y = .data$facet_label, label = .data$gene_label),
+        inherit.aes = FALSE,
+        size = 2.3,
+        color = "white",
+        fontface = "bold",
+        check_overlap = TRUE
+      ) +
+      ggplot2::scale_fill_manual(values = palette, drop = FALSE, name = "Gene type") +
+      ggplot2::guides(
+        fill = ggplot2::guide_legend(nrow = 1L, byrow = TRUE)
+      ) +
+      ggplot2::scale_x_continuous(labels = function(x) paste0(round(x / 1000, 1), " kb")) +
+      gggenes::theme_genes() +
+      ggplot2::labs(
+        title = paste0(
+          "D  CGC gene context",
+          if (length(page_groups) > 1L) {
+            paste0("  ", page_index, "/", length(page_groups))
+          } else {
+            ""
+          }
+        ),
+        subtitle = "Full replicon key is retained; CAZyme labels show all mapped families",
+        x = "Coordinate relative to CGC start",
+        y = NULL
+      ) +
+      ggplot2::theme(
+        plot.title = ggplot2::element_text(face = "bold", size = 14),
+        plot.title.position = "plot",
+        plot.subtitle = ggplot2::element_text(size = 9, color = "#475569"),
+        axis.text.y = ggplot2::element_text(size = 7.2),
+        legend.position = "bottom",
+        legend.direction = "horizontal",
+        legend.box = "horizontal",
+        legend.box.just = "center",
+        legend.key.height = grid::unit(0.28, "cm"),
+        legend.key.width = grid::unit(0.50, "cm"),
+        legend.spacing.x = grid::unit(0.10, "cm"),
+        plot.margin = ggplot2::margin(8, 12, 8, 2)
+      )
+  })
+}
+
+.dnmb_dbcan_matrix_pages <- function(domains, families_per_page = 30L,
+                                     substrates_per_page = 12L,
+                                     substrate_mode = c("supported", "family_prior")) {
+  substrate_mode <- match.arg(substrate_mode)
+  if (!nrow(domains)) return(list())
+  data <- as.data.frame(domains, stringsAsFactors = FALSE)
+  if (!"substrate_source" %in% names(data)) data$substrate_source <- "legacy"
+  if (identical(substrate_mode, "family_prior")) {
+    data <- data[
+      data$substrate_source == "family_prior" & data$substrate != "unknown",
+      ,
+      drop = FALSE
+    ]
+  } else {
+    data$substrate[data$substrate_source == "family_prior"] <- "unknown"
+  }
+  if (!nrow(data)) return(list())
+
+  links <- data |>
+    tidyr::separate_rows("substrate", sep = ";\\s*") |>
+    dplyr::mutate(substrate = ifelse(is.na(.data$substrate) | !nzchar(.data$substrate), "unknown", .data$substrate)) |>
+    dplyr::count(.data$family, .data$substrate, name = "genes")
+  if (identical(substrate_mode, "family_prior")) {
+    links <- links[links$substrate != "unknown", , drop = FALSE]
+  }
+  if (!nrow(links)) return(list())
+
+  balanced_groups <- function(values, max_per_page) {
+    n_pages <- ceiling(length(values) / max(1L, as.integer(max_per_page)))
+    if (n_pages <= 1L) return(list(values))
+    unname(split(values, cut(seq_along(values), breaks = n_pages, labels = FALSE)))
+  }
+  substrate_order <- links |>
+    dplyr::group_by(.data$substrate) |>
+    dplyr::summarise(total = sum(.data$genes), .groups = "drop") |>
+    dplyr::arrange(dplyr::desc(.data$total), .data$substrate)
+  substrate_groups <- balanced_groups(substrate_order$substrate, substrates_per_page)
+  specs <- list()
+  for (substrates in substrate_groups) {
+    subset <- links[links$substrate %in% substrates, , drop = FALSE]
+    family_order <- subset |>
+      dplyr::group_by(.data$family) |>
+      dplyr::summarise(total = sum(.data$genes), .groups = "drop") |>
+      dplyr::arrange(dplyr::desc(.data$total), .data$family)
+    family_groups <- balanced_groups(family_order$family, families_per_page)
+    for (families in family_groups) {
+      specs[[length(specs) + 1L]] <- list(
+        data = subset[subset$family %in% families, , drop = FALSE],
+        families = families,
+        substrates = substrates
+      )
+    }
+  }
+
+  title_text <- if (identical(substrate_mode, "family_prior")) {
+    "F  Family-level substrate prior (hypothesis only)"
+  } else {
+    "E  Substrate-family support"
+  }
+  subtitle_text <- if (identical(substrate_mode, "family_prior")) {
+    "Broad family associations only; these are not gene-specific substrate evidence"
+  } else {
+    "PUL/dbCAN-sub/overview support; unknown has no gene- or CGC-level substrate assignment"
+  }
+  colors <- if (identical(substrate_mode, "family_prior")) {
+    c(low = "#F8D9A0", high = "#D97706")
+  } else {
+    c(low = "#BFE3DA", high = "#087F8C")
+  }
+
+  lapply(seq_along(specs), function(page_index) {
+    spec <- specs[[page_index]]
+    plot_data <- spec$data
+    plot_data$family <- factor(plot_data$family, levels = rev(spec$families))
+    plot_data$substrate <- factor(plot_data$substrate, levels = spec$substrates)
+    ggplot2::ggplot(plot_data, ggplot2::aes(x = .data$substrate, y = .data$family)) +
+      ggplot2::geom_point(ggplot2::aes(size = .data$genes, fill = .data$genes), shape = 21, color = "#334155", stroke = 0.25) +
+      ggplot2::geom_text(ggplot2::aes(label = .data$genes), size = 2.5, color = "#0F172A") +
+      ggplot2::scale_size_continuous(range = c(3, 11), guide = "none") +
+      ggplot2::scale_fill_gradient(low = colors[["low"]], high = colors[["high"]], guide = "none") +
+      ggplot2::labs(
+        title = paste0(
+          title_text,
+          if (length(specs) > 1L) {
+            paste0("  ", page_index, "/", length(specs))
+          } else {
+            ""
+          }
+        ),
+        subtitle = subtitle_text,
+        x = NULL,
+        y = NULL
+      ) +
+      ggplot2::theme_bw(base_size = 10) +
+      ggplot2::theme(
+        plot.title = ggplot2::element_text(face = "bold", size = 14),
+        plot.title.position = "plot",
+        plot.subtitle = ggplot2::element_text(size = 9, color = "#475569"),
+        axis.text.x = ggplot2::element_text(angle = 45, hjust = 1, size = 8),
+        axis.text.y = ggplot2::element_text(size = 8),
+        panel.grid.minor = ggplot2::element_blank(),
+        plot.margin = ggplot2::margin(8, 12, 12, 2)
+      )
+  })
+}
+
+.dnmb_dbcan_one_page_layout <- function(inputs) {
+  hit_groups <- .dnmb_dbcan_hit_contig_groups(
+    inputs,
+    contigs_per_page = .Machine$integer.max
+  )
+  contig_keys <- unique(unlist(hit_groups, use.names = FALSE))
+  n_contigs <- length(contig_keys)
+  contig_ncol <- if (n_contigs <= 4L) {
+    1L
+  } else if (n_contigs <= 12L) {
+    2L
+  } else {
+    3L
+  }
+  summary_plot <- .dnmb_dbcan_summary_page(
+    inputs,
+    contig_keys = contig_keys,
+    include_details = TRUE,
+    contig_ncol = contig_ncol
+  )
+
+  n_cgc <- length(unique(as.character(inputs$cgc$dbcan_cgc_id)))
+  cgc_plot <- if (n_cgc > 0L) {
+    .dnmb_dbcan_cgc_pages(
+      inputs$cgc,
+      clusters_per_page = max(1L, n_cgc)
+    )[[1L]]
+  } else {
+    NULL
+  }
+
+  matrix_plots <- c(
+    .dnmb_dbcan_matrix_pages(
+      inputs$domains,
+      families_per_page = .Machine$integer.max,
+      substrates_per_page = .Machine$integer.max,
+      substrate_mode = "supported"
+    ),
+    .dnmb_dbcan_matrix_pages(
+      inputs$domains,
+      families_per_page = .Machine$integer.max,
+      substrates_per_page = .Machine$integer.max,
+      substrate_mode = "family_prior"
+    )
+  )
+  matrix_plots <- Filter(Negate(is.null), matrix_plots)
+  matrix_rows <- if (length(matrix_plots)) {
+    vapply(matrix_plots, function(plot) {
+      if (!is.data.frame(plot$data) || !"family" %in% names(plot$data)) return(1L)
+      max(1L, length(unique(as.character(plot$data$family))))
+    }, integer(1))
+  } else {
+    integer(0)
+  }
+  matrix_plot <- if (length(matrix_plots) == 1L) {
+    matrix_plots[[1L]]
+  } else if (length(matrix_plots) > 1L) {
+    cowplot::plot_grid(
+      plotlist = matrix_plots,
+      ncol = 1L,
+      rel_heights = pmax(1, matrix_rows)
+    )
+  } else {
+    NULL
+  }
+
+  if (!is.null(cgc_plot) && !is.null(matrix_plot)) {
+    detail_plot <- cowplot::plot_grid(
+      cgc_plot, matrix_plot,
+      ncol = 2L,
+      rel_widths = c(1.55, 1)
+    )
+    page_width <- 28
+  } else if (!is.null(cgc_plot)) {
+    detail_plot <- cgc_plot
+    page_width <- 20
+  } else if (!is.null(matrix_plot)) {
+    detail_plot <- matrix_plot
+    page_width <- 18
+  } else {
+    detail_plot <- NULL
+    page_width <- 14
+  }
+
+  contig_rows <- max(1L, ceiling(max(1L, n_contigs) / contig_ncol))
+  summary_height <- max(7, 5.8 + 0.55 * max(0L, contig_rows - 2L))
+  detail_rows <- max(c(n_cgc, sum(matrix_rows), 0L))
+  detail_height <- if (is.null(detail_plot)) 0 else max(10, 2.4 + 0.21 * detail_rows)
+
+  if (is.null(detail_plot)) {
+    page_plot <- summary_plot
+    page_height <- max(9, summary_height)
+  } else {
+    page_plot <- cowplot::plot_grid(
+      summary_plot, detail_plot,
+      ncol = 1L,
+      rel_heights = c(summary_height, detail_height)
+    )
+    page_height <- summary_height + detail_height
+  }
+
+  list(
+    plot = page_plot,
+    width = page_width,
+    height = page_height,
+    n_contigs = n_contigs,
+    n_cgc = n_cgc,
+    n_matrix_rows = sum(matrix_rows)
+  )
+}
+
+.dnmb_plot_dbcan_module <- function(genbank_table, output_dir) {
+  inputs <- .dnmb_dbcan_read_plot_inputs(genbank_table, output_dir)
+  if (!nrow(inputs$cazy) && !nrow(inputs$cgc)) {
+    stop("dbCAN plot: no mapped CAZyme or CGC data found.", call. = FALSE)
+  }
+
+  layout <- .dnmb_dbcan_one_page_layout(inputs)
+  plot_dir <- .dnmb_module_plot_dir(output_dir)
+  pdf_path <- file.path(plot_dir, "dbcan_cgc_overview.pdf")
+  grDevices::cairo_pdf(
+    pdf_path,
+    width = layout$width,
+    height = layout$height,
+    onefile = FALSE
+  )
+  device_open <- TRUE
+  on.exit({
+    if (device_open) grDevices::dev.off()
+  }, add = TRUE)
+  print(layout$plot)
+  grDevices::dev.off()
+  device_open <- FALSE
+
+  list(
+    pdf = pdf_path,
+    pages = 1L,
+    width = layout$width,
+    height = layout$height
+  )
 }

--- a/R/plot_gapmind_carbon.R
+++ b/R/plot_gapmind_carbon.R
@@ -14,6 +14,32 @@
   path_col <- "GapMindCarbon_pathway_id"; step_col <- "GapMindCarbon_step_id"
   conf_col <- "GapMindCarbon_confidence"; bp_col <- "GapMindCarbon_on_best_path"
   lt_col <- "locus_tag"
+  confidence_rank <- c(none = 0L, low = 1L, medium = 2L, high = 3L)
+  score_confidence <- function(score) {
+    score <- suppressWarnings(base::as.numeric(score))
+    base::ifelse(
+      !base::is.na(score) & score >= 2, "high",
+      base::ifelse(!base::is.na(score) & score >= 1, "medium", "none")
+    )
+  }
+  clean_locus <- function(x) {
+    x <- base::trimws(base::as.character(x))
+    x[base::is.na(x) | !base::nzchar(x)] <- NA_character_
+    x
+  }
+  collapse_exact_locus <- function(x) {
+    if (!base::nrow(x)) return(x)
+    locus_key <- base::ifelse(base::is.na(x$locus_tag), "<missing>", x$locus_tag)
+    key <- base::paste(x$pathway_id, x$step_id, locus_key, sep = "\r")
+    rank <- unname(confidence_rank[x$confidence])
+    rank[base::is.na(rank)] <- 0L
+    keep_order <- base::order(key, -rank, base::seq_len(base::nrow(x)))
+    x <- x[keep_order, , drop = FALSE]
+    key <- key[keep_order]
+    x <- x[!base::duplicated(key), , drop = FALSE]
+    base::rownames(x) <- NULL
+    x
+  }
   found <- data.frame(
     pathway_id = character(),
     step_id = character(),
@@ -21,21 +47,39 @@
     locus_tag = character(),
     stringsAsFactors = FALSE
   )
-  if (path_col %in% base::names(tbl)) {
+  if (base::all(c(path_col, step_col) %in% base::names(tbl))) {
     tbl <- tbl[!is.na(tbl[[path_col]]) & base::nzchar(tbl[[path_col]]), , drop = FALSE]
     if (base::nrow(tbl)) {
       has_bp <- bp_col %in% names(tbl)
-      bp_tbl <- if (has_bp) tbl[!is.na(tbl[[bp_col]]) & tbl[[bp_col]] == TRUE, , drop = FALSE] else tbl
-      has_lt <- lt_col %in% names(bp_tbl)
-      found <- bp_tbl |>
-        dplyr::group_by(pathway_id = .data[[path_col]], step_id = .data[[step_col]]) |>
-        dplyr::summarise(
-          confidence = dplyr::case_when(
-            any(.data[[conf_col]] == "high") ~ "high",
-            any(.data[[conf_col]] == "medium") ~ "medium", TRUE ~ "low"),
-          locus_tag = if (has_lt) dplyr::first(.data[[lt_col]]) else NA_character_,
-          .groups = "drop") |>
-        as.data.frame(stringsAsFactors = FALSE)
+      if (has_bp) {
+        bp_value <- base::tolower(base::trimws(base::as.character(tbl[[bp_col]])))
+        keep_bp <- !base::is.na(bp_value) & bp_value %in% c("1", "true", "t")
+        bp_tbl <- tbl[keep_bp, , drop = FALSE]
+      } else {
+        bp_tbl <- tbl
+      }
+      if (base::nrow(bp_tbl)) {
+        workbook_confidence <- if (conf_col %in% base::names(bp_tbl)) {
+          base::tolower(base::trimws(base::as.character(bp_tbl[[conf_col]])))
+        } else if ("GapMindCarbon_step_score" %in% base::names(bp_tbl)) {
+          score_confidence(bp_tbl[["GapMindCarbon_step_score"]])
+        } else {
+          base::rep("low", base::nrow(bp_tbl))
+        }
+        workbook_confidence[!workbook_confidence %in% base::names(confidence_rank)] <- "low"
+        found <- data.frame(
+          pathway_id = base::as.character(bp_tbl[[path_col]]),
+          step_id = base::as.character(bp_tbl[[step_col]]),
+          confidence = workbook_confidence,
+          locus_tag = if (lt_col %in% base::names(bp_tbl)) {
+            clean_locus(bp_tbl[[lt_col]])
+          } else {
+            base::rep(NA_character_, base::nrow(bp_tbl))
+          },
+          stringsAsFactors = FALSE
+        )
+        found <- collapse_exact_locus(found)
+      }
     }
   }
   # Supplement from aa.sum.steps in carbon module directory
@@ -50,14 +94,36 @@
   if (!is.null(steps_file)) {
     st <- utils::read.delim(steps_file, stringsAsFactors = FALSE)
     if (all(c("onBestPath","pathway","step","score") %in% names(st))) {
-      bp_st <- st[st$onBestPath == 1 & !duplicated(st[,c("pathway","step")]), , drop = FALSE]
-      bp_st$confidence <- dplyr::case_when(bp_st$score>=2~"high", bp_st$score>=1~"medium", TRUE~"low")
-      lt_s <- if ("locusId" %in% names(bp_st)) bp_st$locusId else NA_character_
-      extra <- data.frame(pathway_id=bp_st$pathway, step_id=bp_st$step,
-                          confidence=bp_st$confidence, locus_tag=lt_s, stringsAsFactors=FALSE)
-      ekey <- paste0(extra$pathway_id,"::",extra$step_id)
-      fkey <- paste0(found$pathway_id,"::",found$step_id)
-      found <- rbind(found, extra[!ekey %in% fkey, , drop=FALSE])
+      best_path <- suppressWarnings(base::as.numeric(st$onBestPath)) == 1
+      best_path[base::is.na(best_path)] <- FALSE
+      bp_st <- st[best_path, , drop = FALSE]
+      if (base::nrow(bp_st)) {
+        primary <- data.frame(
+          pathway_id = base::as.character(bp_st$pathway),
+          step_id = base::as.character(bp_st$step),
+          confidence = score_confidence(bp_st$score),
+          locus_tag = if ("locusId" %in% names(bp_st)) {
+            clean_locus(bp_st$locusId)
+          } else {
+            base::rep(NA_character_, base::nrow(bp_st))
+          },
+          stringsAsFactors = FALSE
+        )
+        secondary <- found[0, , drop = FALSE]
+        if (base::all(c("score2", "locusId2") %in% base::names(bp_st))) {
+          score2 <- suppressWarnings(base::as.numeric(bp_st$score2))
+          locus2 <- clean_locus(bp_st$locusId2)
+          keep_secondary <- !base::is.na(score2) & score2 > 0 & !base::is.na(locus2)
+          secondary <- data.frame(
+            pathway_id = base::as.character(bp_st$pathway[keep_secondary]),
+            step_id = base::as.character(bp_st$step[keep_secondary]),
+            confidence = score_confidence(score2[keep_secondary]),
+            locus_tag = locus2[keep_secondary],
+            stringsAsFactors = FALSE
+          )
+        }
+        found <- collapse_exact_locus(base::rbind(found, primary, secondary))
+      }
     }
   }
   if (!base::nrow(found)) return(NULL)

--- a/R/run_cache.R
+++ b/R/run_cache.R
@@ -249,6 +249,17 @@
       error = function(e) list(found = FALSE)
     )
     signatures$dbCAN$run_dbcan_available <- isTRUE(run_dbcan$found)
+    signatures$dbCAN$run_dbcan_version <- if (isTRUE(run_dbcan$found)) {
+      tryCatch(.dnmb_dbcan_tool_version(), error = function(e) NA_character_)
+    } else {
+      NA_character_
+    }
+    signatures$dbCAN$run_dbcan_path <- if (isTRUE(run_dbcan$found)) {
+      normalizePath(run_dbcan$path, winslash = "/", mustWork = FALSE)
+    } else {
+      NA_character_
+    }
+    signatures$dbCAN$pipeline_contract_version <- .dnmb_dbcan_pipeline_contract_version()
   }
   if ("PAZy" %in% module_aliases) {
     signatures$PAZy <- .dnmb_db_manifest_identity("pazy", current_version, cache_root = module_cache_root)
@@ -432,7 +443,12 @@
     ),
     dbCAN = list(
       mode = "all",
-      paths = c(file.path(wd, "dnmb_module_dbcan", "run_dbcan", "overview.tsv"))
+      paths = c(
+        file.path(wd, "dnmb_module_dbcan", "dbcan_gene_id_map.tsv"),
+        file.path(wd, "dnmb_module_dbcan", "run_dbcan", "overview.tsv"),
+        file.path(wd, "dnmb_module_dbcan", "run_dbcan", "dnmb_mapped_domains.tsv"),
+        file.path(wd, "dnmb_module_dbcan", "run_dbcan", "dnmb_cazy_gene_summary.tsv")
+      )
     ),
     PAZy = list(
       mode = "all",
@@ -541,6 +557,22 @@
   if (file.exists(.dnmb_module_completion_sentinel_path(alias, wd = wd))) {
     if (identical(as.character(alias)[1], "Promotech")) {
       return(.dnmb_promotech_stage_artifacts_complete(wd = wd))
+    }
+    if (identical(as.character(alias)[1], "dbCAN")) {
+      spec <- .dnmb_module_stage_expected_artifacts(alias, wd = wd)
+      if (file.exists(file.path(wd, "dnmb_module_dbcan", "run_dbcan", "overview.tsv"))) {
+        return(all(file.exists(spec$paths)))
+      }
+      query_fasta <- file.path(wd, "dnmb_module_dbcan", "dbcan_query_proteins.faa")
+      gene_map <- file.path(wd, "dnmb_module_dbcan", "dbcan_gene_id_map.tsv")
+      if (file.exists(query_fasta) && file.exists(gene_map) &&
+          isTRUE(file.info(query_fasta)$size == 0)) {
+        return(TRUE)
+      }
+      return(all(file.exists(c(
+        gene_map,
+        file.path(wd, "dnmb_module_dbcan", "dbcan_hmmsearch.domtblout")
+      ))))
     }
     return(TRUE)
   }

--- a/R/snfg_symbols.R
+++ b/R/snfg_symbols.R
@@ -12,7 +12,8 @@
 # ---- Split diamond (upper triangle colored / lower triangle white) for SNFG uronic acids ----
 # This matches the SNFG symbol sheet: top triangle filled, bottom triangle white.
 .dnmb_snfg_split_diamond_layers <- function(cx, cy, r = 0.20, fill_color = "#0072BC",
-                                            border_color = "black", border_lw = 0.3) {
+                                            border_color = "black", border_lw = 0.3,
+                                            alpha = 1) {
   # Diamond vertices: top, right, bottom, left
   top   <- c(cx, cy + r)
   right <- c(cx + r, cy)
@@ -38,17 +39,18 @@
   list(
     ggplot2::geom_polygon(data = lower_df,
       ggplot2::aes(x = .data$x, y = .data$y),
-      fill = "white", color = NA, inherit.aes = FALSE),
+      fill = "white", color = NA, alpha = alpha, inherit.aes = FALSE),
     ggplot2::geom_polygon(data = upper_df,
       ggplot2::aes(x = .data$x, y = .data$y),
-      fill = fill_color, color = NA, inherit.aes = FALSE),
+      fill = fill_color, color = NA, alpha = alpha, inherit.aes = FALSE),
     ggplot2::geom_polygon(data = outline_df,
       ggplot2::aes(x = .data$x, y = .data$y),
-      fill = NA, color = border_color, linewidth = border_lw, inherit.aes = FALSE),
+      fill = NA, color = border_color, linewidth = border_lw, alpha = alpha,
+      inherit.aes = FALSE),
     ggplot2::annotate(
       "segment",
       x = left[1], xend = right[1], y = left[2], yend = right[2],
-      color = border_color, linewidth = border_lw
+      color = border_color, linewidth = border_lw, alpha = alpha
     )
   )
 }

--- a/tests/testthat/test-cazy-continuity-transport.R
+++ b/tests/testthat/test-cazy-continuity-transport.R
@@ -1,0 +1,87 @@
+test_that("continuity overlays retain their first explicit intracellular node", {
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  edges <- DNMB:::.dnmb_cct_3zone_cyto_edges(nodes)
+  route_groups <- list(
+    starch = c("maltose", "trehalose"),
+    xylan = c("xylose", "arabinose"),
+    deoxyribose = "deoxyribose",
+    ppp = c("xylose", "arabinose", "ribose")
+  )
+  entry_map <- DNMB:::.dnmb_cct_auto_entry_map()
+
+  expected_starts <- c(
+    maltose = "Glucose",
+    xylose = "Xylulose",
+    deoxyribose = "Deoxyribose-5-P"
+  )
+  for (pathway_id in names(expected_starts)) {
+    route <- DNMB:::.dnmb_cct_best_continuity_nodes(
+      pathway_id = pathway_id,
+      cyto_nodes = nodes,
+      cyto_edges = edges,
+      route_group_members = route_groups,
+      entry_map = entry_map,
+      matched_steps = data.frame(),
+      transporters = NULL
+    )
+    expect_gte(length(route), 2L)
+    expect_identical(unname(route[1L]), unname(expected_starts[pathway_id]))
+  }
+})
+
+test_that("an aligned transporter trunk keeps a multi-target bus connected", {
+  memberships <- data.frame(
+    cs_id = c("Deoxyribose", "Deoxyribose"),
+    lane_x = c(3, 3),
+    tx_draw = c(3, 5),
+    ty_draw = c(8.5, 8.5),
+    confidence = c("high", "high"),
+    locus_tag = c("aligned_target", "offset_target"),
+    color = c("#8A5879", "#8A5879"),
+    stringsAsFactors = FALSE
+  )
+
+  layout <- DNMB:::.dnmb_cct_transporter_bus_layout(
+    memberships, y_memb = 8.5, source_offset = 0.76
+  )
+  group_id <- layout$groups$group[1L]
+  aligned <- layout$trunks[
+    layout$trunks$group == "target:aligned_target", , drop = FALSE
+  ]
+
+  expect_false(layout$groups$direct[1L])
+  expect_false(any(layout$stems$group == group_id))
+  expect_equal(nrow(aligned), 1L)
+  expect_equal(aligned$y, 8.5 + 0.76, tolerance = 1e-10)
+  expect_lte(min(aligned$y, aligned$yend), layout$groups$bus_y[1L])
+  expect_gte(max(aligned$y, aligned$yend), layout$groups$bus_y[1L])
+})
+
+test_that("deoP is retained as deoxyribose uptake with a source glyph lane", {
+  expect_true(DNMB:::.dnmb_cct_is_transport_like_step("deoP"))
+
+  genbank <- data.frame(
+    locus_tag = "DEOP_0001",
+    gene = "deoP",
+    GapMindCarbon_pathway_id = "deoxyribose",
+    GapMindCarbon_step_id = "deoP",
+    GapMindCarbon_confidence = "high",
+    GapMindCarbon_step_score = 2,
+    stringsAsFactors = FALSE
+  )
+  transporters <- DNMB:::.dnmb_cct_3zone_extract_transporters(genbank)
+  expect_equal(nrow(transporters), 1L)
+  expect_identical(transporters$pathway, "deoxyribose")
+  expect_identical(transporters$step, "deoP")
+
+  expect_identical(
+    unname(DNMB:::.dnmb_cct_monomer_lane_map()["deoxyribose"]),
+    "deoxyribose"
+  )
+  expect_true(
+    "deoxyribose" %in% DNMB:::.dnmb_cct_extracellular_monomer_ids()
+  )
+  source_nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  source_nodes <- source_nodes[source_nodes$type == "carbon_source", , drop = FALSE]
+  expect_true("Deoxyribose" %in% source_nodes$id)
+})

--- a/tests/testthat/test-cazy-core-metabolism.R
+++ b/tests/testthat/test-cazy-core-metabolism.R
@@ -1,0 +1,404 @@
+test_that("core metabolism requires corroborated annotations and rejects common confounders", {
+  core <- data.frame(
+    locus_tag = c(
+      "core_cs", "core_acn", "core_icd", "core_odh_e1", "core_odh_e2",
+      "core_suc_d", "core_suc_c", "core_sdh_a", "core_sdh_b", "core_sdh_c",
+      "core_fum", "core_mdh", "core_ace_a", "core_ace_b",
+      "noise_prpc", "noise_prpd", "noise_leub", "noise_prpb", "noise_bsha"
+    ),
+    gene = c(
+      "gltA", "acnA", "icd", "sucA", "sucB",
+      "sucD", "sucC", "sdhA", "sdhB", "sdhC",
+      "fumB", "mdh", "aceA", "aceB",
+      "prpC", "prpD", "leuB", "prpB", "bshA"
+    ),
+    product = c(
+      "citrate synthase", "aconitate hydratase", "isocitrate dehydrogenase",
+      "2-oxoglutarate dehydrogenase E1 component",
+      "2-oxoglutarate dehydrogenase E2 dihydrolipoyl succinyltransferase",
+      "succinate--CoA ligase subunit alpha", "succinate--CoA ligase subunit beta",
+      "succinate dehydrogenase flavoprotein subunit",
+      "succinate dehydrogenase iron-sulfur subunit",
+      "succinate dehydrogenase cytochrome b subunit",
+      "fumarate hydratase", "malate dehydrogenase", "isocitrate lyase",
+      "malate synthase A", "citrate synthase", "2-methylcitrate dehydratase",
+      "isocitrate/isopropylmalate family dehydrogenase",
+      "methylisocitrate lyase", "N-acetylglucosaminyl L-malate synthase"
+    ),
+    EC_number = c(
+      "2.3.3.1", "4.2.1.3", "1.1.1.42", "1.2.4.2", "2.3.1.61",
+      "6.2.1.5", "6.2.1.5", "1.3.5.1", "1.3.5.1", "1.3.5.1",
+      "4.2.1.2", "1.1.1.37", "4.1.3.1", "2.3.3.9",
+      "2.3.3.1", "4.2.1.79", "1.1.1.41", "4.1.3.30", "2.4.1.251"
+    ),
+    EggNOG_Preferred_name = c(
+      "gltA", "acnA", "icd", "sucA", "sucB", "sucD", "sucC",
+      "sdhA", "sdhB", "sdhC", "fumB", "mdh", "aceA", "aceB",
+      "prpC", "prpD", "leuB", "prpB", "bshA"
+    ),
+    EggNOG_EC = NA_character_,
+    EggNOG_KEGG_ko = c(
+      "ko:K01647", "ko:K01681", "ko:K00031", "ko:K00164", "ko:K00658",
+      "ko:K01902", "ko:K01903", "ko:K00239", "ko:K00240", "ko:K00241",
+      "ko:K01676", "ko:K00024", "ko:K01637", "ko:K01638",
+      "ko:K01647,ko:K01659", "ko:K01720", "ko:K00030,ko:K00052",
+      "ko:K03417", "ko:K00691"
+    ),
+    EggNOG_Description = NA_character_,
+    stringsAsFactors = FALSE
+  )
+
+  result <- DNMB:::.dnmb_cct_core_metabolism_evidence(core)
+
+  core_steps <- result$steps[result$steps$pathway != "Glycolysis", , drop = FALSE]
+  expect_true(all(core_steps$status == "active"))
+  retained <- unlist(strsplit(core_steps$locus_tags, "; ", fixed = TRUE))
+  expect_false(any(grepl("^noise_", retained)))
+  expect_setequal(
+    core_steps$reaction_id,
+    sprintf("C%02d", 1:10)
+  )
+
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  labels <- DNMB:::.dnmb_cct_core_direct_labels(
+    core_steps, result$display_hits, nodes
+  )
+  expect_setequal(labels$reaction_id, sprintf("C%02d", 1:10))
+  expect_false(any(grepl("^C[0-9]{2}", labels$label)))
+  expect_match(labels$label[labels$reaction_id == "C06"], "sdhA  core_sdh_a")
+  expect_match(labels$label[labels$reaction_id == "C06"], "sdhC  core_sdh_c")
+})
+
+test_that("glycolysis reactions require specific corroborated annotations", {
+  glycolysis <- data.frame(
+    locus_tag = c(
+      "gly_glk", "gly_pgi", "gly_pfk", "gly_fba", "gly_tpi",
+      "gly_gap", "gly_pgk", "gly_gpm", "gly_eno", "gly_pyk",
+      "noise_fruk", "noise_lacd", "noise_mtnw"
+    ),
+    gene = c(
+      "glk", "pgi", "pfkA", "fbaB", "tpiA", "gapA", "pgk", "gpmI",
+      "eno", "pyk", "fruK", "lacD", "mtnW"
+    ),
+    product = c(
+      "glucokinase", "glucose-6-phosphate isomerase", "6-phosphofructokinase",
+      "class I fructose-bisphosphate aldolase", "triose-phosphate isomerase",
+      "glyceraldehyde-3-phosphate dehydrogenase", "phosphoglycerate kinase",
+      "2,3-bisphosphoglycerate-independent phosphoglycerate mutase",
+      "phosphopyruvate hydratase", "pyruvate kinase",
+      "1-phosphofructokinase", "tagatose-bisphosphate aldolase",
+      "2,3-diketo-5-methylthiopentyl-1-phosphate enolase"
+    ),
+    EC_number = c(
+      "2.7.1.2", "5.3.1.9", "2.7.1.11", "4.1.2.13", "5.3.1.1",
+      "1.2.1.12", "2.7.2.3", "5.4.2.12", "4.2.1.11", "2.7.1.40",
+      "2.7.1.56", "4.1.2.40", "5.3.2.5"
+    ),
+    EggNOG_Preferred_name = c(
+      "glk", "pgi", "pfkA", "fbaB", "tpiA", "gapA", "pgk", "gpmI",
+      "eno", "pyk", "fruK", "lacD", "mtnW"
+    ),
+    EggNOG_EC = NA_character_,
+    EggNOG_KEGG_ko = c(
+      "ko:K00845", "ko:K01810", "ko:K00850", "ko:K11645", "ko:K01803",
+      "ko:K00134", "ko:K00927", "ko:K15633", "ko:K01689", "ko:K00873",
+      "ko:K00882", "ko:K01622", "ko:K01601"
+    ),
+    EggNOG_Description = NA_character_,
+    stringsAsFactors = FALSE
+  )
+
+  result <- DNMB:::.dnmb_cct_core_metabolism_evidence(glycolysis)
+  steps <- result$steps[result$steps$pathway == "Glycolysis", , drop = FALSE]
+  expect_setequal(steps$reaction_id, sprintf("C%02d", 11:20))
+  expect_true(all(steps$status == "active"))
+  retained <- unlist(strsplit(steps$locus_tags, "; ", fixed = TRUE))
+  expect_false(any(grepl("^noise_", retained)))
+
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  labels <- DNMB:::.dnmb_cct_core_direct_labels(
+    steps, result$display_hits, nodes
+  )
+  expect_setequal(labels$reaction_id, sprintf("C%02d", 11:20))
+  expect_true(all(grepl("gly_", labels$label, fixed = TRUE)))
+  expect_false(any(grepl("^C[0-9]{2}", labels$label)))
+})
+
+test_that("the map omits the duplicate central-carbon summary shelf", {
+  plot_body <- paste(
+    deparse(body(DNMB:::.dnmb_plot_cazy_carbon_3zone_v2)),
+    collapse = "\n"
+  )
+
+  expect_false(grepl("Central carbon metabolism", plot_body, fixed = TRUE))
+  expect_false(grepl(
+    "Conservative genome-annotation support", plot_body, fixed = TRUE
+  ))
+  expect_true(grepl("core_direct_label_df", plot_body, fixed = TRUE))
+  expect_true(grepl("core_ledger_df", plot_body, fixed = TRUE))
+  expect_true(grepl("Full functional evidence", plot_body, fixed = TRUE))
+})
+
+test_that("multi-subunit core reactions remain partial when a required component is absent", {
+  partial <- data.frame(
+    locus_tag = c("odh_e1", "sdh_a", "sdh_b", "frd_a"),
+    gene = c("sucA", "sdhA", "sdhB", "frdA"),
+    product = c(
+      "2-oxoglutarate dehydrogenase E1 component",
+      "succinate dehydrogenase flavoprotein subunit",
+      "succinate dehydrogenase iron-sulfur subunit",
+      "fumarate reductase flavoprotein subunit"
+    ),
+    EC_number = c("1.2.4.2", "1.3.5.1", "1.3.5.1", "1.3.5.4"),
+    EggNOG_Preferred_name = c("sucA", "sdhA", "sdhB", "frdA"),
+    EggNOG_EC = NA_character_,
+    EggNOG_KEGG_ko = c("ko:K00164", "ko:K00239", "ko:K00240", "ko:K00244"),
+    EggNOG_Description = NA_character_,
+    stringsAsFactors = FALSE
+  )
+
+  steps <- DNMB:::.dnmb_cct_core_metabolism_evidence(partial)$steps
+  expect_identical(steps$status[steps$reaction_id == "C04"], "partial")
+  expect_identical(steps$status[steps$reaction_id == "C06"], "partial")
+})
+
+test_that("Ribose and Fucose routes have distinct biochemical semantics", {
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  nodes <- DNMB:::.dnmb_cct_merge_entry_into_mainstream(nodes)
+  nodes <- DNMB:::.dnmb_cct_resolve_grid_overlaps(nodes)
+  edges <- DNMB:::.dnmb_cct_3zone_cyto_edges(nodes)
+
+  has_edge <- function(from, to) any(edges$from == from & edges$to == to)
+  expect_true(has_edge("Ribose", "R-5-P"))
+  expect_true(has_edge("Fucose", "Fuculose"))
+  expect_true(has_edge("Fuculose", "Fuculose-1-P"))
+  expect_false(has_edge("Ribose", "Fuculose"))
+})
+
+test_that("deoxyribose has a dedicated directed mini-branch", {
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  edges <- DNMB:::.dnmb_cct_3zone_cyto_edges(nodes)
+
+  expect_true("Deoxyribose" %in% nodes$id)
+  expect_true("Deoxyribose-5-P" %in% nodes$id)
+  expect_identical(
+    nodes$sugar_type[nodes$id == "Deoxyribose"],
+    "deoxyribose"
+  )
+  has_edge <- function(from, to) {
+    any(edges$from == from & edges$to == to)
+  }
+  expect_true(has_edge("Deoxyribose", "Deoxyribose-5-P"))
+  expect_true(has_edge("Deoxyribose-5-P", "GA3P"))
+  expect_true(has_edge("Deoxyribose-5-P", "Acetaldehyde"))
+  expect_true(has_edge("Acetaldehyde", "Acetate"))
+  expect_true(has_edge("Acetate", "Acetyl-CoA"))
+})
+
+test_that("cytoplasmic disaccharide glyphs preserve component identity", {
+  components <- function(source_id) {
+    DNMB:::.dnmb_cct_carbon_source_render_spec(source_id)$sugar_type
+  }
+
+  expect_identical(components("Maltose"), c("glucose", "glucose"))
+  expect_identical(components("Cellobiose"), c("glucose", "glucose"))
+  expect_identical(components("Trehalose"), c("glucose", "glucose"))
+  expect_identical(components("Lactose"), c("galactose", "glucose"))
+  expect_identical(components("Sucrose"), c("glucose", "fructose"))
+
+  expect_identical(
+    unique(DNMB:::.dnmb_cct_carbon_source_render_spec("Cellobiose")$bond),
+    "beta"
+  )
+  expect_identical(
+    unique(DNMB:::.dnmb_cct_carbon_source_render_spec("Maltose")$bond),
+    "alpha"
+  )
+})
+
+test_that("every cytoplasmic carbon source has a registered glyph spec", {
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  source_ids <- nodes$id[nodes$type == "carbon_source"]
+  specs <- lapply(source_ids, DNMB:::.dnmb_cct_carbon_source_render_spec)
+
+  expect_true(length(source_ids) > 0L)
+  expect_true(all(vapply(specs, function(x) all(x$registered), logical(1))))
+  expect_true(all(vapply(specs, function(x) nrow(x) >= 1L, logical(1))))
+  expect_identical(DNMB:::.dnmb_snfg_abbreviation_v2("NAG"), "GlcNAc")
+  expect_identical(DNMB:::.dnmb_snfg_abbreviation_v2("deoxyribose"), "dRib")
+})
+
+test_that("exact deoxyribose mappings are case-insensitive and directed", {
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  edges <- DNMB:::.dnmb_cct_3zone_cyto_edges(nodes)
+  evidence <- data.frame(
+    pathway_id = c(
+      "DeOxYrIbOsE", "DEOXYRIBOSE", "deoxyribose",
+      "Deoxyribose", "DEOXYRIBOSE"
+    ),
+    step_id = c("DeOk", "DEOC", "adh", "ACS", "not-a-reaction"),
+    confidence = c("high", "high", "medium", "high", "high"),
+    rank = c(3L, 3L, 2L, 3L, 3L),
+    locus_tag = c("deoK_1", "deoC_1", "adh_1", "acs_1", "noise_1"),
+    stringsAsFactors = FALSE
+  )
+
+  matches <- DNMB:::.dnmb_cct_exact_step_edge_matches(evidence, edges)
+  expect_setequal(
+    unique(tolower(matches$mapped_step_id)),
+    c("deok", "deoc", "adh", "acs")
+  )
+  expect_equal(sum(tolower(matches$mapped_step_id) == "deoc"), 2L)
+  expect_false("noise_1" %in% matches$locus_tag)
+  expect_true(all(
+    paste(matches$mapped_from, matches$mapped_to, sep = "->") %in%
+      paste(edges$from, edges$to, sep = "->")
+  ))
+
+  reversed <- edges
+  idx <- reversed$from == "Acetate" & reversed$to == "Acetyl-CoA"
+  reversed$from[idx] <- "Acetyl-CoA"
+  reversed$to[idx] <- "Acetate"
+  reversed_matches <- DNMB:::.dnmb_cct_exact_step_edge_matches(
+    evidence[evidence$step_id == "ACS", , drop = FALSE], reversed
+  )
+  expect_equal(nrow(reversed_matches), 0L)
+})
+
+test_that("exact labels aggregate loci and never use arbitrary edge fallback", {
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  edges <- DNMB:::.dnmb_cct_3zone_cyto_edges(nodes)
+  evidence <- data.frame(
+    pathway_id = c("DEOXYRIBOSE", "deoxyribose", "deoxyribose", "ribose"),
+    step_id = c("deoC", "DEOC", "adh", "deoC"),
+    confidence = c("medium", "high", "medium", "high"),
+    rank = c(2L, 3L, 2L, 3L),
+    locus_tag = c("deoC_a", "deoC_b", "adh_a", "unmapped"),
+    stringsAsFactors = FALSE
+  )
+
+  labels <- DNMB:::.dnmb_cct_exact_step_labels(evidence, edges)
+  deoc <- labels[tolower(labels$step_id) == "deoc", , drop = FALSE]
+  adh <- labels[tolower(labels$step_id) == "adh", , drop = FALSE]
+  expect_equal(nrow(deoc), 1L)
+  expect_match(deoc$label, "deoC_a", fixed = TRUE)
+  expect_match(deoc$label, "deoC_b", fixed = TRUE)
+  expect_identical(deoc$color, "#007C83")
+  expect_identical(adh$color, "#B7791F")
+  expect_false(any(grepl("unmapped", labels$label, fixed = TRUE)))
+
+  unknown <- evidence[1, , drop = FALSE]
+  unknown$step_id <- "unmapped-step"
+  expect_equal(
+    nrow(DNMB:::.dnmb_cct_exact_step_labels(unknown, edges)),
+    0L
+  )
+})
+
+test_that("hub routing avoids unrelated metabolite nodes", {
+  node_x <- c(
+    "R-5-P" = 19, "Fuculose" = 22, "Fuculose-1-P" = 22,
+    "DHAP" = 9.5
+  )
+  node_y <- c(
+    "R-5-P" = 5.5, "Fuculose" = 7, "Fuculose-1-P" = 6.5,
+    "DHAP" = 5.5
+  )
+  obstacle_x <- c(node_x, Ribose = 21.75, Fucose = 22.25)
+  obstacle_y <- c(node_y, Ribose = 8, Fucose = 8)
+
+  ribose_path <- DNMB:::.dnmb_cct_points_from_start_to_nodes(
+    21.75, 8, "R-5-P", node_x, node_y,
+    obstacle_x = obstacle_x, obstacle_y = obstacle_y
+  )
+  fucose_path <- DNMB:::.dnmb_cct_points_from_start_to_nodes(
+    22.25, 8, c("Fuculose", "Fuculose-1-P", "DHAP"), node_x, node_y,
+    obstacle_x = obstacle_x, obstacle_y = obstacle_y
+  )
+
+  expect_lt(
+    DNMB:::.dnmb_cct_path_obstacle_score(ribose_path, c(22, 22), c(7, 6.5)),
+    1000
+  )
+  expect_lt(
+    DNMB:::.dnmb_cct_path_obstacle_score(fucose_path, 19, 5.5),
+    1000
+  )
+})
+
+test_that("carbon-source lanes retain their optimized quarter-grid positions", {
+  nodes <- data.frame(
+    id = c("Ribose", "Fucose", "Fuculose"),
+    x = c(21.75, 22.25, 22),
+    y = c(8, 8, 7),
+    label = c("Ribose", "Fucose", "Fuculose"),
+    type = c("carbon_source", "carbon_source", "entry_intermediate"),
+    sugar_type = c("ribose", "fucose", "fucose"),
+    stringsAsFactors = FALSE
+  )
+
+  resolved <- DNMB:::.dnmb_cct_resolve_grid_overlaps(nodes, step = 0.5)
+  expect_equal(resolved$x[resolved$id == "Ribose"], 21.75)
+  expect_equal(resolved$x[resolved$id == "Fucose"], 22.25)
+})
+
+test_that("extracellular Rha uses its own rhamnose lane and evidence state", {
+  lane_map <- DNMB:::.dnmb_cct_monomer_lane_map()
+
+  expect_identical(unname(lane_map["fucose"]), "fucose")
+  expect_identical(unname(lane_map["rhamnose"]), "rhamnose")
+  expect_false(identical(unname(lane_map["fucose"]), unname(lane_map["rhamnose"])))
+})
+
+test_that("monomer aliases are separated on deterministic half-cell lanes", {
+  preferred <- c(
+    ribose = 24.75,
+    fucose = 25.25,
+    rhamnose = 25.75,
+    glca = 26.50,
+    gala = 26.50
+  )
+
+  placed <- DNMB:::.dnmb_cct_separate_lanes(
+    preferred, min_gap = 0.5, snap_step = 0.25
+  )
+  repeated <- DNMB:::.dnmb_cct_separate_lanes(
+    preferred, min_gap = 0.5, snap_step = 0.25
+  )
+
+  expect_identical(names(placed), names(preferred))
+  expect_identical(placed, repeated)
+  expect_equal(anyDuplicated(placed), 0L)
+  expect_gte(min(diff(sort(placed))), 0.5)
+  expect_gte(abs(placed["ribose"] - placed["fucose"]), 0.5)
+  expect_gte(abs(placed["fucose"] - placed["rhamnose"]), 0.5)
+  expect_gte(abs(placed["glca"] - placed["gala"]), 0.5)
+})
+
+test_that("short pentose routes stay inside endpoint bounds without loop-back", {
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  nodes <- DNMB:::.dnmb_cct_merge_entry_into_mainstream(nodes)
+  nodes <- DNMB:::.dnmb_cct_resolve_grid_overlaps(nodes)
+  edges <- DNMB:::.dnmb_cct_3zone_cyto_edges(nodes)
+  pentose_pairs <- list(
+    c("Ru-5-P", "R-5-P"),
+    c("Ru-5-P", "Xu-5-P"),
+    c("Xu-5-P", "S-7-P"),
+    c("R-5-P", "S-7-P"),
+    c("S-7-P", "E-4-P")
+  )
+
+  for (pair in pentose_pairs) {
+    edge <- edges[edges$from == pair[1] & edges$to == pair[2], , drop = FALSE]
+    expect_equal(nrow(edge), 1L)
+    path <- DNMB:::.dnmb_cct_edge_points_from_row(edge, grid_step = 0.5)
+    expect_gte(min(path$x), min(edge$x, edge$xend) - 1e-8)
+    expect_lte(max(path$x), max(edge$x, edge$xend) + 1e-8)
+    expect_gte(min(path$y), min(edge$y, edge$yend) - 1e-8)
+    expect_lte(max(path$y), max(edge$y, edge$yend) + 1e-8)
+
+    path_length <- sum(sqrt(diff(path$x)^2 + diff(path$y)^2))
+    manhattan <- abs(edge$xend - edge$x) + abs(edge$yend - edge$y)
+    expect_lte(path_length, manhattan + 1e-8)
+  }
+})

--- a/tests/testthat/test-cazy-deoxyribose-alternatives.R
+++ b/tests/testthat/test-cazy-deoxyribose-alternatives.R
@@ -1,0 +1,106 @@
+test_that("deoxyribose acetaldehyde degradation alternatives have directed edges", {
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  edges <- DNMB:::.dnmb_cct_3zone_cyto_edges(nodes)
+  mapping <- DNMB:::.dnmb_cct_exact_step_edge_map()
+
+  expected <- data.frame(
+    step = c("adh", "acka", "pta", "acs", "ald-dh-coa"),
+    from = c("Acetaldehyde", "Acetate", "Acetyl-P", "Acetate", "Acetaldehyde"),
+    to = c("Acetate", "Acetyl-P", "Acetyl-CoA", "Acetyl-CoA", "Acetyl-CoA"),
+    stringsAsFactors = FALSE
+  )
+  for (i in seq_len(nrow(expected))) {
+    edge_present <- edges$from == expected$from[i] & edges$to == expected$to[i]
+    map_present <- tolower(mapping$pathway_id) == "deoxyribose" &
+      tolower(mapping$step_id) == expected$step[i] &
+      mapping$from == expected$from[i] & mapping$to == expected$to[i]
+    expect_true(any(edge_present), info = expected$step[i])
+    expect_true(any(map_present), info = expected$step[i])
+  }
+})
+
+test_that("alternative deoxyribose steps match exact edges case-insensitively", {
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  edges <- DNMB:::.dnmb_cct_3zone_cyto_edges(nodes)
+  evidence <- data.frame(
+    pathway_id = rep(" DeOxYrIbOsE ", 5L),
+    step_id = c("ADH", "AckA", "PTA", "AcS", "ALD-DH-COA"),
+    confidence = "high",
+    rank = 3L,
+    locus_tag = paste0("locus_", seq_len(5L)),
+    stringsAsFactors = FALSE
+  )
+
+  matches <- DNMB:::.dnmb_cct_exact_step_edge_matches(evidence, edges)
+  expect_setequal(
+    tolower(matches$mapped_step_id),
+    c("adh", "acka", "pta", "acs", "ald-dh-coa")
+  )
+  expect_equal(nrow(matches), 5L)
+})
+
+test_that("exact reaction anchors lie on the rendered cumulative-midpoint path", {
+  nodes <- DNMB:::.dnmb_cct_sugar_nodes()
+  edges <- DNMB:::.dnmb_cct_3zone_cyto_edges(nodes)
+  evidence <- data.frame(
+    pathway_id = "deoxyribose",
+    step_id = c("ackA", "pta", "acs", "ald-dh-CoA"),
+    confidence = "high",
+    rank = 3L,
+    locus_tag = paste0("anchor_", seq_len(4L)),
+    stringsAsFactors = FALSE
+  )
+  labels <- DNMB:::.dnmb_cct_exact_step_labels(evidence, edges)
+  mapping <- DNMB:::.dnmb_cct_exact_step_edge_map()
+
+  point_path_distance <- function(x, y, path) {
+    distances <- vapply(seq_len(nrow(path) - 1L), function(i) {
+      ax <- path$x[i]
+      ay <- path$y[i]
+      dx <- path$x[i + 1L] - ax
+      dy <- path$y[i + 1L] - ay
+      denom <- dx^2 + dy^2
+      t <- if (denom > 0) ((x - ax) * dx + (y - ay) * dy) / denom else 0
+      t <- min(1, max(0, t))
+      sqrt((x - (ax + t * dx))^2 + (y - (ay + t * dy))^2)
+    }, numeric(1))
+    min(distances)
+  }
+
+  for (i in seq_len(nrow(labels))) {
+    step <- tolower(labels$step_id[i])
+    map_row <- mapping[
+      tolower(mapping$pathway_id) == "deoxyribose" &
+        tolower(mapping$step_id) == step & mapping$label_anchor,
+      , drop = FALSE
+    ][1, , drop = FALSE]
+    edge <- edges[
+      edges$from == map_row$from & edges$to == map_row$to,
+      , drop = FALSE
+    ][1, , drop = FALSE]
+    path <- DNMB:::.dnmb_cct_edge_points_from_row(edge, grid_step = 0.5)
+    expected_midpoint <- DNMB:::.dnmb_cct_route_label_point(path, frac = 0.5)
+
+    expect_equal(labels$x[i], expected_midpoint$x, tolerance = 1e-10)
+    expect_equal(labels$y[i], expected_midpoint$y, tolerance = 1e-10)
+    expect_lt(point_path_distance(labels$x[i], labels$y[i], path), 1e-10)
+  }
+
+  acs_label <- labels[tolower(labels$step_id) == "acs", , drop = FALSE]
+  acs_edge <- edges[edges$from == "Acetate" & edges$to == "Acetyl-CoA", , drop = FALSE]
+  endpoint_mean <- c(mean(c(acs_edge$x, acs_edge$xend)), mean(c(acs_edge$y, acs_edge$yend)))
+  expect_gt(sqrt((acs_label$x - endpoint_mean[1])^2 + (acs_label$y - endpoint_mean[2])^2), 0.1)
+})
+
+test_that("step target lookup is case-insensitive for mixed-case GapMind IDs", {
+  expect_identical(
+    DNMB:::.dnmb_cct_step_target_nodes(" NAgA ", "NAG"),
+    c("GlcN-6-P")
+  )
+  expect_identical(DNMB:::.dnmb_cct_step_target_nodes("GalK", "galactose"), c("Gal-1-P"))
+  expect_identical(DNMB:::.dnmb_cct_step_target_nodes("XYLa", "xylose"), c("Xylulose", "Xu-5-P"))
+  expect_identical(DNMB:::.dnmb_cct_step_target_nodes("FucI", "fucose"), c("Fuculose", "Fuculose-1-P", "DHAP"))
+  expect_identical(DNMB:::.dnmb_cct_step_target_nodes("LacZ", "lactose"), c("Gal-1-P", "Glc-6-P"))
+  expect_identical(DNMB:::.dnmb_cct_step_target_nodes("ACKA", "DEOXYRIBOSE"), c("Acetate", "Acetyl-P"))
+  expect_identical(DNMB:::.dnmb_cct_step_target_nodes("ald-DH-CoA", "deoxyribose"), c("Acetaldehyde", "Acetyl-CoA"))
+})

--- a/tests/testthat/test-cazy-external-label-layout.R
+++ b/tests/testthat/test-cazy-external-label-layout.R
@@ -1,0 +1,104 @@
+test_that("fixed extracellular labels retain regular chain-relative coordinates", {
+  labels <- data.frame(
+    x = c(1.0, 1.2, 1.4),
+    y = c(3.27, 3.13, 2.90),
+    label = c("Cellulose", "\u03b21-4", "\u03b11-3"),
+    label_kind = c("title", "bond", "branch_bond"),
+    anchor_x = c(1.0, 1.2, 1.4),
+    anchor_y = c(3.0, 3.0, 3.0),
+    priority = c(30, 8, 10),
+    hjust = c(0.5, 0.5, 0),
+    color = c("#333333", "#777777", "#795548"),
+    stringsAsFactors = FALSE
+  )
+
+  placed <- DNMB:::.dnmb_cct_layout_external_labels(labels, xlim = c(0, 4))
+
+  expect_equal(placed$x_lab, labels$x)
+  expect_equal(placed$y_lab, labels$y)
+  expect_identical(placed$row_level, rep(0L, nrow(labels)))
+  expect_false(any(placed$draw_leader))
+})
+
+test_that("G-ID labels use one primary and at most two auxiliary rows", {
+  labels <- data.frame(
+    x = rep(2, 7),
+    y = rep(3, 7),
+    label = sprintf("G%02d", 1:7),
+    label_kind = "gh",
+    anchor_x = rep(2, 7),
+    anchor_y = rep(3.18, 7),
+    priority = 7:1,
+    hjust = 0.5,
+    color = "#C62828",
+    stringsAsFactors = FALSE
+  )
+
+  placed <- DNMB:::.dnmb_cct_layout_external_labels(
+    labels, xlim = c(0, 4), row_step = 0.15, max_aux_rows = 2L
+  )
+
+  expect_setequal(unique(placed$row_level), 0:2)
+  expect_lte(max(placed$row_level), 2L)
+  expect_true(any(placed$row_level > 0L))
+  expect_true(all(placed$y_lab == 3 - placed$row_level * 0.15))
+  expect_identical(placed$row_level[1:3], rep(0L, 3))
+  expect_identical(placed$row_level[4:6], rep(1L, 3))
+  expect_identical(placed$row_level[7], 2L)
+  expect_equal(placed$x_lab[1:3], c(2.00, 2.28, 1.72), tolerance = 1e-8)
+
+  for (yy in unique(placed$y_lab)) {
+    row <- placed[placed$y_lab == yy, , drop = FALSE]
+    if (nrow(row) < 2L) next
+    row <- row[order(row$x_lab), , drop = FALSE]
+    widths <- pmax(0.20, nchar(row$label) * 0.055)
+    required <- (head(widths, -1L) + tail(widths, -1L)) / 2 + 0.08
+    expect_true(all(diff(row$x_lab) >= required - 1e-8))
+  }
+})
+
+test_that("spaced G-ID labels stay on the primary row without leaders", {
+  labels <- data.frame(
+    x = c(0.5, 1.5, 2.5),
+    y = rep(3, 3),
+    label = c("G01", "G02", "G03"),
+    label_kind = "gh",
+    anchor_x = c(0.5, 1.5, 2.5),
+    anchor_y = rep(3.18, 3),
+    priority = 1,
+    hjust = 0.5,
+    color = "#C62828",
+    stringsAsFactors = FALSE
+  )
+
+  placed <- DNMB:::.dnmb_cct_layout_external_labels(labels, xlim = c(0, 3))
+
+  expect_identical(placed$row_level, rep(0L, 3))
+  expect_equal(placed$x_lab, labels$anchor_x)
+  expect_false(any(placed$draw_leader))
+  expect_equal(nrow(DNMB:::.dnmb_cct_external_label_leaders(placed)), 0L)
+})
+
+test_that("external G-ID layout is deterministic across input order", {
+  labels <- data.frame(
+    x = c(1, 1, 1.12, 1.15, 2),
+    y = c(3, 3, 3, 3, 2.7),
+    label = c("G05", "G01", "G03", "G02", "G04"),
+    label_kind = "gh",
+    anchor_x = c(1, 1, 1.12, 1.15, 2),
+    anchor_y = c(3.18, 3.18, 3.18, 3.18, 2.88),
+    priority = c(1, 5, 3, 4, 2),
+    hjust = 0.5,
+    color = "#C62828",
+    stringsAsFactors = FALSE
+  )
+
+  a <- DNMB:::.dnmb_cct_layout_external_labels(labels, xlim = c(0, 3))
+  b <- DNMB:::.dnmb_cct_layout_external_labels(labels[5:1, ], xlim = c(0, 3))
+  a <- a[order(a$label), c("label", "x_lab", "y_lab", "row_level")]
+  b <- b[order(b$label), c("label", "x_lab", "y_lab", "row_level")]
+  rownames(a) <- NULL
+  rownames(b) <- NULL
+
+  expect_identical(a, b)
+})

--- a/tests/testthat/test-cazy-extracellular-route-anchors.R
+++ b/tests/testthat/test-cazy-extracellular-route-anchors.R
@@ -1,0 +1,187 @@
+.cazy_extra_route_spec <- function(route_id, source_kind, source_id,
+                                   target_kind, target_id, points) {
+  list(
+    route_id = route_id,
+    source_kind = source_kind,
+    source_id = source_id,
+    target_kind = target_kind,
+    target_id = target_id,
+    points = points,
+    group = "release",
+    priority = 1,
+    color = "#1565C0",
+    linewidth = 0.3,
+    alpha = 0.5,
+    linetype = "solid",
+    gradient = FALSE,
+    trim_start = 0.06,
+    trim_end = 0.06
+  )
+}
+
+.cazy_extra_route_fixture <- function() {
+  anchors <- data.frame(
+    kind = c("scissor", "branch_sugar", "monosaccharide", "transporter"),
+    id = c("cut:starch", "branch:pectin:1", "glucose", "T01"),
+    x = c(1, 3, 7, 9),
+    y = c(12, 11, 9.5, 8.5),
+    stringsAsFactors = FALSE
+  )
+  specs <- list(
+    valid = .cazy_extra_route_spec(
+      "valid", "scissor", "cut:starch", "monosaccharide", "glucose",
+      data.frame(x = c(1, 1, 7, 7), y = c(12, 11.4, 11.4, 9.5))
+    ),
+    near = .cazy_extra_route_spec(
+      "near", "branch_sugar", "branch:pectin:1", "monosaccharide", "glucose",
+      data.frame(
+        x = c(3 + 5e-7, 3, 7, 7 - 5e-7),
+        y = c(11 - 5e-7, 10.8, 10.8, 9.5 + 5e-7)
+      )
+    ),
+    missing_source = .cazy_extra_route_spec(
+      "missing-source", "scissor", "cut:absent", "monosaccharide", "glucose",
+      data.frame(x = c(4, 4, 7, 7), y = c(12, 11.2, 11.2, 9.5))
+    ),
+    missing_target = .cazy_extra_route_spec(
+      "missing-target", "scissor", "cut:starch", "transporter", "T99",
+      data.frame(x = c(1, 1, 8, 8), y = c(12, 10.5, 10.5, 8.5))
+    ),
+    detached_source = .cazy_extra_route_spec(
+      "detached-source", "scissor", "cut:starch", "monosaccharide", "glucose",
+      data.frame(x = c(2, 2, 7, 7), y = c(12, 10.8, 10.8, 9.5))
+    ),
+    detached_target = .cazy_extra_route_spec(
+      "detached-target", "scissor", "cut:starch", "monosaccharide", "glucose",
+      data.frame(x = c(1, 1, 6, 6), y = c(12, 10.6, 10.6, 9.5))
+    ),
+    nonfinite = .cazy_extra_route_spec(
+      "nonfinite", "scissor", "cut:starch", "monosaccharide", "glucose",
+      data.frame(x = c(1, 1, NA_real_, 7), y = c(12, 10.4, 10.4, 9.5))
+    )
+  )
+  list(anchors = anchors, specs = specs)
+}
+
+.cazy_extra_route_directions <- function(points, tolerance = 1e-8) {
+  if (is.null(points) || nrow(points) < 2L) return(character())
+  dx <- diff(points$x)
+  dy <- diff(points$y)
+  direction <- ifelse(
+    abs(dx) <= tolerance & abs(dy) <= tolerance, "Z",
+    ifelse(abs(dy) <= tolerance, "H", ifelse(abs(dx) <= tolerance, "V", "D"))
+  )
+  direction[direction != "Z"]
+}
+
+.cazy_extra_has_sharp_orthogonal_corner <- function(points) {
+  direction <- .cazy_extra_route_directions(points)
+  if (length(direction) < 2L) return(FALSE)
+  adjacent <- paste(direction[-length(direction)], direction[-1L], sep = "")
+  any(adjacent %in% c("HV", "VH"))
+}
+
+test_that("extracellular routes require visible source and target anchors", {
+  fixture <- .cazy_extra_route_fixture()
+  validated <- DNMB:::.dnmb_cct_validate_extracellular_routes(
+    fixture$specs, fixture$anchors, tolerance = 1e-6
+  )
+
+  route_ids <- vapply(validated, `[[`, character(1), "route_id")
+  expect_setequal(route_ids, c("valid", "near"))
+  expect_false(any(c(
+    "missing-source", "missing-target", "detached-source",
+    "detached-target", "nonfinite"
+  ) %in% route_ids))
+})
+
+test_that("validated extracellular endpoints snap to their drawn anchors", {
+  fixture <- .cazy_extra_route_fixture()
+  validated <- DNMB:::.dnmb_cct_validate_extracellular_routes(
+    fixture$specs, fixture$anchors, tolerance = 1e-6
+  )
+
+  for (spec in validated) {
+    source <- fixture$anchors[
+      fixture$anchors$kind == spec$source_kind &
+        fixture$anchors$id == spec$source_id,
+      , drop = FALSE
+    ]
+    target <- fixture$anchors[
+      fixture$anchors$kind == spec$target_kind &
+        fixture$anchors$id == spec$target_id,
+      , drop = FALSE
+    ]
+    expect_equal(nrow(source), 1L)
+    expect_equal(nrow(target), 1L)
+    expect_equal(
+      unlist(spec$points[1L, c("x", "y")]),
+      c(x = source$x, y = source$y),
+      tolerance = 0
+    )
+    expect_equal(
+      unlist(spec$points[nrow(spec$points), c("x", "y")]),
+      c(x = target$x, y = target$y),
+      tolerance = 0
+    )
+  }
+})
+
+test_that("extracellular lanes are offset before every corner is rounded", {
+  anchors <- data.frame(
+    kind = c("scissor", "scissor", "monosaccharide", "monosaccharide"),
+    id = c("cut:a", "cut:b", "glucose", "galactose"),
+    x = c(1, 2, 7, 8),
+    y = c(12, 12, 9.5, 9.5),
+    stringsAsFactors = FALSE
+  )
+  specs <- list(
+    .cazy_extra_route_spec(
+      "release-a", "scissor", "cut:a", "monosaccharide", "glucose",
+      data.frame(x = c(1, 1, 7, 7), y = c(12, 11, 11, 9.5))
+    ),
+    .cazy_extra_route_spec(
+      "release-b", "scissor", "cut:b", "monosaccharide", "galactose",
+      data.frame(x = c(2, 2, 8, 8), y = c(12, 11, 11, 9.5))
+    )
+  )
+  validated <- DNMB:::.dnmb_cct_validate_extracellular_routes(
+    specs, anchors, tolerance = 1e-6
+  )
+  metadata <- data.frame(
+    route_id = vapply(validated, `[[`, character(1), "route_id"),
+    priority = vapply(validated, `[[`, numeric(1), "priority"),
+    group = vapply(validated, `[[`, character(1), "group"),
+    stringsAsFactors = FALSE
+  )
+  raw_lanes <- DNMB:::.dnmb_cct_separate_route_lanes(
+    lapply(validated, `[[`, "points"), metadata,
+    lane_step = 0.08, max_offset = 0.16,
+    connection_mode = "move_internal", round_radius = 0
+  )
+  rounded_lanes <- DNMB:::.dnmb_cct_separate_route_lanes(
+    lapply(validated, `[[`, "points"), metadata,
+    lane_step = 0.08, max_offset = 0.16,
+    connection_mode = "move_internal", round_radius = 0.08
+  )
+
+  for (route_index in seq_along(raw_lanes)) {
+    expected <- DNMB:::.dnmb_cct_round_orthogonal_route(
+      raw_lanes[[route_index]], radius = 0.08
+    )
+    expect_equal(
+      unname(as.matrix(rounded_lanes[[route_index]][, c("x", "y")])),
+      unname(as.matrix(expected[, c("x", "y")]))
+    )
+    expect_false(.cazy_extra_has_sharp_orthogonal_corner(rounded_lanes[[route_index]]))
+    expect_true("D" %in% .cazy_extra_route_directions(rounded_lanes[[route_index]]))
+    expect_equal(
+      unlist(rounded_lanes[[route_index]][1L, c("x", "y")]),
+      unlist(specs[[route_index]]$points[1L, c("x", "y")])
+    )
+    expect_equal(
+      unlist(rounded_lanes[[route_index]][nrow(rounded_lanes[[route_index]]), c("x", "y")]),
+      unlist(specs[[route_index]]$points[nrow(specs[[route_index]]$points), c("x", "y")])
+    )
+  }
+})

--- a/tests/testthat/test-cazy-membrane-route-gutters.R
+++ b/tests/testthat/test-cazy-membrane-route-gutters.R
@@ -1,0 +1,364 @@
+.cazy_membrane_route_pair_key <- function(route) {
+  paste(route$cs_id, route$target_key, sep = "\r")
+}
+
+.cazy_membrane_horizontal_levels <- function(points, tolerance = 1e-8) {
+  if (is.null(points) || nrow(points) < 2L) return(numeric())
+  dx <- diff(points$x)
+  dy <- diff(points$y)
+  unique(points$y[-nrow(points)][
+    abs(dx) > tolerance & abs(dy) <= tolerance
+  ])
+}
+
+.cazy_membrane_route_fixture <- function() {
+  data.frame(
+    cs_id = c("Maltose", "Galactose", "Mannitol", "Sucrose"),
+    locus_tag = c("T_SHARED", "T_SHARED", "T_MTL", "T_SCR"),
+    source_x = c(1.4, 3.4, 6.2, 8.2),
+    source_y = c(10.5, 9.5, 9.5, 9.5),
+    lane_x = c(1.4, 3.4, 6.2, 8.2),
+    tx_draw = c(4.4, 4.4, 6.8, 7.6),
+    ty_draw = c(8.62, 8.62, 8.38, 8.50),
+    cyto_x = c(2.0, 3.0, 6.0, 8.0),
+    cyto_y = c(7.75, 7.65, 7.70, 7.80),
+    confidence = c("high", "high", "high", "high"),
+    color = c("#8C510A", "#01665E", "#5E3C99", "#C51B7D"),
+    stringsAsFactors = FALSE
+  )
+}
+
+.cazy_membrane_drawn_rows <- function(layout, fixture) {
+  drawn <- layout$memberships[layout$memberships$draw, , drop = FALSE]
+  drawn_keys <- paste(drawn$cs_id, drawn$target_key, sep = "\r")
+  fixture_keys <- paste(fixture$cs_id, fixture$locus_tag, sep = "\r")
+  fixture[fixture_keys %in% drawn_keys, , drop = FALSE]
+}
+
+.cazy_membrane_routes_by_pair <- function(routes) {
+  keys <- vapply(routes, .cazy_membrane_route_pair_key, character(1))
+  routes[order(keys)]
+}
+
+test_that("transporter route lanes leave visible gutters above and below the membrane", {
+  y_memb <- 8.5
+  membrane_half_height <- 0.20
+  glyph_clearance <- 0.11
+  route_gap <- 0.08
+  fixture <- .cazy_membrane_route_fixture()
+
+  layout <- DNMB:::.dnmb_cct_transporter_bus_layout(
+    fixture,
+    y_memb = y_memb,
+    glyph_clearance = glyph_clearance,
+    corner_radius = 0.08
+  )
+  selected <- .cazy_membrane_drawn_rows(layout, fixture)
+  interior <- DNMB:::.dnmb_cct_transporter_interior_routes(
+    selected,
+    y_memb = y_memb,
+    glyph_clearance = glyph_clearance,
+    source_clearance = glyph_clearance,
+    corner_radius = 0.08
+  )
+
+  expect_gt(length(layout$exterior_routes), 0L)
+  expect_gt(length(interior), 0L)
+
+  for (route in layout$exterior_routes) {
+    target <- selected[
+      selected$cs_id == route$cs_id &
+        selected$locus_tag == route$target_key,
+      , drop = FALSE
+    ]
+    expect_equal(nrow(target), 1L)
+    upper_envelope <- max(
+      y_memb + membrane_half_height,
+      target$ty_draw + glyph_clearance
+    )
+    horizontal_y <- .cazy_membrane_horizontal_levels(route$points)
+    expect_gt(length(horizontal_y), 0L)
+    expect_true(all(horizontal_y >= upper_envelope + route_gap - 1e-10))
+  }
+
+  for (route in interior) {
+    target <- selected[
+      selected$cs_id == route$cs_id &
+        selected$locus_tag == route$target_key,
+      , drop = FALSE
+    ]
+    expect_equal(nrow(target), 1L)
+    lower_envelope <- min(
+      y_memb - membrane_half_height,
+      target$ty_draw - glyph_clearance
+    )
+    horizontal_y <- .cazy_membrane_horizontal_levels(route$points)
+    expect_gt(length(horizontal_y), 0L)
+    expect_true(all(horizontal_y <= lower_envelope - route_gap + 1e-10))
+  }
+})
+
+test_that("exterior and interior route halves meet the same selected T-ID", {
+  y_memb <- 8.5
+  glyph_clearance <- 0.11
+  fixture <- .cazy_membrane_route_fixture()
+  layout <- DNMB:::.dnmb_cct_transporter_bus_layout(
+    fixture, y_memb = y_memb, glyph_clearance = glyph_clearance
+  )
+  selected <- .cazy_membrane_drawn_rows(layout, fixture)
+  interior <- DNMB:::.dnmb_cct_transporter_interior_routes(
+    selected, y_memb = y_memb,
+    glyph_clearance = glyph_clearance,
+    source_clearance = glyph_clearance
+  )
+
+  exterior_keys <- vapply(
+    layout$exterior_routes, .cazy_membrane_route_pair_key, character(1)
+  )
+  interior_keys <- vapply(
+    interior, .cazy_membrane_route_pair_key, character(1)
+  )
+  expect_setequal(exterior_keys, interior_keys)
+
+  exterior_ids <- stats::setNames(vapply(
+    layout$exterior_routes, `[[`, character(1), "route_id"
+  ), exterior_keys)
+  interior_ids <- stats::setNames(vapply(
+    interior, `[[`, character(1), "route_id"
+  ), interior_keys)
+  common_keys <- sort(intersect(names(exterior_ids), names(interior_ids)))
+  expect_identical(
+    unname(exterior_ids[common_keys]),
+    unname(interior_ids[common_keys])
+  )
+
+  for (pair_key in common_keys) {
+    exterior <- layout$exterior_routes[[match(pair_key, exterior_keys)]]
+    inside <- interior[[match(pair_key, interior_keys)]]
+    target <- selected[
+      paste(selected$cs_id, selected$locus_tag, sep = "\r") == pair_key,
+      , drop = FALSE
+    ]
+    expect_equal(nrow(target), 1L)
+
+    exterior_end <- exterior$points[nrow(exterior$points), c("x", "y")]
+    interior_start <- inside$points[1L, c("x", "y")]
+    expect_equal(
+      unlist(exterior_end),
+      c(x = target$tx_draw, y = target$ty_draw + glyph_clearance)
+    )
+    expect_equal(
+      unlist(interior_start),
+      c(x = target$tx_draw, y = target$ty_draw - glyph_clearance)
+    )
+
+    if (nrow(exterior$points) > 1L) {
+      expect_equal(
+        exterior$points$x[nrow(exterior$points) - 1L],
+        target$tx_draw
+      )
+    }
+    if (nrow(inside$points) > 1L) {
+      expect_equal(inside$points$x[2L], target$tx_draw)
+    }
+  }
+})
+
+test_that("shared-transporter route pairing and geometry are deterministic", {
+  fixture <- .cazy_membrane_route_fixture()
+  shuffled_fixture <- fixture[c(4, 2, 1, 3), , drop = FALSE]
+
+  build_routes <- function(rows) {
+    layout <- DNMB:::.dnmb_cct_transporter_bus_layout(rows, y_memb = 8.5)
+    selected <- .cazy_membrane_drawn_rows(layout, rows)
+    interior <- DNMB:::.dnmb_cct_transporter_interior_routes(
+      selected, y_memb = 8.5
+    )
+    list(
+      layout = layout,
+      exterior = .cazy_membrane_routes_by_pair(layout$exterior_routes),
+      render = .cazy_membrane_routes_by_pair(layout$exterior_render_routes),
+      interior = .cazy_membrane_routes_by_pair(interior)
+    )
+  }
+
+  original <- build_routes(fixture)
+  shuffled <- build_routes(shuffled_fixture)
+
+  compare_routes <- function(first, second) {
+    first_keys <- vapply(first, .cazy_membrane_route_pair_key, character(1))
+    second_keys <- vapply(second, .cazy_membrane_route_pair_key, character(1))
+    expect_identical(first_keys, second_keys)
+    expect_identical(
+      vapply(first, `[[`, character(1), "route_id"),
+      vapply(second, `[[`, character(1), "route_id")
+    )
+    for (i in seq_along(first)) {
+      expect_equal(
+        unname(as.matrix(first[[i]]$points[, c("x", "y")])),
+        unname(as.matrix(second[[i]]$points[, c("x", "y")]))
+      )
+    }
+  }
+
+  compare_routes(original$exterior, shuffled$exterior)
+  compare_routes(original$render, shuffled$render)
+  compare_routes(original$interior, shuffled$interior)
+
+  shared_exterior <- Filter(
+    function(route) identical(route$target_key, "T_SHARED"),
+    original$exterior
+  )
+  shared_interior <- Filter(
+    function(route) identical(route$target_key, "T_SHARED"),
+    original$interior
+  )
+  expect_equal(length(shared_exterior), 2L)
+  expect_equal(length(shared_interior), 2L)
+  expect_true(all(vapply(
+    shared_exterior,
+    function(route) isTRUE(all.equal(route$target_x, 4.4)),
+    logical(1)
+  )))
+  expect_true(all(vapply(
+    shared_interior,
+    function(route) isTRUE(all.equal(route$points$x[1L], 4.4)),
+    logical(1)
+  )))
+})
+
+test_that("every exterior membership keeps its colour to the final transporter", {
+  fixture <- .cazy_membrane_route_fixture()
+  layout <- DNMB:::.dnmb_cct_transporter_bus_layout(fixture, y_memb = 8.5)
+  drawn <- layout$memberships[layout$memberships$draw, , drop = FALSE]
+
+  expected_ids <- vapply(seq_len(nrow(drawn)), function(i) {
+    DNMB:::.dnmb_cct_transporter_route_id(
+      drawn$cs_id[i], drawn$target_key[i]
+    )
+  }, character(1))
+  rendered_ids <- vapply(
+    layout$exterior_render_routes, `[[`, character(1), "route_id"
+  )
+
+  # A shared transporter must not replace membership paths with one neutral
+  # transport-trunk route. Each coloured source path remains independently
+  # traceable through its final segment and arrowhead.
+  expect_setequal(rendered_ids, expected_ids)
+  expect_identical(anyDuplicated(rendered_ids), 0L)
+  expect_false(any(startsWith(rendered_ids, "transport-trunk:")))
+
+  fixture_keys <- paste(fixture$cs_id, fixture$locus_tag, sep = "\r")
+  for (i in seq_len(nrow(drawn))) {
+    route <- layout$exterior_render_routes[[match(expected_ids[i], rendered_ids)]]
+    fixture_row <- fixture[
+      fixture_keys == paste(drawn$cs_id[i], drawn$target_key[i], sep = "\r"),
+      , drop = FALSE
+    ]
+    expect_equal(nrow(fixture_row), 1L)
+    expect_identical(route$color, fixture_row$color)
+    expect_true(isTRUE(route$arrow_last))
+    expect_equal(route$transporter_x, fixture_row$tx_draw)
+    expect_lte(abs(route$landing_x - fixture_row$tx_draw), 0.07 + 1e-10)
+    expect_equal(
+      unlist(route$points[nrow(route$points), c("x", "y")]),
+      c(x = fixture_row$tx_draw, y = fixture_row$ty_draw + 0.11)
+    )
+    expect_equal(c(route$target_x, route$target_y), unname(unlist(
+      route$points[nrow(route$points), c("x", "y")]
+    )))
+  }
+
+  shared_render <- Filter(
+    function(route) identical(route$target_key, "T_SHARED"),
+    layout$exterior_render_routes
+  )
+  expect_equal(length(shared_render), 2L)
+  expect_equal(
+    length(unique(vapply(shared_render, `[[`, numeric(1), "landing_x"))),
+    2L
+  )
+  expect_true(all(vapply(shared_render, function(route) {
+    if (abs(route$landing_x - route$target_x) <= 1e-8) return(TRUE)
+    penultimate <- route$points[nrow(route$points) - 1L, c("x", "y")]
+    isTRUE(all.equal(
+      unname(unlist(penultimate)),
+      c(route$landing_x, route$landing_y)
+    ))
+  }, logical(1))))
+})
+
+test_that("an aligned shared membership retains its coloured route", {
+  memberships <- data.frame(
+    cs_id = c("Galactose", "Xylose"),
+    locus_tag = c("T_SHARED", "T_SHARED"),
+    source_x = c(4.4, 2.0), source_y = c(9.5, 9.5),
+    lane_x = c(4.4, 2.0),
+    tx_draw = c(4.4, 4.4), ty_draw = c(8.5, 8.5),
+    confidence = c("high", "high"),
+    color = c("#CCA800", "#01665E"),
+    stringsAsFactors = FALSE
+  )
+  layout <- DNMB:::.dnmb_cct_transporter_bus_layout(memberships, y_memb = 8.5)
+  rendered_ids <- vapply(
+    layout$exterior_render_routes, `[[`, character(1), "route_id"
+  )
+  aligned_id <- DNMB:::.dnmb_cct_transporter_route_id(
+    "Galactose", "T_SHARED"
+  )
+  aligned <- layout$exterior_render_routes[[match(aligned_id, rendered_ids)]]
+
+  expect_false(is.null(aligned))
+  expect_identical(aligned$color, "#CCA800")
+  expect_true(isTRUE(aligned$arrow_last))
+  expect_equal(
+    unlist(aligned$points[nrow(aligned$points), c("x", "y")]),
+    c(x = 4.4, y = 8.61)
+  )
+})
+
+test_that("distinct loci at one substrate anchor get separate route centers", {
+  ids <- c("L03", "L01", "L02")
+  desired <- rep(10, 3)
+  spans <- c(0.30, 0.26, 0.30)
+  ranks <- rep(2, 3)
+
+  pack <- function(idx) {
+    packed <- DNMB:::.dnmb_cct_pack_transporters_lane(
+      center_x = mean(desired[idx]),
+      half_spans = spans[idx],
+      lane_ranks = ranks[idx],
+      desired_x = desired[idx],
+      stable_ids = ids[idx],
+      y_memb = 8.5,
+      xlim = c(9.0, 11.0)
+    )
+    packed$locus_tag <- ids[idx]
+    packed[order(packed$locus_tag), , drop = FALSE]
+  }
+
+  original <- pack(seq_along(ids))
+  shuffled <- pack(c(3, 1, 2))
+
+  expect_equal(length(unique(original$tx)), length(ids))
+  pairs <- utils::combn(seq_len(nrow(original)), 2L)
+  for (j in seq_len(ncol(pairs))) {
+    ii <- pairs[, j]
+    pair_spans <- spans[match(original$locus_tag[ii], ids)]
+    expect_gte(abs(diff(original$tx[ii])), max(pair_spans) + 0.08 - 1e-10)
+  }
+  ordered_spans <- spans[match(original$locus_tag, ids)]
+  expect_true(all(original$tx - ordered_spans >= 9.0 - 1e-10))
+  expect_true(all(original$tx + ordered_spans <= 11.0 + 1e-10))
+  for (row in unique(original$row_id)) {
+    ii <- which(original$row_id == row)
+    if (length(ii) < 2L) next
+    ii <- ii[order(original$tx[ii])]
+    edge_gap <- diff(original$tx[ii]) -
+      head(ordered_spans[ii], -1L) - tail(ordered_spans[ii], -1L)
+    expect_true(all(edge_gap >= 0.08 - 1e-10))
+  }
+  expect_equal(original$tx, shuffled$tx)
+  expect_equal(original$ty, shuffled$ty)
+  expect_identical(original$row_id, shuffled$row_id)
+})

--- a/tests/testthat/test-cazy-route-lanes-notchless.R
+++ b/tests/testthat/test-cazy-route-lanes-notchless.R
@@ -1,0 +1,294 @@
+.cazy_notchless_direction_classes <- function(points, tolerance = 1e-8) {
+  if (is.null(points) || nrow(points) < 2L) return(character())
+  dx <- diff(points$x)
+  dy <- diff(points$y)
+  direction <- ifelse(
+    abs(dx) <= tolerance & abs(dy) <= tolerance, "Z",
+    ifelse(
+      abs(dy) <= tolerance, "H",
+      ifelse(abs(dx) <= tolerance, "V", "D")
+    )
+  )
+  direction[direction != "Z"]
+}
+
+.cazy_notchless_has_horizontal_jog <- function(points, tolerance = 1e-8) {
+  direction <- .cazy_notchless_direction_classes(points, tolerance = tolerance)
+  if (length(direction) < 3L) return(FALSE)
+  any(
+    direction[-c(length(direction) - 1L, length(direction))] == "H" &
+      direction[-c(1L, length(direction))] == "V" &
+      direction[-c(1L, 2L)] == "H"
+  )
+}
+
+.cazy_notchless_fixture <- function() {
+  routes <- list(
+    main = data.frame(
+      x = c(0, 0, 3, 3, 6, 6),
+      y = c(4, 3, 3, 3, 3, 2)
+    ),
+    left = data.frame(
+      x = c(-0.5, -0.5, 2.5, 2.5),
+      y = c(4, 3, 3, 2)
+    ),
+    right = data.frame(
+      x = c(3.5, 3.5, 6.5, 6.5),
+      y = c(4, 3, 3, 2)
+    )
+  )
+  metadata <- data.frame(
+    route_id = c("mid", "aaa", "zzz"),
+    priority = c(1, 1, 1),
+    group = "release",
+    stringsAsFactors = FALSE
+  )
+  list(routes = routes, metadata = metadata)
+}
+
+.cazy_notchless_separate <- function(fixture, round_radius = 0) {
+  DNMB:::.dnmb_cct_separate_route_lanes(
+    fixture$routes,
+    fixture$metadata,
+    lane_step = 0.08,
+    max_offset = 0.20,
+    y_tolerance = 0.01,
+    min_overlap = 0.20,
+    connection_mode = "move_internal",
+    round_radius = round_radius
+  )
+}
+
+test_that("one route keeps one height across a continuous horizontal run", {
+  fixture <- .cazy_notchless_fixture()
+  separated <- .cazy_notchless_separate(fixture)
+  assignments <- attr(separated, "lane_assignments")
+  main_assignments <- assignments[assignments$route_id == "mid", , drop = FALSE]
+  main_path <- separated[[which(fixture$metadata$route_id == "mid")]]
+
+  expect_gt(nrow(main_assignments), 1L)
+  expect_equal(length(unique(round(main_assignments$lane_y, 8))), 1L)
+  expect_false(.cazy_notchless_has_horizontal_jog(main_path))
+
+  dx <- diff(main_path$x)
+  dy <- diff(main_path$y)
+  horizontal_y <- main_path$y[-nrow(main_path)][
+    abs(dx) > 1e-8 & abs(dy) <= 1e-8
+  ]
+  expect_equal(length(unique(round(horizontal_y, 8))), 1L)
+  expect_equal(unlist(main_path[1L, c("x", "y")]), c(x = 0, y = 4))
+  expect_equal(unlist(main_path[nrow(main_path), c("x", "y")]), c(x = 6, y = 2))
+})
+
+test_that("rounding is applied to the final offset lane without adding a notch", {
+  fixture <- .cazy_notchless_fixture()
+  unrounded <- .cazy_notchless_separate(fixture, round_radius = 0)
+  rounded <- .cazy_notchless_separate(fixture, round_radius = 0.04)
+
+  for (route_index in seq_along(unrounded)) {
+    expected <- DNMB:::.dnmb_cct_round_orthogonal_route(
+      unrounded[[route_index]], radius = 0.04
+    )
+    expect_equal(
+      unname(as.matrix(rounded[[route_index]][, c("x", "y")])),
+      unname(as.matrix(expected[, c("x", "y")]))
+    )
+  }
+
+  main_path <- rounded[[which(fixture$metadata$route_id == "mid")]]
+  expect_false(.cazy_notchless_has_horizontal_jog(main_path))
+  expect_equal(unlist(main_path[1L, c("x", "y")]), c(x = 0, y = 4))
+  expect_equal(unlist(main_path[nrow(main_path), c("x", "y")]), c(x = 6, y = 2))
+})
+
+test_that("rounded lane corners use symmetric incoming and outgoing tangents", {
+  fixture <- .cazy_notchless_fixture()
+  unrounded <- .cazy_notchless_separate(fixture, round_radius = 0)[[1L]]
+  rounded <- .cazy_notchless_separate(fixture, round_radius = 0.04)[[1L]]
+  radius <- 0.04
+
+  checked_corners <- 0L
+  for (corner_index in 2:(nrow(unrounded) - 1L)) {
+    previous <- unlist(unrounded[corner_index - 1L, c("x", "y")])
+    corner <- unlist(unrounded[corner_index, c("x", "y")])
+    following <- unlist(unrounded[corner_index + 1L, c("x", "y")])
+    incoming <- corner - previous
+    outgoing <- following - corner
+    incoming_length <- sqrt(sum(incoming^2))
+    outgoing_length <- sqrt(sum(outgoing^2))
+    incoming_unit <- incoming / incoming_length
+    outgoing_unit <- outgoing / outgoing_length
+    if (abs(sum(incoming_unit * outgoing_unit)) > 1e-8) next
+
+    tangent_length <- min(radius, incoming_length * 0.30, outgoing_length * 0.30)
+    expected_incoming <- corner - incoming_unit * tangent_length
+    expected_outgoing <- corner + outgoing_unit * tangent_length
+    incoming_distance <-
+      (rounded$x - expected_incoming[[1L]])^2 +
+      (rounded$y - expected_incoming[[2L]])^2
+    outgoing_distance <-
+      (rounded$x - expected_outgoing[[1L]])^2 +
+      (rounded$y - expected_outgoing[[2L]])^2
+    actual_incoming <- unlist(
+      rounded[which.min(incoming_distance), c("x", "y")]
+    )
+    actual_outgoing <- unlist(
+      rounded[which.min(outgoing_distance), c("x", "y")]
+    )
+
+    expect_equal(actual_incoming, expected_incoming, tolerance = 1e-10)
+    expect_equal(actual_outgoing, expected_outgoing, tolerance = 1e-10)
+    expect_equal(
+      sqrt(sum((actual_incoming - corner)^2)),
+      sqrt(sum((actual_outgoing - corner)^2)),
+      tolerance = 1e-10
+    )
+    checked_corners <- checked_corners + 1L
+  }
+  expect_equal(checked_corners, 2L)
+})
+
+test_that("lane separation retains endpoints and unrelated route anchors", {
+  routes <- list(
+    anchored = data.frame(
+      x = c(0, 0, 1, 1, 6, 6, 7, 7),
+      y = c(5, 4, 4, 3, 3, 2, 2, 1)
+    ),
+    overlap = data.frame(
+      x = c(2, 2, 5, 5),
+      y = c(4, 3, 3, 2)
+    )
+  )
+  metadata <- data.frame(
+    route_id = c("anchored", "overlap"),
+    priority = c(2, 1),
+    group = "entry",
+    stringsAsFactors = FALSE
+  )
+  separated <- DNMB:::.dnmb_cct_separate_route_lanes(
+    routes, metadata,
+    lane_step = 0.08, max_offset = 0.16,
+    connection_mode = "move_internal"
+  )
+  path <- separated[[1L]]
+  preserved <- data.frame(
+    x = c(0, 0, 1, 6, 7, 7),
+    y = c(5, 4, 4, 2, 2, 1)
+  )
+  path_keys <- paste(path$x, path$y, sep = ":")
+  anchor_keys <- paste(preserved$x, preserved$y, sep = ":")
+
+  expect_true(all(anchor_keys %in% path_keys))
+  expect_equal(unlist(path[1L, c("x", "y")]), c(x = 0, y = 5))
+  expect_equal(unlist(path[nrow(path), c("x", "y")]), c(x = 7, y = 1))
+})
+
+test_that("short and same-axis routes never become diagonal", {
+  routes <- list(
+    point = data.frame(x = 1, y = 1),
+    vertical = data.frame(x = c(2, 2, 2), y = c(4, 3, 2)),
+    flat_a = data.frame(x = c(0, 2, 4), y = c(3, 3, 3)),
+    flat_b = data.frame(x = c(0, 2, 4), y = c(3, 3, 3))
+  )
+  metadata <- data.frame(
+    route_id = names(routes),
+    priority = c(1, 1, 2, 1),
+    group = "edge-case",
+    stringsAsFactors = FALSE
+  )
+  separated <- DNMB:::.dnmb_cct_separate_route_lanes(
+    routes, metadata,
+    lane_step = 0.08, max_offset = 0.16,
+    connection_mode = "move_internal"
+  )
+
+  for (route_index in seq_along(routes)) {
+    original <- routes[[route_index]]
+    adjusted <- separated[[route_index]]
+    expect_equal(
+      unlist(adjusted[1L, c("x", "y")]),
+      unlist(original[1L, c("x", "y")])
+    )
+    expect_equal(
+      unlist(adjusted[nrow(adjusted), c("x", "y")]),
+      unlist(original[nrow(original), c("x", "y")])
+    )
+    expect_false("D" %in% .cazy_notchless_direction_classes(adjusted))
+    expect_false(.cazy_notchless_has_horizontal_jog(adjusted))
+  }
+})
+
+test_that("notchless lane geometry is deterministic after route shuffling", {
+  fixture <- .cazy_notchless_fixture()
+  baseline <- .cazy_notchless_separate(fixture, round_radius = 0.04)
+  baseline_by_id <- stats::setNames(baseline, fixture$metadata$route_id)
+
+  order_shuffled <- c(3L, 1L, 2L)
+  shuffled_fixture <- list(
+    routes = fixture$routes[order_shuffled],
+    metadata = fixture$metadata[order_shuffled, , drop = FALSE]
+  )
+  shuffled <- .cazy_notchless_separate(shuffled_fixture, round_radius = 0.04)
+  shuffled_by_id <- stats::setNames(
+    shuffled, shuffled_fixture$metadata$route_id
+  )
+
+  for (route_id in sort(fixture$metadata$route_id)) {
+    expect_equal(
+      unname(as.matrix(baseline_by_id[[route_id]][, c("x", "y")])),
+      unname(as.matrix(shuffled_by_id[[route_id]][, c("x", "y")]))
+    )
+  }
+})
+
+test_that("hub-entry fallback stays orthogonal until final lane rounding", {
+  raw_path <- DNMB:::.dnmb_cct_hub_entry_path(
+    hub_x = 1, hub_y = 5,
+    target_x = 5, target_y = 1,
+    lane_rank = 2L, target_count = 3L,
+    grid_step = 0.5,
+    rounded = FALSE
+  )
+  direction <- .cazy_notchless_direction_classes(raw_path)
+
+  expect_true(nrow(raw_path) >= 4L)
+  expect_false("D" %in% direction)
+
+  routes <- list(first = raw_path, second = raw_path)
+  metadata <- data.frame(
+    route_id = c("hub-fallback-a", "hub-fallback-b"),
+    priority = c(2, 1), group = "hub",
+    stringsAsFactors = FALSE
+  )
+  unrounded <- DNMB:::.dnmb_cct_separate_route_lanes(
+    routes = routes,
+    metadata = metadata,
+    lane_step = 0.08,
+    max_offset = 0.16,
+    round_radius = 0
+  )
+  rounded <- DNMB:::.dnmb_cct_separate_route_lanes(
+    routes = routes,
+    metadata = metadata,
+    lane_step = 0.08,
+    max_offset = 0.16,
+    round_radius = 0.04
+  )
+
+  for (route_index in seq_along(routes)) {
+    expected <- DNMB:::.dnmb_cct_round_orthogonal_route(
+      unrounded[[route_index]], radius = 0.04
+    )
+    expect_equal(
+      unname(as.matrix(rounded[[route_index]][, c("x", "y")])),
+      unname(as.matrix(expected[, c("x", "y")]))
+    )
+  }
+
+  separated <- rounded[[1L]]
+  expect_equal(unlist(separated[1L, c("x", "y")]), c(x = 1, y = 5))
+  expect_equal(
+    unlist(separated[nrow(separated), c("x", "y")]),
+    c(x = 5, y = 1)
+  )
+})

--- a/tests/testthat/test-cazy-route-lanes.R
+++ b/tests/testthat/test-cazy-route-lanes.R
@@ -1,0 +1,135 @@
+test_that("shared horizontal route segments receive deterministic bounded lanes", {
+  routes <- list(
+    alpha = data.frame(x = c(0, 0, 4, 4), y = c(2, 1, 1, 0)),
+    beta = data.frame(x = c(1, 1, 5, 5), y = c(2, 1, 1, 0)),
+    gamma = data.frame(x = c(2, 2, 6, 6), y = c(2, 1.02, 1.02, 0))
+  )
+  metadata <- data.frame(
+    route_id = c("alpha", "beta", "gamma"),
+    priority = c(3, 2, 1),
+    group = c("hexose", "hexose", "pentose"),
+    stringsAsFactors = FALSE
+  )
+
+  separated <- DNMB:::.dnmb_cct_separate_route_lanes(
+    routes, metadata,
+    lane_step = 0.06, max_offset = 0.20,
+    y_tolerance = 0.04, min_overlap = 0.20,
+    connection_mode = "move_internal"
+  )
+  assignments <- attr(separated, "lane_assignments")
+  lane_by_id <- stats::setNames(assignments$lane_y, assignments$route_id)
+
+  shuffled <- DNMB:::.dnmb_cct_separate_route_lanes(
+    routes[c(3, 1, 2)], metadata[c(3, 1, 2), ],
+    lane_step = 0.06, max_offset = 0.20,
+    y_tolerance = 0.04, min_overlap = 0.20,
+    connection_mode = "move_internal"
+  )
+  shuffled_assignments <- attr(shuffled, "lane_assignments")
+  shuffled_by_id <- stats::setNames(
+    shuffled_assignments$lane_y, shuffled_assignments$route_id
+  )
+
+  expect_equal(lane_by_id[sort(names(lane_by_id))],
+               shuffled_by_id[sort(names(shuffled_by_id))])
+  expect_equal(length(unique(round(assignments$lane_y, 8))), 3L)
+  expect_true(all(abs(assignments$offset) <= 0.20 + 1e-10))
+})
+
+test_that("route lane transitions preserve endpoints and original vertices", {
+  routes <- list(
+    first = data.frame(x = c(0, 0, 4, 4), y = c(3, 2, 2, 0)),
+    second = data.frame(x = c(1, 1, 5, 5), y = c(3, 2, 2, 0))
+  )
+  metadata <- data.frame(
+    route_id = c("first", "second"), priority = c(2, 1), group = "entry"
+  )
+  separated <- DNMB:::.dnmb_cct_separate_route_lanes(
+    routes, metadata,
+    lane_step = 0.06, max_offset = 0.12,
+    connection_mode = "transition"
+  )
+
+  for (i in seq_along(routes)) {
+    original <- routes[[i]]
+    adjusted <- separated[[i]]
+    expect_equal(unlist(adjusted[1, c("x", "y")]),
+                 unlist(original[1, c("x", "y")]))
+    expect_equal(
+      unlist(adjusted[nrow(adjusted), c("x", "y")]),
+      unlist(original[nrow(original), c("x", "y")])
+    )
+    original_keys <- paste(original$x, original$y, sep = ":")
+    adjusted_keys <- paste(adjusted$x, adjusted$y, sep = ":")
+    expect_true(all(original_keys %in% adjusted_keys))
+  }
+})
+
+test_that("move-internal release lanes retain origin and target with rounded elbows", {
+  routes <- list(
+    glucose = data.frame(x = c(2, 2, 8, 8), y = c(7, 6.8, 6.8, 4)),
+    galactose = data.frame(x = c(3, 3, 9, 9), y = c(7, 6.8, 6.8, 4))
+  )
+  metadata <- data.frame(
+    route_id = c("release:glucose", "release:galactose"),
+    priority = c(1, 1), group = c("release", "release")
+  )
+  separated <- DNMB:::.dnmb_cct_separate_route_lanes(
+    routes, metadata,
+    lane_step = 0.07, max_offset = 0.14,
+    y_tolerance = 0.04, min_overlap = 0.20,
+    connection_mode = "move_internal", round_radius = 0.04
+  )
+  assignments <- attr(separated, "lane_assignments")
+
+  expect_equal(length(unique(round(assignments$lane_y, 8))), 2L)
+  for (i in seq_along(routes)) {
+    expect_equal(unlist(separated[[i]][1, c("x", "y")]),
+                 unlist(routes[[i]][1, c("x", "y")]))
+    expect_equal(unlist(separated[[i]][nrow(separated[[i]]), c("x", "y")]),
+                 unlist(routes[[i]][nrow(routes[[i]]), c("x", "y")]))
+    expect_gt(nrow(separated[[i]]), nrow(routes[[i]]))
+  }
+})
+
+test_that("continuity colour stops at the first central-carbon merge", {
+  expect_identical(
+    DNMB:::.dnmb_cct_route_to_first_core_merge(
+      c("Glucose", "Glc-6-P", "Fru-6-P", "Pyruvate")
+    ),
+    c("Glucose", "Glc-6-P")
+  )
+  expect_identical(
+    DNMB:::.dnmb_cct_route_to_first_core_merge(
+      c("Fuculose", "Fuculose-1-P", "DHAP", "GA3P")
+    ),
+    c("Fuculose", "Fuculose-1-P", "DHAP")
+  )
+  expect_identical(
+    DNMB:::.dnmb_cct_route_to_first_core_merge(
+      c("Deoxyribose-5-P", "GA3P", "1,3-BPG")
+    ),
+    c("Deoxyribose-5-P", "GA3P")
+  )
+  expect_null(
+    DNMB:::.dnmb_cct_route_to_first_core_merge(c("R-5-P", "S-7-P"))
+  )
+})
+
+test_that("branched carbon sources retain every initial intracellular product", {
+  node_ids <- DNMB:::.dnmb_cct_sugar_nodes()$id
+
+  expect_setequal(
+    DNMB:::.dnmb_cct_initial_entry_targets("Lactose", node_ids),
+    c("Glucose", "Gal-1-P")
+  )
+  expect_setequal(
+    DNMB:::.dnmb_cct_initial_entry_targets("Sucrose", node_ids),
+    c("Glucose", "Fru-6-P")
+  )
+  expect_identical(
+    DNMB:::.dnmb_cct_initial_entry_targets("Maltose", node_ids),
+    "Glucose"
+  )
+})

--- a/tests/testthat/test-cazy-snfg-labels.R
+++ b/tests/testthat/test-cazy-snfg-labels.R
@@ -1,0 +1,85 @@
+test_that("cytoplasmic sugar nodes use compact labels inside their glyphs", {
+  inside <- DNMB:::.dnmb_cct_cytoplasmic_inside_label
+
+  expect_identical(inside("Glucose", "Glucose", "backbone", "glucose"), "Glc")
+  expect_identical(
+    inside("GlcNAc-6-P", "GlcNAc-6-P", "entry_intermediate", "glcnac"),
+    "GlcNAc-\n6-P"
+  )
+  expect_identical(
+    inside("Fru-1,6-BP", "Fru-1,6-BP", "backbone", "fructose"),
+    "Fru-\n1,6-BP"
+  )
+  expect_identical(inside("R-5-P", "R-5-P", "ppp", "ribose"), "R-5-P")
+  expect_identical(inside("Glycerol-3-P", "Glycerol-3-P", "entry_intermediate", "glycerol"), "Gro-3-P")
+  expect_identical(inside("Pyruvate", "Pyruvate", "backbone", "intermediate"), "")
+  expect_identical(inside("Citrate", "Citrate", "tca", "intermediate"), "")
+})
+
+test_that("SNFG abbreviations use unambiguous standard residue names", {
+  expect_identical(DNMB:::.dnmb_snfg_abbreviation_v2("NAG"), "GlcNAc")
+  expect_identical(DNMB:::.dnmb_snfg_abbreviation_v2("glucosamine"), "GlcN")
+  expect_identical(DNMB:::.dnmb_snfg_abbreviation_v2("glca"), "GlcA")
+  expect_identical(DNMB:::.dnmb_snfg_abbreviation_v2("gala"), "GalA")
+  expect_identical(DNMB:::.dnmb_snfg_abbreviation_v2("deoxyribose"), "dRib")
+  expect_identical(DNMB:::.dnmb_snfg_abbreviation_v2("glycerol"), "Gro")
+})
+
+test_that("carbon-source glyphs contain abbreviations instead of full names", {
+  layer_labels <- function(plot) {
+    unlist(lapply(plot$layers, function(layer) {
+      if (!is.data.frame(layer$data) || !"label" %in% names(layer$data)) return(character(0))
+      as.character(layer$data$label)
+    }), use.names = FALSE)
+  }
+
+  maltose <- DNMB:::.dnmb_cct_render_carbon_source_node(
+    ggplot2::ggplot(), 1, 1, "Maltose"
+  )
+  nag <- DNMB:::.dnmb_cct_render_carbon_source_node(
+    ggplot2::ggplot(), 1, 1, "NAG"
+  )
+
+  expect_true("Mal" %in% layer_labels(maltose))
+  expect_false("Maltose" %in% layer_labels(maltose))
+  expect_true("Glc\nNAc" %in% layer_labels(nag))
+  expect_false("NAG" %in% layer_labels(nag))
+})
+
+test_that("SNFG legend is generated from every rendered sugar type", {
+  nodes <- data.frame(
+    sugar_type = c("glucose", "intermediate", "deoxyribose", "glucosamine", "glycerol"),
+    stringsAsFactors = FALSE
+  )
+  branches <- list(
+    Xylan = list(list(sugar = "arabinose"))
+  )
+  used <- DNMB:::.dnmb_cct_used_snfg_types(
+    cyto_nodes = nodes,
+    source_ids = c("Mannitol", "Lactose"),
+    monomer_ids = "gala",
+    extra_chains = list(Xylan = c("xylose", "xylose")),
+    extra_branches = branches
+  )
+  legend <- DNMB:::.dnmb_cct_snfg_legend_data(used)
+
+  expected <- c(
+    "glucose", "deoxyribose", "glucosamine", "glycerol", "mannitol",
+    "galactose", "gala", "xylose", "arabinose"
+  )
+  expect_setequal(used, expected)
+  expect_setequal(legend$sugar, used)
+  expect_false("intermediate" %in% legend$sugar)
+  expect_identical(
+    legend$label[legend$sugar == "deoxyribose"],
+    "2-Deoxy-D-ribose (dRib)"
+  )
+  expect_identical(
+    legend$label[legend$sugar == "glucosamine"],
+    "D-Glucosamine (GlcN)"
+  )
+  expect_identical(
+    legend$label[legend$sugar == "mannitol"],
+    "D-Mannitol (Mtl)"
+  )
+})

--- a/tests/testthat/test-cazy-sugar-icon-sizing.R
+++ b/tests/testthat/test-cazy-sugar-icon-sizing.R
@@ -1,0 +1,150 @@
+.cazy_symbol_core_half_span <- function(x, cx = 0, cy = 0) {
+  layers <- if (inherits(x, "ggplot")) x$layers else x
+  if (length(layers) < 2L) {
+    stop("SNFG symbols must contain a halo and a core layer")
+  }
+
+  # Every SNFG renderer puts its white clearance halo first. The remaining
+  # layers describe the actual symbol, its divider, and optional text.
+  core_layers <- layers[-1L]
+  spans <- vapply(core_layers, function(layer) {
+    if (inherits(layer$geom, "GeomCustomAnn")) {
+      bounds <- unlist(layer$geom_params[c("xmin", "xmax", "ymin", "ymax")])
+      if (length(bounds) == 4L && all(is.finite(bounds))) {
+        return(max(abs(bounds - c(cx, cx, cy, cy))))
+      }
+    }
+
+    dat <- layer$data
+    if (!is.data.frame(dat) || !nrow(dat)) return(0)
+    x_cols <- intersect(c("x", "xend"), names(dat))
+    y_cols <- intersect(c("y", "yend"), names(dat))
+    offsets <- c(
+      unlist(lapply(x_cols, function(nm) abs(as.numeric(dat[[nm]]) - cx))),
+      unlist(lapply(y_cols, function(nm) abs(as.numeric(dat[[nm]]) - cy)))
+    )
+    offsets <- offsets[is.finite(offsets)]
+    if (length(offsets)) max(offsets) else 0
+  }, numeric(1))
+
+  max(spans)
+}
+
+test_that("single SNFG shapes share one nominal icon half-span", {
+  requested_radius <- 0.10
+  representative_sugars <- c(
+    circle = "galactose",
+    square = "glcnac",
+    diamond = "glca",
+    triangle = "fucose",
+    star = "xylose",
+    pentagon = "fructose"
+  )
+
+  spans <- vapply(representative_sugars, function(sugar) {
+    layers <- DNMB:::.dnmb_snfg_symbol_layers_v2(
+      2, 3, sugar, size = requested_radius
+    )
+    .cazy_symbol_core_half_span(layers, cx = 2, cy = 3)
+  }, numeric(1))
+
+  expect_equal(
+    unname(spans),
+    rep(requested_radius, length(representative_sugars)),
+    tolerance = 1e-10
+  )
+})
+
+test_that("SNFG polygon shapes use a comparable centered bounding box", {
+  radius <- DNMB:::.dnmb_cct_sugar_icon_radius()
+  shape_types <- c("circle", "square", "diamond", "triangle", "star", "pentagon")
+  bounds <- vapply(shape_types, function(shape_type) {
+    points <- DNMB:::.dnmb_snfg_polygon_coords_v2(
+      shape_type, x = 0, y = 0, size = radius
+    )
+    c(
+      width = diff(range(points$x)),
+      height = diff(range(points$y)),
+      center_x = mean(range(points$x)),
+      center_y = mean(range(points$y))
+    )
+  }, numeric(4))
+
+  expect_equal(
+    unname(apply(bounds[c("width", "height"), , drop = FALSE], 2L, max)),
+    rep(2 * radius, length(shape_types)),
+    tolerance = 1e-10
+  )
+  expect_true(all(bounds[c("width", "height"), ] >= 1.70 * radius))
+  expect_equal(
+    max(abs(bounds[c("center_x", "center_y"), ])),
+    0,
+    tolerance = 1e-10
+  )
+})
+
+test_that("single-sugar carbon sources preserve the requested icon radius", {
+  requested_radius <- 0.10
+  source_ids <- c("Galactose", "NAG", "Gluconate", "Fucose", "Xylose", "Fructose")
+
+  spans <- vapply(source_ids, function(source_id) {
+    plot <- DNMB:::.dnmb_cct_render_carbon_source_node(
+      ggplot2::ggplot(), 2, 3, source_id, r = requested_radius
+    )
+    .cazy_symbol_core_half_span(plot, cx = 2, cy = 3)
+  }, numeric(1))
+
+  expect_equal(
+    unname(spans),
+    rep(requested_radius, length(source_ids)),
+    tolerance = 1e-10
+  )
+})
+
+test_that("direct and carbon-source monosaccharides use the same map footprint", {
+  requested_radius <- 0.10
+  direct <- DNMB:::.dnmb_snfg_symbol_layers_v2(
+    2, 3, "galactose", size = requested_radius
+  )
+  source <- DNMB:::.dnmb_cct_render_carbon_source_node(
+    ggplot2::ggplot(), 2, 3, "Galactose", r = requested_radius
+  )
+  default_source <- DNMB:::.dnmb_cct_render_carbon_source_node(
+    ggplot2::ggplot(), 2, 3, "Galactose"
+  )
+
+  direct_span <- .cazy_symbol_core_half_span(direct, cx = 2, cy = 3)
+  source_span <- .cazy_symbol_core_half_span(source, cx = 2, cy = 3)
+  default_span <- .cazy_symbol_core_half_span(default_source, cx = 2, cy = 3)
+
+  expect_equal(source_span, direct_span, tolerance = 1e-10)
+  expect_equal(default_span, direct_span, tolerance = 1e-10)
+})
+
+test_that("composite sugars keep full-size non-overlapping residue icons", {
+  requested_radius <- DNMB:::.dnmb_cct_sugar_icon_radius()
+  plot <- DNMB:::.dnmb_cct_render_carbon_source_node(
+    ggplot2::ggplot(), 2, 3, "Maltose", r = requested_radius
+  )
+  custom_layers <- Filter(
+    function(layer) inherits(layer$geom, "GeomCustomAnn"),
+    plot$layers
+  )
+  bounds <- lapply(custom_layers, function(layer) layer$geom_params)
+  radii <- vapply(bounds, function(item) {
+    (as.numeric(item$xmax) - as.numeric(item$xmin)) / 2
+  }, numeric(1))
+  centers <- vapply(bounds, function(item) {
+    (as.numeric(item$xmax) + as.numeric(item$xmin)) / 2
+  }, numeric(1))
+  core_centers <- sort(centers[abs(radii - requested_radius) <= 1e-10])
+
+  expect_equal(requested_radius, 0.10)
+  expect_equal(length(core_centers), 2L)
+  expect_equal(
+    unname(diff(core_centers)),
+    2.18 * requested_radius,
+    tolerance = 1e-10
+  )
+  expect_gt(diff(core_centers), 2 * requested_radius)
+})

--- a/tests/testthat/test-cazy-transporter-continuity.R
+++ b/tests/testthat/test-cazy-transporter-continuity.R
@@ -1,0 +1,205 @@
+.cazy_route_directions <- function(points, tolerance = 1e-8) {
+  if (is.null(points) || nrow(points) < 2L) return(character())
+  dx <- diff(points$x)
+  dy <- diff(points$y)
+  out <- ifelse(
+    abs(dx) <= tolerance & abs(dy) <= tolerance, "Z",
+    ifelse(abs(dy) <= tolerance, "H", ifelse(abs(dx) <= tolerance, "V", "D"))
+  )
+  out[out != "Z"]
+}
+
+test_that("selected transporters resolve to visible extracellular anchors", {
+  carbon_src <- data.frame(
+    id = c("Maltose", "Galactose", "Sucrose", "Mannitol"),
+    x = c(2, 4, 6, 8), y = rep(8, 4),
+    sugar_type = c("glucose", "galactose", "glucose", "mannose")
+  )
+  anchors <- DNMB:::.dnmb_cct_transporter_source_anchors(
+    cs_ids = carbon_src$id, carbon_src = carbon_src,
+    mono_x_map = c(galactose = 4.5), y_mono = 9.5,
+    extra_center_map = c(Maltose = 2.4),
+    extra_y_map = c(Maltose = 10.5)
+  )
+  anchors <- anchors[match(carbon_src$id, anchors$cs_id), , drop = FALSE]
+
+  expect_identical(anchors$source_kind,
+                   c("complex_chain", "monosaccharide",
+                     "explicit_source", "explicit_source"))
+  expect_equal(anchors$source_x, c(2.4, 4.5, 6, 8))
+  expect_equal(anchors$source_y, c(10.5, 9.5, 9.5, 9.5))
+  expect_identical(anchors$create_glyph, c(FALSE, FALSE, TRUE, TRUE))
+  expect_equal(anchors$cyto_x, carbon_src$x)
+  expect_false("Ribose" %in% anchors$cs_id)
+})
+
+test_that("transporter pathways never substitute chemically distinct sugars", {
+  pathway_map <- DNMB:::.dnmb_cct_transporter_pathway_map()
+  pul_map <- DNMB:::.dnmb_cct_pul_substrate_to_cs()
+
+  expect_identical(unname(pathway_map["glucose"]), "Glucose")
+  expect_identical(unname(pathway_map["maltose"]), "Maltose")
+  expect_true(is.na(unname(pathway_map["deoxyribonate"])))
+  expect_identical(unname(pul_map["glucose"]), "Glucose")
+  expect_true(is.na(unname(pul_map["pectin"])))
+})
+
+test_that("explicit uptake glyphs are packed away from visible monomers", {
+  carbon_src <- data.frame(
+    id = c("Sucrose", "Mannitol"),
+    x = c(4, 4.1), y = c(8, 8),
+    sugar_type = c("fructose", "mannose"),
+    stringsAsFactors = FALSE
+  )
+  anchors <- DNMB:::.dnmb_cct_transporter_source_anchors(
+    cs_ids = carbon_src$id,
+    carbon_src = carbon_src,
+    mono_x_map = c(glucose = 4, fructose = 5),
+    y_mono = 9.5
+  )
+
+  expect_true(all(anchors$create_glyph))
+  expect_gte(min(abs(outer(anchors$source_x, c(4, 5), "-"))), 0.5 - 1e-10)
+  expect_gte(abs(diff(sort(anchors$source_x))), 0.5 - 1e-10)
+})
+
+test_that("exterior bus paths use visible source coordinates and one rounded elbow pass", {
+  memberships <- data.frame(
+    cs_id = c("Maltose", "Maltose"),
+    lane_x = c(99, 99),
+    source_x = c(2.4, 2.4), source_y = c(10.5, 10.5),
+    tx_draw = c(4, 5), ty_draw = c(8.5, 8.5),
+    confidence = c("high", "high"),
+    locus_tag = c("T_A", "T_B"),
+    color = c("#123456", "#123456"), stringsAsFactors = FALSE
+  )
+  layout <- DNMB:::.dnmb_cct_transporter_bus_layout(
+    memberships, y_memb = 8.5, corner_radius = 0.08
+  )
+
+  expect_equal(length(layout$exterior_routes), 2L)
+  expect_true(all(layout$memberships$lane_x == 2.4))
+  for (route in layout$exterior_routes) {
+    expect_equal(unlist(route$points[1, c("x", "y")]),
+                 c(x = 2.4, y = 10.5))
+    expect_equal(unlist(route$points[nrow(route$points), c("x", "y")]),
+                 c(x = route$target_x, y = route$target_y))
+    directions <- .cazy_route_directions(route$points)
+    adjacent <- if (length(directions) > 1L) {
+      paste(head(directions, -1L), tail(directions, -1L), sep = "")
+    } else character()
+    expect_false(any(adjacent %in% c("HV", "VH")))
+    expect_true("D" %in% directions)
+  }
+})
+
+test_that("aligned and empty transporter layouts never create orphan guides", {
+  empty <- DNMB:::.dnmb_cct_transporter_bus_layout(NULL)
+  expect_length(empty$exterior_routes, 0L)
+
+  aligned <- data.frame(
+    cs_id = "Ribose", lane_x = 3, source_x = 3, source_y = 9.5,
+    tx_draw = 3, ty_draw = 8.5, confidence = "high",
+    locus_tag = "RBS_T", color = "#008000", stringsAsFactors = FALSE
+  )
+  layout <- DNMB:::.dnmb_cct_transporter_bus_layout(aligned)
+  expect_length(layout$exterior_routes, 1L)
+  points <- layout$exterior_routes[[1L]]$points
+  expect_equal(unlist(points[1L, c("x", "y")]), c(x = 3, y = 9.5))
+  expect_equal(
+    unlist(points[nrow(points), c("x", "y")]),
+    c(x = 3, y = 8.61)
+  )
+  expect_true(all(abs(diff(points$x)) <= 1e-10))
+  expect_false("D" %in% .cazy_route_directions(points))
+})
+
+test_that("selected transporter paths continue from membrane into the cytoplasmic source", {
+  memberships <- data.frame(
+    cs_id = c("Sucrose", "Mannitol"),
+    locus_tag = c("SCR_T", "MTL_T"),
+    tx_draw = c(5.4, 8.3), ty_draw = c(8.5, 8.62),
+    cyto_x = c(6, 8), cyto_y = c(8, 8),
+    confidence = c("high", "medium"),
+    color = c("#00A651", "#3182BD"), stringsAsFactors = FALSE
+  )
+  routes <- DNMB:::.dnmb_cct_transporter_interior_routes(
+    memberships, y_memb = 8.5, corner_radius = 0.08
+  )
+
+  expect_equal(length(routes), 2L)
+  for (i in seq_along(routes)) {
+    points <- routes[[i]]$points
+    row <- memberships[memberships$locus_tag == routes[[i]]$target_key, ]
+    expect_equal(unlist(points[1, c("x", "y")]),
+                 c(x = row$tx_draw, y = row$ty_draw - 0.11))
+    expect_equal(unlist(points[nrow(points), c("x", "y")]),
+                 c(x = row$cyto_x, y = row$cyto_y + 0.11))
+    directions <- .cazy_route_directions(points)
+    adjacent <- if (length(directions) > 1L) {
+      paste(head(directions, -1L), tail(directions, -1L), sep = "")
+    } else character()
+    expect_false(any(adjacent %in% c("HV", "VH")))
+    expect_true("D" %in% directions)
+  }
+
+  expect_length(DNMB:::.dnmb_cct_transporter_interior_routes(NULL), 0L)
+  expect_length(DNMB:::.dnmb_cct_transporter_interior_routes(
+    memberships[0, , drop = FALSE]
+  ), 0L)
+})
+
+test_that("every drawn membership has exterior and interior halves at the same T-ID", {
+  memberships <- data.frame(
+    cs_id = c("Glucose", "Glucose", "Maltose", "Mannitol"),
+    locus_tag = c("T_SHARED", "T_MEDIUM", "T_SHARED", "T_MTL"),
+    source_x = c(2, 2, 4, 6), source_y = c(9.5, 9.5, 10.5, 9.5),
+    lane_x = c(2, 2, 4, 6),
+    tx_draw = c(3, 3.5, 3, 6.5), ty_draw = rep(8.5, 4),
+    cyto_x = c(2.5, 2.5, 4.5, 6), cyto_y = rep(8, 4),
+    confidence = c("high", "medium", "high", "medium"),
+    color = c("#004A7C", "#004A7C", "#004A7C", "#1B5A8A"),
+    stringsAsFactors = FALSE
+  )
+  layout <- DNMB:::.dnmb_cct_transporter_bus_layout(
+    memberships, y_memb = 8.5, suppress_redundant_medium = TRUE
+  )
+  drawn <- layout$memberships[layout$memberships$draw, , drop = FALSE]
+  draw_keys <- paste(drawn$cs_id, drawn$target_key, sep = "\r")
+  membership_keys <- paste(memberships$cs_id, memberships$locus_tag, sep = "\r")
+  selected <- memberships[membership_keys %in% draw_keys, , drop = FALSE]
+  interior <- DNMB:::.dnmb_cct_transporter_interior_routes(selected, y_memb = 8.5)
+
+  exterior_keys <- vapply(layout$exterior_routes, function(route) {
+    paste(route$cs_id, route$target_key, sep = "\r")
+  }, character(1))
+  interior_keys <- vapply(interior, function(route) {
+    paste(route$cs_id, route$target_key, sep = "\r")
+  }, character(1))
+  expect_setequal(exterior_keys, interior_keys)
+  expect_false(paste("Glucose", "T_MEDIUM", sep = "\r") %in% exterior_keys)
+  expect_true(paste("Glucose", "T_SHARED", sep = "\r") %in% exterior_keys)
+  expect_true(paste("Maltose", "T_SHARED", sep = "\r") %in% exterior_keys)
+})
+
+test_that("suppressed transporter entities remain ledger-only", {
+  memberships <- data.frame(
+    cs_id = c("Glucose", "Glucose"),
+    lane_x = c(2, 2), source_x = c(2, 2), source_y = c(9.7, 9.7),
+    tx_draw = c(3, 4), ty_draw = c(8.5, 8.5),
+    confidence = c("high", "medium"),
+    locus_tag = c("T_HIGH", "T_MEDIUM"),
+    color = c("#004A7C", "#004A7C"), stringsAsFactors = FALSE
+  )
+  entities <- data.frame(
+    locus_tag = c("T_HIGH", "T_MEDIUM"),
+    anchor_id = c("T01", "T02"), stringsAsFactors = FALSE
+  )
+  layout <- DNMB:::.dnmb_cct_transporter_bus_layout(memberships)
+  drawn <- DNMB:::.dnmb_cct_drawn_transporter_entities(
+    entities, layout$memberships
+  )
+
+  expect_identical(drawn$locus_tag, "T_HIGH")
+  expect_true("T_MEDIUM" %in% entities$locus_tag)
+})

--- a/tests/testthat/test-dbcan-evidence-mapping.R
+++ b/tests/testthat/test-dbcan-evidence-mapping.R
@@ -1,0 +1,1122 @@
+make_dbcan_genes <- function() {
+  data.frame(
+    locus_tag = c("Athe_2769", "Athe_2770", NA_character_, "context_gene"),
+    protein_id = c("P2769", "P2770", "CAD88572.1", NA_character_),
+    translation = c("MAAAAA", "MBBBBB", "MCCCCC", NA_character_),
+    contig = rep("same display definition", 4),
+    contig_number = c(1L, 2L, 2L, 2L),
+    start = c(1L, 1L, 100L, 220L),
+    end = c(18L, 18L, 117L, 300L),
+    direction = c("+", "-", "+", "+"),
+    stringsAsFactors = FALSE
+  )
+}
+
+write_dbcan_overview_fixture <- function(path) {
+  fixture <- data.frame(
+    "Gene ID" = c("DNMBCAZY_0000001", "DNMBCAZY_0000002", "DNMBCAZY_0000003", "legacy_0004"),
+    "EC#" = c("3.2.1.1", "-", "-", "-"),
+    dbCAN_hmm = c("CBM34(1-80)+GH13_39(81-300)", "-", "-", "GH5(1-100)"),
+    dbCAN_sub = c("CBM34_e14|CBM34_e14|GH13_39", "GH20_e1", "-", "-"),
+    DIAMOND = c("GH13_39", "GH20", "GT4", "-"),
+    "#ofTools" = c(3L, 2L, 1L, 1L),
+    "Recommend Results" = c("CBM34_e14|CBM34_e14|GH13_39", "GH20_e1", "-", "-"),
+    Substrate = c("-;alpha-glucan", "hostglycan", "-", "cellulose"),
+    check.names = FALSE,
+    stringsAsFactors = FALSE
+  )
+  utils::write.table(fixture, path, sep = "\t", row.names = FALSE, quote = FALSE)
+  invisible(path)
+}
+
+read_dbcan_pdf_geometry <- function(path) {
+  pdfinfo <- Sys.which("pdfinfo")
+  if (!nzchar(pdfinfo)) return(NULL)
+
+  info <- system2(pdfinfo, shQuote(normalizePath(path)), stdout = TRUE, stderr = TRUE)
+  page_line <- grep("^Pages:", info, value = TRUE)
+  size_line <- grep("^Page size:", info, value = TRUE)
+  if (length(page_line) != 1L || length(size_line) != 1L) return(NULL)
+
+  size_match <- regmatches(
+    size_line,
+    regexec(
+      "^Page size:[[:space:]]*([0-9.]+)[[:space:]]+x[[:space:]]+([0-9.]+)[[:space:]]+pts",
+      size_line
+    )
+  )[[1]]
+  if (length(size_match) != 3L) return(NULL)
+
+  list(
+    pages = as.integer(sub("^Pages:[[:space:]]*", "", page_line)),
+    width_pt = as.numeric(size_match[[2]]),
+    height_pt = as.numeric(size_match[[3]])
+  )
+}
+
+test_that("dbCAN synthetic IDs preserve locus suffixes and separate replicons", {
+  genes <- make_dbcan_genes()
+  id_map <- DNMB:::.dnmb_dbcan_build_gene_map(genes)
+
+  expect_identical(id_map$mapping_id[1:3], c("Athe_2769", "Athe_2770", "CAD88572.1"))
+  expect_length(unique(id_map$dbcan_query_id), nrow(genes))
+  expect_identical(id_map$dbcan_contig_key[1:2], c("replicon_0001", "replicon_0002"))
+
+  fasta <- tempfile(fileext = ".faa")
+  gff <- tempfile(fileext = ".gff")
+  on.exit(unlink(c(fasta, gff), force = TRUE), add = TRUE)
+  fasta_info <- DNMB:::.dnmb_dbcan_write_mapped_query_fasta(id_map, fasta)
+  gff_info <- DNMB:::.dnmb_dbcan_write_query_gff(genes, gff, id_map = id_map)
+
+  expect_identical(fasta_info$n, 3L)
+  expect_identical(DNMB:::.dnmb_fasta_headers(fasta), id_map$dbcan_query_id[1:3])
+  expect_identical(nrow(gff_info$contig_map), 2L)
+  gff_body <- readLines(gff)[-1]
+  expect_true(any(startsWith(gff_body, "ctg1\t")))
+  expect_true(any(startsWith(gff_body, "ctg2\t")))
+  expect_true(any(grepl("DNMBCAZY_0000004", gff_body, fixed = TRUE)))
+})
+
+test_that("dbCAN overview retains consensus, multi-domain calls, and evidence tiers", {
+  path <- tempfile(fileext = ".tsv")
+  on.exit(unlink(path, force = TRUE), add = TRUE)
+  write_dbcan_overview_fixture(path)
+  id_map <- DNMB:::.dnmb_dbcan_build_gene_map(make_dbcan_genes())
+  overview <- DNMB:::dnmb_dbcan_parse_overview(path, id_map = id_map)
+
+  expect_identical(overview$query[1:3], c("Athe_2769", "Athe_2770", "CAD88572.1"))
+  expect_identical(overview$dbcan_all_families[[1]], "CBM34; GH13_39")
+  expect_identical(overview$dbcan_primary_family[[1]], "GH13_39")
+  expect_identical(overview$dbcan_family_count[[1]], 2L)
+  expect_identical(overview$dbcan_evidence_tier, c("very_high", "high", "audit", "medium"))
+  expect_identical(overview$dbcan_overview_substrate[1:2], c("alpha-glucan", "host glycan"))
+  expect_identical(
+    DNMB:::.dnmb_dbcan_family_tokens(overview$dbcan_all_families[[1]]),
+    c("CBM34", "GH13_39")
+  )
+})
+
+test_that("CAZy 3-zone map retains every GH domain from multi-domain calls", {
+  genes <- data.frame(
+    locus_tag = c("gene_1", "gene_2", "gene_3", "gene_4"),
+    gene = c("amyA", "celA", "nagA", "cbm_only"),
+    dbCAN_dbcan_all_families = c("CBM34; GH13_39", NA_character_, "GT4; GH20_e1", "CBM50"),
+    dbCAN_dbcan_hit = c("GH13_39", NA_character_, "GT4", "GH99"),
+    dbCAN_family_id = c("GH99", "GH5", "GT4", "GH5"),
+    stringsAsFactors = FALSE
+  )
+
+  gh <- DNMB:::.dnmb_cct_3zone_extract_gh(genes)
+
+  expect_identical(gh$locus_tag, c("gene_1", "gene_2", "gene_3"))
+  expect_identical(gh$gh_family, c("GH13_39", "GH5", "GH20"))
+})
+
+test_that("CAZy transporter packing separates dense glyph intervals", {
+  packed <- DNMB:::.dnmb_cct_pack_transporters_lane(
+    center_x = 10,
+    half_spans = rep(0.14, 8),
+    lane_ranks = 8:1,
+    label_widths = rep(0.5, 8),
+    label_dx = rep(0, 8),
+    desired_x = rep(10, 8),
+    y_memb = 8.5
+  )
+
+  expect_equal(nrow(packed), 8L)
+  expect_true(all(is.finite(packed$tx)))
+  expect_true(all(is.finite(packed$ty)))
+  expect_gte(length(unique(packed$row_id)), 2L)
+  expect_lte(max(packed$row_id), 3L)
+  expect_lte(max(abs(packed$ty - 8.5)), 0.12)
+  expect_gte(min(diff(sort(unique(packed$ty)))), 0.12 - 1e-10)
+
+  for (row_id in unique(packed$row_id)) {
+    row <- packed[packed$row_id == row_id, , drop = FALSE]
+    row <- row[order(row$tx), , drop = FALSE]
+    if (nrow(row) < 2L) next
+    edge_gap <- diff(row$tx) - 0.14 - 0.14
+    expect_true(all(edge_gap >= 0.08 - 1e-10))
+  }
+})
+
+test_that("CAZy transporter buses consolidate substrate memberships deterministically", {
+  memberships <- data.frame(
+    cs_id = c("A", "A", "A", "B", "C", "D", "E", "F"),
+    lane_x = c(1, 1, 1, 2, 3, 4, 5, 6),
+    tx_draw = c(4, 5, 6, 4, 4, 5, 5, 6),
+    ty_draw = c(8.5, 8.62, 8.5, 8.5, 8.5, 8.62, 8.62, 8.5),
+    confidence = c("high", "high", "medium", "high", "high", "high", "medium", "high"),
+    locus_tag = c("shared_1", "shared_2", "medium_only", "shared_1",
+                  "shared_1", "shared_2", "shared_2", "direct_1"),
+    color = c("#A00000", "#A00000", "#A00000", "#0060A0",
+              "#008060", "#7040A0", "#A07000", "#303030"),
+    stringsAsFactors = FALSE
+  )
+
+  layout <- DNMB:::.dnmb_cct_transporter_bus_layout(memberships, y_memb = 8.5)
+  shuffled <- DNMB:::.dnmb_cct_transporter_bus_layout(
+    memberships[c(6, 2, 8, 1, 7, 4, 3, 5), ], y_memb = 8.5
+  )
+
+  expect_equal(
+    layout$groups[order(layout$groups$group), ],
+    shuffled$groups[order(shuffled$groups$group), ],
+    ignore_attr = TRUE
+  )
+  expect_equal(
+    layout$trunks[order(layout$trunks$group), ],
+    shuffled$trunks[order(shuffled$trunks$group), ],
+    ignore_attr = TRUE
+  )
+  expect_equal(sum(layout$memberships$draw), 7L)
+  expect_false(layout$memberships$draw[layout$memberships$target_key == "medium_only"])
+  expect_equal(sum(layout$groups$direct), 2L)
+  expect_equal(nrow(layout$direct), 1L)
+
+  bus_groups <- layout$groups[!layout$groups$direct, , drop = FALSE]
+  expect_true(all(bus_groups$bus_y >= 8.5 + 0.70 - 1e-10))
+  expect_true(all(bus_groups$bus_y <= 8.5 + 1.12 + 1e-10))
+  for (tier in unique(bus_groups$tier)) {
+    row <- bus_groups[bus_groups$tier == tier, , drop = FALSE]
+    row <- row[order(row$x_left), , drop = FALSE]
+    if (nrow(row) < 2L) next
+    expect_true(all(head(row$x_right, -1L) + 0.05 <= tail(row$x_left, -1L) + 1e-10))
+  }
+
+  # Three substrate lanes share one physical target but produce one trunk.
+  expect_equal(sum(layout$trunks$group == "target:shared_1"), 1L)
+  expect_equal(sum(layout$trunks$group == "target:shared_2"), 1L)
+  expect_true(all(pmin(layout$stems$y, layout$stems$yend) > 8.5 + 0.20))
+  expect_true(all(layout$trunks$y > 8.5 + 0.20))
+  expect_true(all(layout$trunks$yend >= 8.5 + 0.11 - 1e-10))
+})
+
+test_that("CAZy transporter bus tiers stay inside their reserved vertical band", {
+  memberships <- data.frame(
+    cs_id = sprintf("S%02d", seq_len(20)),
+    lane_x = seq_len(20),
+    tx_draw = rep(20.5, 20),
+    ty_draw = rep(8.5, 20),
+    confidence = rep("high", 20),
+    locus_tag = rep("shared_target", 20),
+    color = rep("#52616B", 20),
+    stringsAsFactors = FALSE
+  )
+
+  layout <- DNMB:::.dnmb_cct_transporter_bus_layout(
+    memberships,
+    y_memb = 8.5,
+    bus_offset = 0.62,
+    max_bus_offset = 0.86
+  )
+  buses <- layout$groups[!layout$groups$direct, , drop = FALSE]
+
+  expect_gt(length(unique(buses$tier)), 10L)
+  expect_gte(min(buses$bus_y), 8.5 + 0.62 - 1e-10)
+  expect_lte(max(buses$bus_y), 8.5 + 0.86 + 1e-10)
+  expect_equal(nrow(layout$trunks), 1L)
+})
+
+test_that("CAZy transporter labels use deterministic tracks above the membrane", {
+  labels <- data.frame(
+    x = c(1, 1.02, 1.04, 3, 4, 4.02),
+    y = rep(8.5, 6),
+    label = sprintf("T%02d", seq_len(6)),
+    color = rep("#102A43", 6),
+    size = rep(1.6, 6),
+    fontface = rep("bold", 6),
+    hjust = rep(0.5, 6),
+    priority = c(20, 10, 20, 10, 20, 10),
+    stringsAsFactors = FALSE
+  )
+
+  laid_out <- DNMB:::.dnmb_cct_layout_transporter_labels(
+    labels, xlim = c(0, 5), y_memb = 8.5
+  )
+  shuffled <- DNMB:::.dnmb_cct_layout_transporter_labels(
+    labels[c(4, 1, 6, 2, 5, 3), ], xlim = c(0, 5), y_memb = 8.5
+  )
+
+  expect_equal(
+    laid_out[order(laid_out$label), c("x_lab", "y_lab", "track_level")],
+    shuffled[order(shuffled$label), c("x_lab", "y_lab", "track_level")],
+    ignore_attr = TRUE
+  )
+  expect_true(all(laid_out$track_level %in% 0:2))
+  expect_equal(
+    laid_out$y_lab,
+    8.5 + 0.40 + laid_out$track_level * 0.16,
+    tolerance = 1e-10
+  )
+  expect_true(all(laid_out$y_lab > 8.5))
+  expect_true(all(laid_out$x_lab - laid_out$label_width / 2 >= 0))
+  expect_true(all(laid_out$x_lab + laid_out$label_width / 2 <= 5))
+
+  for (track in unique(laid_out$track_level)) {
+    row <- laid_out[laid_out$track_level == track, , drop = FALSE]
+    row <- row[order(row$x_lab), , drop = FALSE]
+    if (nrow(row) < 2L) next
+    required <- (head(row$label_width, -1) + tail(row$label_width, -1)) / 2 + 0.08
+    expect_true(all(diff(row$x_lab) >= required - 1e-10))
+  }
+})
+
+test_that("CAZy transporter labels use fixed text and short orthogonal leaders", {
+  labels <- data.frame(
+    x = c(1, 1.02, 2), y = rep(8.5, 3),
+    label = c("T01", "T02", "T03"),
+    color = c("#102A43", "#52616B", "#102A43"),
+    size = rep(1.6, 3), fontface = rep("bold", 3),
+    hjust = rep(0.5, 3), priority = c(20, 10, 20),
+    stringsAsFactors = FALSE
+  )
+  laid_out <- DNMB:::.dnmb_cct_layout_transporter_labels(
+    labels, xlim = c(0, 3), y_memb = 8.5
+  )
+  leaders <- DNMB:::.dnmb_cct_transporter_label_leaders(laid_out)
+
+  expect_equal(nrow(leaders), 3L * sum(laid_out$draw_leader))
+  expect_false(any(
+    laid_out$track_level == 0L &
+      abs(laid_out$x_lab - laid_out$anchor_x) <= 0.04 &
+      laid_out$draw_leader
+  ))
+  for (segment in split(leaders, leaders$group)) {
+    expect_equal(segment$x[1], segment$x[2], tolerance = 1e-10)
+    expect_equal(segment$y[2], segment$y[3], tolerance = 1e-10)
+    expect_true(segment$y[1] < segment$y[2])
+  }
+
+  layer <- DNMB:::.dnmb_cct_transporter_text_layer(laid_out)
+  expect_s3_class(layer, "Layer")
+  expect_true(inherits(layer$geom, "GeomText"))
+  expect_false(inherits(layer$geom, "GeomTextRepel"))
+  expect_no_error(ggplot2::ggplot_build(ggplot2::ggplot() + layer))
+})
+
+test_that("CAZy cleavage scissors have handles, crossed blades, and a pivot", {
+  geom0 <- DNMB:::.dnmb_scissors_geometry_v2(2, 3, size = 0.1, angle = 0)
+  geom90 <- DNMB:::.dnmb_scissors_geometry_v2(2, 3, size = 0.1, angle = 90)
+
+  expect_equal(nrow(geom0$handles), 2L)
+  expect_equal(nrow(geom0$shanks), 2L)
+  expect_equal(nrow(geom0$blades), 2L)
+  expect_equal(unname(unlist(geom0$pivot[1, c("x", "y")])), c(2, 3))
+  expect_true(all(geom0$handles$x < geom0$pivot$x))
+  expect_true(all(geom0$tips$x > geom0$pivot$x))
+
+  distance_from_pivot <- function(points, pivot) {
+    sqrt((points$x - pivot$x)^2 + (points$y - pivot$y)^2)
+  }
+  expect_equal(
+    distance_from_pivot(geom0$handles, geom0$pivot),
+    distance_from_pivot(geom90$handles, geom90$pivot),
+    tolerance = 1e-10
+  )
+  layers <- DNMB:::.dnmb_scissors_grob_v2(2, 3, size = 0.1)
+  expect_length(layers, 6L)
+  expect_equal(sum(vapply(layers, function(layer) inherits(layer$geom, "GeomCustomAnn"), logical(1))), 3L)
+  expect_false(any(vapply(layers, function(layer) inherits(layer$geom, "GeomPolygon"), logical(1))))
+})
+
+test_that("CAZy circular SNFG symbols use native circles rather than polygons", {
+  circle_layers <- DNMB:::.dnmb_snfg_symbol_layers_v2(1, 1, "glucose", size = 0.1)
+  square_layers <- DNMB:::.dnmb_snfg_symbol_layers_v2(1, 1, "glcnac", size = 0.1)
+
+  expect_true(all(vapply(
+    circle_layers,
+    function(layer) inherits(layer$geom, "GeomCustomAnn"),
+    logical(1)
+  )))
+  expect_false(any(vapply(
+    circle_layers,
+    function(layer) inherits(layer$geom, "GeomPolygon"),
+    logical(1)
+  )))
+  expect_true(any(vapply(
+    square_layers,
+    function(layer) inherits(layer$geom, "GeomPolygon"),
+    logical(1)
+  )))
+})
+
+test_that("CAZy final annotation layer accepts multiline labels and node obstacles", {
+  labels <- data.frame(
+    x = c(1, 1.02), y = c(1, 1.01),
+    label = c("transporter\ngene_1", "GH13_39\ngene_2"),
+    color = c("#111111", "#C62828"), size = c(0.8, 1.0),
+    fontface = "bold", hjust = 0.5, priority = c(10, 9),
+    nudge_x = 0, nudge_y = c(0.1, -0.1),
+    stringsAsFactors = FALSE
+  )
+  obstacles <- DNMB:::.dnmb_cct_obstacle_perimeter(1, 1, rx = 0.2, ry = 0.1)
+  expect_equal(nrow(obstacles), 9L)
+  expect_equal(range(obstacles$x), c(0.8, 1.2), tolerance = 1e-10)
+  expect_equal(range(obstacles$y), c(0.9, 1.1), tolerance = 1e-10)
+
+  layer <- DNMB:::.dnmb_cct_final_text_layer(
+    labels,
+    obstacles = obstacles,
+    xlim = c(0, 2), ylim = c(0, 2)
+  )
+
+  expect_s3_class(layer, "Layer")
+  expect_no_error(ggplot2::ggplot_build(ggplot2::ggplot() + layer))
+})
+
+test_that("CAZy transporter entities preserve supported shared memberships", {
+  transporters <- data.frame(
+    locus_tag = c(
+      rep("AADSM_000052", 5),
+      rep("AADSM_001386", 4),
+      NA_character_
+    ),
+    pathway = c(
+      "arabinose", "galactose", "xylose", "xylose", "sucrose",
+      "arabinose", "galactose", "xylose", "maltose",
+      "arabinose"
+    ),
+    step = c(
+      "araE", "galP", "xylT", "xylT", "MFS-glucose",
+      "araE", "galP", "xylT", "MFS-glucose",
+      "araE"
+    ),
+    cs_id = c(
+      "Arabinose", "Galactose", "Xylose", "Xylose", "Sucrose",
+      "Arabinose", "Galactose", "Xylose", "Maltose",
+      "Arabinose"
+    ),
+    confidence = c(
+      "high", "high", "high", "medium", "none",
+      "high", "high", "none", "low",
+      "high"
+    ),
+    step_score = c(2, 2, 2, 1, 0, 2, 2, 2, 0, 2),
+    stringsAsFactors = FALSE
+  )
+
+  result <- DNMB:::.dnmb_cct_transporter_entities(transporters)
+
+  expect_setequal(result$entities$locus_tag, c("AADSM_000052", "AADSM_001386"))
+  expect_equal(nrow(result$memberships), 6L)
+  membership_counts <- table(result$memberships$locus_tag)
+  expect_setequal(names(membership_counts), c("AADSM_000052", "AADSM_001386"))
+  expect_identical(as.integer(membership_counts), c(3L, 3L))
+  expect_setequal(result$memberships$step, c("araE", "galP", "xylT"))
+  expect_false(any(result$memberships$step == "MFS-glucose"))
+  expect_true(all(result$entities$shared))
+
+  for (label in result$entities$label) {
+    expect_match(label, "araE", fixed = TRUE)
+    expect_match(label, "galP", fixed = TRUE)
+    expect_match(label, "xylT", fixed = TRUE)
+    expect_match(label, "Arabinose", fixed = TRUE)
+    expect_match(label, "Galactose", fixed = TRUE)
+    expect_match(label, "Xylose", fixed = TRUE)
+    expect_match(label, "Shared: yes", fixed = TRUE)
+    expect_false(grepl("+N genes", label, fixed = TRUE))
+    expect_false(grepl("...", label, fixed = TRUE))
+  }
+})
+
+test_that("CAZy transporter recognition includes xylT and SSS models", {
+  expect_true(DNMB:::.dnmb_cct_is_transport_like_step("xylT"))
+  expect_true(DNMB:::.dnmb_cct_is_transport_like_step("SSS-glucose"))
+  expect_true(DNMB:::.dnmb_cct_is_transport_like_step(
+    "BT0355", gene_name = "sodium:solute symporter family protein"
+  ))
+})
+
+test_that("CAZy pathway presence separates active, partial, and reference metabolism", {
+  steps <- data.frame(
+    pathway_id = c("xylose", "xylose", "arabinose", "arabinose", "sucrose"),
+    step_id = c("xylA", "xylB", "araE", "araA", "sucA"),
+    confidence = c("high", "high", "high", "medium", "high"),
+    locus_tag = paste0("LOC_", seq_len(5)),
+    stringsAsFactors = FALSE
+  )
+  stats <- data.frame(
+    pathway_id = c("xylose", "arabinose", "sucrose", "glucosamine"),
+    fraction = c(1, 0.5, 1, 0),
+    stringsAsFactors = FALSE
+  )
+
+  presence <- DNMB:::.dnmb_cct_pathway_presence(
+    steps, stats,
+    valid_pathways = c("xylose", "arabinose", "sucrose", "glucosamine")
+  )
+  state <- setNames(presence$cytoplasm_status, presence$pathway_id)
+
+  expect_identical(unname(state["xylose"]), "active")
+  expect_identical(unname(state["arabinose"]), "active")
+  expect_identical(unname(state["sucrose"]), "partial")
+  expect_identical(unname(state["glucosamine"]), "reference")
+  expect_equal(presence$n_transport[presence$pathway_id == "arabinose"], 1L)
+  expect_equal(presence$n_intracellular[presence$pathway_id == "xylose"], 2L)
+})
+
+test_that("CAZy route labels never collapse distinct genes at a shared target", {
+  labels <- data.frame(
+    x = c(1, 1.1, 2), y = c(1, 1.1, 2),
+    label = c("stepA\nA", "stepD\nD", "stepA\nA"),
+    base_label = c("stepA\nA", "stepD\nD", "stepA\nA"),
+    step_id = c("stepA", "stepD", "stepA"),
+    locus_tag = c("A", "D", "A"),
+    member_loci = c("A;B;C", "D;E;F", "A"),
+    member_keys = c("sA::A;sB::B;sC::C", "sD::D;sE::E;sF::F", "sA::A"),
+    target_id = c("target_1", "target_1", "target_2"),
+    priority = c(10, 9, 8),
+    stringsAsFactors = FALSE
+  )
+
+  collapsed <- DNMB:::.dnmb_cct_collapse_route_labels(labels)
+  target_1 <- collapsed[collapsed$target_id == "target_1", , drop = FALSE]
+  target_2 <- collapsed[collapsed$target_id == "target_2", , drop = FALSE]
+
+  expect_equal(nrow(collapsed), 3L)
+  expect_setequal(target_1$label, c("stepA\nA", "stepD\nD"))
+  expect_false(any(grepl("\\(\\+[0-9]+ genes?\\)", collapsed$label)))
+  expect_setequal(target_1$locus_tag, c("A", "D"))
+  expect_identical(target_2$label, "stepA\nA")
+  expect_identical(target_2$member_loci, "A")
+})
+
+test_that("dbCAN output maps consensus-only genes by original gene row", {
+  genes <- make_dbcan_genes()[1:3, ]
+  id_map <- DNMB:::.dnmb_dbcan_build_gene_map(genes)
+  overview_path <- tempfile(fileext = ".tsv")
+  on.exit(unlink(overview_path, force = TRUE), add = TRUE)
+  write_dbcan_overview_fixture(overview_path)
+  overview <- DNMB:::dnmb_dbcan_parse_overview(overview_path, id_map = id_map)
+
+  raw <- DNMB:::.dnmb_dbcan_empty_hits()
+  raw <- rbind(
+    raw,
+    data.frame(
+      query = "DNMBCAZY_0000001", profile_id = "GH13_39.hmm",
+      profile_length = 300L, gene_length = 320L, evalue = 1e-40,
+      profile_start = 1L, profile_end = 290L, gene_start = 10L,
+      gene_end = 300L, coverage = 0.967, family_id = "GH13_39",
+      hit_label = "GH13_39", substrate_label = NA_character_
+    )
+  )
+  raw <- DNMB:::.dnmb_dbcan_restore_query_map(raw, id_map)
+  hmm_hits <- DNMB:::dnmb_dbcan_normalize_hits(raw)
+  hits <- DNMB:::.dnmb_dbcan_merge_overview_hits(hmm_hits, overview[1:3, ])
+  out <- DNMB:::.dnmb_dbcan_output_table(
+    genes = genes,
+    hits = hits,
+    overview = overview[1:3, ],
+    id_map = id_map
+  )
+
+  expect_identical(out$locus_tag[1:2], c("Athe_2769", "Athe_2770"))
+  expect_identical(out$dbcan_hit[1:3], c("CBM34; GH13_39", "GH20", "GT4"))
+  expect_identical(out$dbcan_hmm_domain_count[[1]], 1L)
+  expect_true(is.na(out$dbcan_hmm_domain_count[[2]]))
+  expect_identical(sort(unique(hits$query)), sort(overview$query[1:3]))
+  expect_false(hits$typing_eligible[hits$query == "CAD88572.1"][[1]])
+})
+
+test_that("dbCAN HMM fallback keeps duplicate locus tags separate by gene row", {
+  genes <- data.frame(
+    locus_tag = c("dup", "dup"),
+    protein_id = c("p1", "p2"),
+    translation = c("MAAAA", "MBBBB"),
+    contig = c("same definition", "same definition"),
+    contig_number = c(1L, 2L),
+    start = c(1L, 1L),
+    end = c(15L, 15L),
+    direction = c("+", "+"),
+    stringsAsFactors = FALSE
+  )
+  id_map <- DNMB:::.dnmb_dbcan_build_gene_map(genes)
+  hits <- tibble::tibble(
+    query = c("dup", "dup"),
+    source = "dbcan",
+    family_system = "dbCAN",
+    family_id = c("GH1", "GT2"),
+    hit_label = c("GH1", "GT2"),
+    enzyme_role = "CAZyme",
+    evidence_mode = "hmm",
+    substrate_label = NA_character_,
+    support = "HMM",
+    typing_eligible = TRUE,
+    evalue = c(1e-20, 1e-30),
+    coverage = c(0.8, 0.9),
+    gene_start = c(1L, 1L),
+    gene_end = c(50L, 60L),
+    dbcan_gene_row = c(1L, 2L)
+  )
+
+  out <- DNMB:::.dnmb_dbcan_output_table(genes, hits, id_map = id_map)
+  expect_identical(out$family_id, c("GH1", "GT2"))
+  expect_identical(out$dbcan_hit, c("GH1", "GT2"))
+})
+
+test_that("dbCAN row mapping survives module merge and append", {
+  genes <- data.frame(
+    locus_tag = c("dup", "dup", NA_character_, NA_character_),
+    protein_id = c("p1", "p2", "p3", "p4"),
+    translation = c("MAAA", "MBBB", "MCCC", "MDDD"),
+    contig = rep("same definition", 4),
+    contig_number = c(1L, 2L, 2L, 3L),
+    start = c(1L, 1L, 100L, 100L),
+    end = c(12L, 12L, 111L, 111L),
+    direction = "+",
+    stringsAsFactors = FALSE
+  )
+  id_map <- DNMB:::.dnmb_dbcan_build_gene_map(genes)
+  hits <- tibble::tibble(
+    query = c("dup", "dup", "p3", "p4"), source = "dbcan",
+    family_system = "dbCAN", family_id = c("GH1", "GT2", "CE1", "CBM2"),
+    hit_label = c("GH1", "GT2", "CE1", "CBM2"), enzyme_role = "CAZyme",
+    evidence_mode = "hmm", substrate_label = NA_character_, support = "HMM",
+    typing_eligible = TRUE, evalue = c(1e-20, 1e-30, 1e-25, 1e-22),
+    coverage = 0.8, gene_start = 1L, gene_end = 50L,
+    dbcan_gene_row = 1:4
+  )
+  dbcan_table <- DNMB:::.dnmb_dbcan_output_table(genes, hits, id_map = id_map)
+  other_table <- genes[, intersect(DNMB:::dnmb_backbone_columns(), names(genes)), drop = FALSE]
+  other_table$locus_tag <- c("legacy_dup", "legacy_dup", NA_character_, NA_character_)
+  other_table$marker <- paste0("m", seq_len(nrow(other_table)))
+  runs <- list(
+    Other = structure(list(database = "Other", output_table = other_table), class = "dnmb_module_run"),
+    dbCAN = structure(list(database = "dbCAN", output_table = dbcan_table), class = "dnmb_module_run")
+  )
+
+  appended <- DNMB:::append_module_results(genes, runs)
+  expect_identical(appended$dbCAN_family_id, c("GH1", "GT2", "CE1", "CBM2"))
+  expect_identical(appended$dbCAN_dbcan_gene_row, 1:4)
+
+  shuffled <- genes[c(2, 1, 4, 3), , drop = FALSE]
+  shuffled_appended <- DNMB:::append_module_results(shuffled, runs)
+  expect_identical(shuffled_appended$protein_id, c("p2", "p1", "p4", "p3"))
+  expect_identical(shuffled_appended$dbCAN_family_id, c("GT2", "GH1", "CBM2", "CE1"))
+  expect_identical(shuffled_appended$dbCAN_dbcan_gene_row, c(2L, 1L, 4L, 3L))
+})
+
+test_that("dbCAN domtblout applies inclusive coverage before overlap filtering", {
+  make_line <- function(query, profile, evalue, profile_from, profile_to, gene_from, gene_to) {
+    fields <- rep("0", 19L)
+    fields[c(1, 3, 4, 6, 13, 16, 17, 18, 19)] <- c(
+      query, "200", profile, "100", format(evalue, scientific = TRUE),
+      profile_from, profile_to, gene_from, gene_to
+    )
+    paste(fields, collapse = " ")
+  }
+  path <- tempfile(fileext = ".domtblout")
+  on.exit(unlink(path, force = TRUE), add = TRUE)
+  writeLines(c(
+    make_line("gene_0001", "GH1.hmm", 1e-40, 1, 20, 1, 80),
+    make_line("gene_0001", "GH2.hmm", 1e-20, 1, 80, 10, 90),
+    make_line("gene_0002", "GH3.hmm", 1e-25, 1, 35, 1, 35)
+  ), path)
+
+  hits <- DNMB:::dnmb_dbcan_parse_domtblout(path, evalue_threshold = 1e-15, coverage_threshold = 0.35)
+  expect_identical(sort(hits$query), c("gene_0001", "gene_0002"))
+  expect_identical(hits$family_id[hits$query == "gene_0001"], "GH2")
+  expect_equal(hits$coverage[hits$query == "gene_0002"], 0.35)
+})
+
+test_that("dbCAN comparative tokens expand all domains once per gene", {
+  calls <- c("CBM34_e14|CBM34_e14|GH13_39", "GH18(2-200)+CBM5_e25")
+  expect_identical(
+    DNMB:::.dnmb_comparative_dbcan_token(calls, level = "family"),
+    c("CBM34", "GH13", "GH18", "CBM5")
+  )
+  expect_identical(
+    DNMB:::.dnmb_comparative_dbcan_token(calls, level = "class"),
+    c("CBM", "GH", "GH", "CBM")
+  )
+})
+
+test_that("dbCAN family substrate prior is explicit and lower priority", {
+  mapping <- tempfile(fileext = ".tsv")
+  on.exit(unlink(mapping, force = TRUE), add = TRUE)
+  writeLines(c(
+    "Substrate_high_level\tSubstrate_curated\tFamily\tName\tEC_Number\tnew_Substrate_high_level\ttype",
+    "xylan\txylan\tGH120\tenzyme\t3.2.1.-\t\t",
+    "starch\tstarch\tGH13\tenzyme\t3.2.1.-\talpha-glucan\tCHANGED",
+    "lignin\tlignin\tAA1\tenzyme\t1.1.1.-\t\tREMOVED",
+    "\t\tGH3\t\"b-glucoside phosphorylase\t\"\t2.4.1.-\tbeta-glucan\tNEW"
+  ), mapping)
+  overview <- tibble::tibble(dbcan_all_families = c("GH120", "GH13_39", "AA1", "GH3"))
+  annotated <- DNMB:::.dnmb_dbcan_add_family_substrate_prior(overview, mapping)
+  expect_identical(
+    annotated$dbcan_family_substrate_prior,
+    c("xylan", "alpha-glucan", NA_character_, "beta-glucan")
+  )
+})
+
+test_that("dbCAN consensus-only overview does not require HMM coordinates", {
+  genes <- make_dbcan_genes()[2, , drop = FALSE]
+  id_map <- DNMB:::.dnmb_dbcan_build_gene_map(genes)
+  path <- tempfile(fileext = ".tsv")
+  on.exit(unlink(path, force = TRUE), add = TRUE)
+  fixture <- data.frame(
+    "Gene ID" = id_map$dbcan_query_id,
+    dbCAN_hmm = "-",
+    dbCAN_sub = "GH20_e1",
+    DIAMOND = "GH20",
+    "#ofTools" = 2L,
+    "Recommend Results" = "GH20_e1",
+    check.names = FALSE
+  )
+  utils::write.table(fixture, path, sep = "\t", row.names = FALSE, quote = FALSE)
+  overview <- DNMB:::dnmb_dbcan_parse_overview(path, id_map = id_map)
+  hits <- DNMB:::.dnmb_dbcan_merge_overview_hits(
+    DNMB:::.dnmb_module_empty_optional_long_table(),
+    overview
+  )
+
+  out <- DNMB:::.dnmb_dbcan_output_table(genes, hits, overview = overview, id_map = id_map)
+  expect_identical(out$dbcan_hit, "GH20")
+  expect_false("dbcan_hmm_domain_count" %in% names(out))
+})
+
+test_that("dbCAN CGC overview keeps dense content on one landscape sheet", {
+  n_clusters <- 25L
+  rows <- lapply(seq_len(n_clusters), function(i) {
+    data.frame(
+      locus_tag = paste0("gene_", i, "_", 1:3),
+      protein_id = paste0("protein_", i, "_", 1:3),
+      contig = "same definition",
+      contig_number = 1L,
+      start = i * 10000L + c(1L, 1001L, 2001L),
+      end = i * 10000L + c(900L, 1900L, 2900L),
+      direction = c("+", "-", "+"),
+      dbCAN_dbcan_all_families = c("GH13_39; CBM34", NA_character_, NA_character_),
+      dbCAN_dbcan_evidence_tier = c("high", NA_character_, NA_character_),
+      dbCAN_substrate_label = c("starch", "starch", "starch"),
+      dbCAN_dbcan_contig_key = "replicon_0001",
+      dbCAN_dbcan_cgc_id = paste0("replicon_0001|CGC", i),
+      dbCAN_dbcan_cgc_gene_type = c("CAZyme", "prodoric", "Sulfatase"),
+      dbCAN_dbcan_cgc_protein_family = c("CAZyme|GH13_39", "prodoric|TF", "Sulfatase|S1"),
+      stringsAsFactors = FALSE
+    )
+  })
+  genes <- dplyr::bind_rows(rows)
+  inputs <- DNMB:::.dnmb_dbcan_read_plot_inputs(genes, tempdir())
+  expect_true(all(c("CAZyme", "TF", "Sulfatase") %in% unique(inputs$cgc$gene_type)))
+  pages <- DNMB:::.dnmb_dbcan_cgc_pages(inputs$cgc, clusters_per_page = 12L)
+  expect_length(pages, 3L)
+  sheet <- DNMB:::.dnmb_dbcan_one_page_layout(inputs)
+  expect_s3_class(sheet$plot, "ggplot")
+  expect_identical(sheet$n_cgc, n_clusters)
+  expect_gte(sheet$width, 14)
+  expect_gt(sheet$height, 9)
+
+  output_dir <- tempfile("dbcan-plot-")
+  dir.create(output_dir)
+  on.exit(unlink(output_dir, recursive = TRUE, force = TRUE), add = TRUE)
+  plot_dir <- file.path(output_dir, "visualizations")
+  dir.create(plot_dir)
+  cazy_path <- file.path(plot_dir, "CAZy_overview.pdf")
+  writeLines("metabolic-map-sentinel", cazy_path, useBytes = TRUE)
+  cazy_md5 <- unname(tools::md5sum(cazy_path))
+
+  result <- DNMB:::.dnmb_plot_dbcan_module(genes, output_dir)
+
+  expect_true(file.exists(result$pdf))
+  expect_identical(basename(result$pdf), "dbcan_cgc_overview.pdf")
+  expect_true(file.exists(cazy_path))
+  expect_identical(unname(tools::md5sum(cazy_path)), cazy_md5)
+  expect_gt(file.info(result$pdf)$size, 1000)
+  expect_identical(result$pages, 1L)
+
+  geometry <- read_dbcan_pdf_geometry(result$pdf)
+  if (!is.null(geometry)) {
+    expect_identical(geometry$pages, 1L)
+    expect_equal(geometry$width_pt, sheet$width * 72, tolerance = 1)
+    expect_equal(geometry$height_pt, sheet$height * 72, tolerance = 1)
+    expect_gt(geometry$width_pt, geometry$height_pt)
+  }
+
+  pdftotext <- Sys.which("pdftotext")
+  if (nzchar(pdftotext)) {
+    page_text_path <- tempfile(fileext = ".txt")
+    on.exit(unlink(page_text_path, force = TRUE), add = TRUE)
+    status <- system2(
+      pdftotext,
+      c("-f", "1", "-l", "1", shQuote(normalizePath(result$pdf)), shQuote(page_text_path)),
+      stdout = FALSE,
+      stderr = FALSE
+    )
+    expect_identical(status, 0L)
+    page_text <- paste(readLines(page_text_path, warn = FALSE), collapse = "\n")
+    expect_match(page_text, "CGC1([^0-9]|$)")
+    expect_match(page_text, paste0("CGC", n_clusters, "([^0-9]|$)"))
+  }
+})
+
+test_that("module plotting keeps the CAZy map separate from dbCAN CGC", {
+  cazy_stub <- NA_character_
+  noop_plot <- function(...) NULL
+  local_mocked_bindings(
+    .dnmb_plot_gapmind_aa_pathway_map = noop_plot,
+    .dnmb_plot_cazy_carbon_transport_map = function(genbank_table, output_dir, file_stub) {
+      cazy_stub <<- file_stub
+      list(pdf = file.path(output_dir, paste0(file_stub, ".pdf")))
+    },
+    .dnmb_plot_defensefinder_module = noop_plot,
+    .dnmb_plot_dbapis_module = noop_plot,
+    .dnmb_plot_acrfinder_module = noop_plot,
+    .dnmb_plot_mrnacal_module = noop_plot,
+    .dnmb_plot_padloc_module = noop_plot,
+    .dnmb_plot_defensepredictor_module = noop_plot,
+    .dnmb_plot_iselement_module = noop_plot,
+    .dnmb_plot_dbcan_module = function(genbank_table, output_dir) {
+      list(pdf = file.path(output_dir, "dbcan_cgc_overview.pdf"))
+    },
+    .dnmb_plot_merops_module = noop_plot,
+    .dnmb_plot_pazy_module = noop_plot,
+    .dnmb_plot_rebasefinder_module = noop_plot,
+    .dnmb_plot_integrated_defense_module = noop_plot,
+    .package = "DNMB"
+  )
+
+  plots <- DNMB:::dnmb_render_module_plots(
+    data.frame(locus_tag = "gene_1", stringsAsFactors = FALSE),
+    output_dir = tempdir()
+  )
+
+  expect_identical(cazy_stub, "CAZy_overview")
+  expect_identical(basename(plots$CAZyTransport$pdf), "CAZy_overview.pdf")
+  expect_identical(basename(plots$dbCAN$pdf), "dbcan_cgc_overview.pdf")
+})
+
+test_that("dbCAN summary renders CGCs when no CAZyme family is assigned", {
+  genes <- make_dbcan_genes()[1:2, ]
+  genes$dbCAN_dbcan_cgc_id <- c("replicon_0001|CGC1", "replicon_0002|CGC1")
+  genes$dbCAN_dbcan_cgc_gene_type <- c("TC", "STP")
+  genes$dbCAN_dbcan_cgc_protein_family <- c("TC|transporter", "STP|sensor")
+
+  inputs <- DNMB:::.dnmb_dbcan_read_plot_inputs(genes, tempdir())
+  expect_equal(nrow(inputs$cazy), 0L)
+  expect_s3_class(DNMB:::.dnmb_dbcan_summary_page(inputs), "ggplot")
+})
+
+test_that("dbCAN genome map paginates hit-containing contigs only", {
+  genes <- data.frame(
+    locus_tag = paste0("gene_", 1:20),
+    protein_id = paste0("protein_", 1:20),
+    contig = paste0("contig ", 1:20),
+    contig_number = 1:20,
+    start = 1L,
+    end = 900L,
+    direction = "+",
+    dbCAN_dbcan_all_families = c(rep("GH1", 17), rep(NA_character_, 3)),
+    dbCAN_dbcan_evidence_tier = "high",
+    stringsAsFactors = FALSE
+  )
+  inputs <- DNMB:::.dnmb_dbcan_read_plot_inputs(genes, tempdir())
+  groups <- DNMB:::.dnmb_dbcan_hit_contig_groups(inputs, contigs_per_page = 8L)
+
+  expect_length(groups, 3L)
+  expect_lte(max(lengths(groups)), 8L)
+  expect_setequal(unlist(groups), sprintf("replicon_%04d", 1:17))
+})
+
+test_that("dbCAN plot separates broad family substrate priors", {
+  domains <- tibble::tibble(
+    family = c("GH1", "GH2"),
+    substrate = c("xylan", paste0("prior", 1:13, collapse = "; ")),
+    substrate_source = c("overview", "family_prior")
+  )
+  supported <- DNMB:::.dnmb_dbcan_matrix_pages(
+    domains,
+    substrates_per_page = 6L,
+    substrate_mode = "supported"
+  )
+  prior <- DNMB:::.dnmb_dbcan_matrix_pages(
+    domains,
+    substrates_per_page = 6L,
+    substrate_mode = "family_prior"
+  )
+
+  expect_length(supported, 1L)
+  expect_setequal(as.character(supported[[1]]$data$substrate), c("xylan", "unknown"))
+  expect_length(prior, 3L)
+  expect_false(any(vapply(prior, function(page) "unknown" %in% as.character(page$data$substrate), logical(1))))
+})
+
+test_that("dbCAN plot overview remaps duplicate locus tags by gene row", {
+  genes <- make_dbcan_genes()[1:2, ]
+  id_map <- DNMB:::.dnmb_dbcan_build_gene_map(genes)
+  genes$dbCAN_dbcan_gene_row <- 1:2
+  genes$dbCAN_dbcan_all_families <- c("GH1", "GT2")
+  genes$dbCAN_dbcan_evidence_tier <- "medium"
+  output_dir <- tempfile("dbcan-plot-map-")
+  run_dir <- file.path(output_dir, "dnmb_module_dbcan", "run_dbcan")
+  dir.create(run_dir, recursive = TRUE)
+  on.exit(unlink(output_dir, recursive = TRUE, force = TRUE), add = TRUE)
+  DNMB:::.dnmb_dbcan_write_gene_map(
+    id_map,
+    file.path(output_dir, "dnmb_module_dbcan", "dbcan_gene_id_map.tsv")
+  )
+  fixture <- data.frame(
+    "Gene ID" = id_map$dbcan_query_id,
+    dbCAN_hmm = c("GH3", "GT4"),
+    dbCAN_sub = c("GH3_e1", "GT4_e1"),
+    DIAMOND = c("GH3", "GT4"),
+    "#ofTools" = 3L,
+    "Recommend Results" = c("GH3_e1", "GT4_e1"),
+    check.names = FALSE
+  )
+  utils::write.table(
+    fixture,
+    file.path(run_dir, "overview.tsv"),
+    sep = "\t",
+    row.names = FALSE,
+    quote = FALSE
+  )
+
+  inputs <- DNMB:::.dnmb_dbcan_read_plot_inputs(genes, output_dir)
+  expect_identical(inputs$genes$dbcan_all_families, c("GH3", "GT4"))
+  expect_identical(inputs$genes$dbcan_gene_row, 1:2)
+})
+
+test_that("dbCAN plot CGC fallback restores synthetic protein IDs", {
+  genes <- make_dbcan_genes()[1:2, ]
+  id_map <- DNMB:::.dnmb_dbcan_build_gene_map(genes)
+  genes$dbCAN_dbcan_gene_row <- 1:2
+  output_dir <- tempfile("dbcan-cgc-map-")
+  run_dir <- file.path(output_dir, "dnmb_module_dbcan", "run_dbcan")
+  dir.create(run_dir, recursive = TRUE)
+  on.exit(unlink(output_dir, recursive = TRUE, force = TRUE), add = TRUE)
+  DNMB:::.dnmb_dbcan_write_gene_map(
+    id_map,
+    file.path(output_dir, "dnmb_module_dbcan", "dbcan_gene_id_map.tsv")
+  )
+  fixture <- data.frame(
+    "CGC#" = c("CGC1", "CGC2"),
+    "Gene Type" = c("TC", "STP"),
+    "Contig ID" = c("ctg1", "ctg2"),
+    "Protein ID" = id_map$dbcan_query_id,
+    "Gene Start" = genes$start,
+    "Gene Stop" = genes$end,
+    "Gene Strand" = genes$direction,
+    "Gene Annotation" = c("TC|transporter", "STP|sensor"),
+    check.names = FALSE
+  )
+  utils::write.table(
+    fixture,
+    file.path(run_dir, "cgc_standard_out.tsv"),
+    sep = "\t",
+    row.names = FALSE,
+    quote = FALSE
+  )
+
+  inputs <- DNMB:::.dnmb_dbcan_read_plot_inputs(genes, output_dir)
+  expect_identical(inputs$cgc$dbcan_gene_row, 1:2)
+  expect_identical(inputs$cgc$dbcan_cgc_id, c("replicon_0001|CGC1", "replicon_0002|CGC2"))
+  expect_identical(inputs$cgc$gene_type, c("TC", "STP"))
+})
+
+test_that("dbCAN cache signature includes the mapping contract", {
+  expect_identical(DNMB:::.dnmb_dbcan_pipeline_contract_version(), 2L)
+  body_text <- paste(deparse(body(DNMB:::dnmb_dbcan_run_standalone)), collapse = "\n")
+  expect_match(body_text, "--threads", fixed = TRUE)
+})
+
+test_that("dbCAN cache signature tracks executable version and path", {
+  tool_version <- "5.2.9"
+  tool_path <- "/opt/dbcan-5.2.9/run_dbcan"
+  local_mocked_bindings(
+    .dnmb_db_manifest_identity = function(...) list(database = "fixture"),
+    dnmb_detect_binary = function(...) list(found = TRUE, path = tool_path),
+    .dnmb_dbcan_tool_version = function() tool_version,
+    .package = "DNMB"
+  )
+  first <- DNMB:::.dnmb_collect_module_db_signatures("dbCAN")$dbCAN
+  tool_version <- "5.3.0"
+  tool_path <- "/opt/dbcan-5.3.0/run_dbcan"
+  second <- DNMB:::.dnmb_collect_module_db_signatures("dbCAN")$dbCAN
+
+  expect_identical(first$run_dbcan_version, "5.2.9")
+  expect_identical(second$run_dbcan_version, "5.3.0")
+  expect_false(identical(first, second))
+})
+
+test_that("dbCAN standalone readiness requires all v5 CGC assets", {
+  root <- tempfile("dbcan-bundle-")
+  dir.create(root)
+  on.exit(unlink(root, recursive = TRUE, force = TRUE), add = TRUE)
+  paths <- DNMB:::.dnmb_dbcan_supporting_paths(root)
+  files <- c(
+    paths$hmm_txt, paste0(paths$hmm_txt, c(".h3f", ".h3i", ".h3m", ".h3p")),
+    paths$fam_substrate_mapping, paths$pul_dmnd, paths$pul_excel,
+    paths$tcdb_dmnd, paths$tf_hmm, paths$tf_dmnd, paths$stp_hmm,
+    paste0(paths$stp_hmm, c(".h3f", ".h3i", ".h3m", ".h3p")),
+    paste0(paths$tf_hmm, c(".h3f", ".h3i", ".h3m", ".h3p")),
+    paths$cazy_dmnd, paths$peptidase_dmnd, paths$sulfatlas_dmnd,
+    paths$dbcan_sub_hmm,
+    paste0(paths$dbcan_sub_hmm, c(".h3f", ".h3i", ".h3m", ".h3p"))
+  )
+  file.create(files)
+  dir.create(paths$pul_dir)
+  expect_true(DNMB:::.dnmb_dbcan_standalone_ready(paths))
+  unlink(paths$peptidase_dmnd)
+  expect_false(DNMB:::.dnmb_dbcan_standalone_ready(paths))
+  file.create(paths$peptidase_dmnd)
+  unlink(paths$pul_dir, recursive = TRUE)
+  expect_false(DNMB:::.dnmb_dbcan_standalone_ready(paths))
+})
+
+test_that("dbCAN recognizes the v5 synteny_pdf directory", {
+  root <- tempfile("dbcan-synteny-")
+  dir.create(file.path(root, "synteny_pdf"), recursive = TRUE)
+  on.exit(unlink(root, recursive = TRUE, force = TRUE), add = TRUE)
+  expect_identical(
+    DNMB:::.dnmb_dbcan_synteny_output_dir(root),
+    file.path(root, "synteny_pdf")
+  )
+})
+
+test_that("dbCAN retries HMMER when standalone execution fails", {
+  root <- tempfile("dbcan-fallback-")
+  dir.create(root)
+  on.exit(unlink(root, recursive = TRUE, force = TRUE), add = TRUE)
+  fallback_called <- FALSE
+  empty_result <- function(ok, component) list(
+    ok = ok,
+    status = DNMB:::.dnmb_dbcan_status_row(component, if (ok) "ok" else "failed", "fixture"),
+    files = list(), manifest = NULL,
+    raw_hits = DNMB:::.dnmb_dbcan_empty_hits(),
+    hits = DNMB:::.dnmb_module_empty_optional_long_table(),
+    overview = DNMB:::.dnmb_dbcan_empty_overview(),
+    cgc_genes = tibble::tibble(), substrate = tibble::tibble()
+  )
+  local_mocked_bindings(
+    dnmb_detect_binary = function(...) list(found = TRUE, message = "fixture"),
+    dnmb_dbcan_run_standalone = function(...) empty_result(FALSE, "standalone_fixture"),
+    dnmb_dbcan_run_hmmsearch = function(...) {
+      fallback_called <<- TRUE
+      empty_result(TRUE, "hmm_fixture")
+    },
+    .package = "DNMB"
+  )
+  genes <- make_dbcan_genes()[1, , drop = FALSE]
+  result <- DNMB:::dnmb_run_dbcan_module(genes, root, install = FALSE)
+
+  expect_true(result$ok)
+  expect_true(fallback_called)
+  expect_true(all(c("standalone_fixture", "run_dbcan_fallback", "hmm_fixture") %in% result$status$component))
+})
+
+test_that("comparative dbCAN collector accepts legacy overview headers", {
+  root <- tempfile("dbcan-comparative-")
+  genome <- file.path(root, "Genome_A")
+  run_dir <- file.path(genome, "dnmb_module_dbcan", "run_dbcan")
+  dir.create(run_dir, recursive = TRUE)
+  on.exit(unlink(root, recursive = TRUE, force = TRUE), add = TRUE)
+  writeLines(c("LOCUS       FIXTURE", "//"), file.path(genome, "fixture.gbff"))
+  fixture <- data.frame(
+    "Protein ID" = c("p1", "p2", "p3"),
+    HMMER = c("GH5(1-100)", "-", "-"),
+    "dbCAN-sub" = c("-", "CBM2_e1", "-"),
+    diamond = c("-", "-", "GT4"),
+    "Recommended Results" = c("-", "-", "-"),
+    check.names = FALSE
+  )
+  utils::write.table(
+    fixture, file.path(run_dir, "overview.tsv"), sep = "\t",
+    row.names = FALSE, quote = FALSE
+  )
+  collected <- DNMB:::.dnmb_comparative_collect_dbcan(
+    root,
+    marker_rel = file.path("dnmb_module_dbcan", "run_dbcan", "overview.tsv"),
+    level = "family",
+    verbose = FALSE
+  )
+  expect_setequal(collected$systems$subtype, c("GH5", "CBM2", "GT4"))
+})
+
+test_that("dbCAN zero-protein completion sentinel is cacheable", {
+  root <- tempfile("dbcan-empty-cache-")
+  module_dir <- file.path(root, "dnmb_module_dbcan")
+  dir.create(module_dir, recursive = TRUE)
+  on.exit(unlink(root, recursive = TRUE, force = TRUE), add = TRUE)
+  file.create(file.path(module_dir, "dbcan_query_proteins.faa"))
+  writeLines("dbcan_gene_row\tdbcan_query_id", file.path(module_dir, "dbcan_gene_id_map.tsv"))
+  DNMB:::.dnmb_module_write_completion_sentinel("dbCAN", wd = root, n_hits = 0L)
+
+  expect_true(DNMB:::.dnmb_module_stage_artifacts_exist("dbCAN", wd = root))
+})
+
+test_that("dbCAN empty input removes stale standalone outputs", {
+  root <- tempfile("dbcan-stale-")
+  stale_dir <- file.path(root, "run_dbcan")
+  dir.create(stale_dir, recursive = TRUE)
+  on.exit(unlink(root, recursive = TRUE, force = TRUE), add = TRUE)
+  writeLines("stale", file.path(stale_dir, "overview.tsv"))
+  genes <- make_dbcan_genes()[4, , drop = FALSE]
+
+  result <- DNMB:::dnmb_run_dbcan_module(genes, root, install = FALSE)
+  expect_true(result$ok)
+  expect_false(dir.exists(stale_dir))
+})
+
+test_that("GapMind carbon step status preserves best-path primary and positive secondary loci", {
+  root <- tempfile("gapmind-carbon-steps-")
+  module_dir <- file.path(root, "dnmb_module_gapmindcarbon")
+  dir.create(module_dir, recursive = TRUE)
+  on.exit(unlink(root, recursive = TRUE, force = TRUE), add = TRUE)
+  steps <- data.frame(
+    pathway = c("arabinose", "galactose", "xylose"),
+    step = c("araE", "galP", "xylT"),
+    onBestPath = c(1, 1, 0),
+    score = c(0, 2, 2),
+    locusId = c("LOC_PRIMARY_ZERO", "LOC_PRIMARY_HIGH", "LOC_OFF_PATH"),
+    score2 = c(2, 0, 2),
+    locusId2 = c("LOC_SECONDARY_HIGH", "LOC_SECONDARY_ZERO", "LOC_OFF_PATH_2"),
+    stringsAsFactors = FALSE
+  )
+  utils::write.table(
+    steps,
+    file.path(module_dir, "aa.sum.steps"),
+    sep = "\t",
+    row.names = FALSE,
+    quote = FALSE
+  )
+
+  status <- DNMB:::.dnmb_gapmind_carbon_step_status(data.frame(), output_dir = root)
+
+  expect_identical(
+    names(status),
+    c("pathway_id", "step_id", "confidence", "locus_tag")
+  )
+  expect_setequal(
+    paste(status$pathway_id, status$step_id, status$locus_tag, status$confidence, sep = "::"),
+    c(
+      "arabinose::araE::LOC_PRIMARY_ZERO::none",
+      "arabinose::araE::LOC_SECONDARY_HIGH::high",
+      "galactose::galP::LOC_PRIMARY_HIGH::high"
+    )
+  )
+  expect_false(any(status$locus_tag %in% c("LOC_SECONDARY_ZERO", "LOC_OFF_PATH", "LOC_OFF_PATH_2")))
+})
+
+test_that("GapMind carbon workbook fallback keeps distinct loci per step", {
+  workbook <- data.frame(
+    GapMindCarbon_pathway_id = rep("arabinose", 4),
+    GapMindCarbon_step_id = rep("araE", 4),
+    GapMindCarbon_confidence = c("low", "high", "medium", "none"),
+    GapMindCarbon_on_best_path = c(TRUE, TRUE, 1, FALSE),
+    locus_tag = c("LOC_A", "LOC_A", "LOC_B", "LOC_IGNORED"),
+    stringsAsFactors = FALSE
+  )
+
+  status <- DNMB:::.dnmb_gapmind_carbon_step_status(workbook)
+
+  expect_identical(
+    status[, c("locus_tag", "confidence")],
+    data.frame(
+      locus_tag = c("LOC_A", "LOC_B"),
+      confidence = c("high", "medium"),
+      stringsAsFactors = FALSE
+    )
+  )
+})


### PR DESCRIPTION
## What changed
- Modernized dbCAN multi-domain/evidence parsing, CGC mapping, duplicate-locus row stability, and cache/API integration.
- Improved CAZy carbon-map routing, transporter continuity, SNFG icons and labels, and central-metabolism evidence.
- Converted the dbCAN CGC overview to a dynamic one-page poster with horizontal legends and consistently aligned panel titles.
- Added focused CAZy/dbCAN regression tests.

## Why
- dbCAN v5-style multi-domain evidence and duplicate locus tags were not preserved reliably.
- Route consolidation and inconsistent icon/layout scaling could obscure or disconnect CAZy pathway information.
- The CGC visualization explicitly paginated content and used inconsistent panel-title alignment.

## Validation
- `Rscript -e 'devtools::test(reporter="summary")'`
- `git diff --check`
- Verified the KCTC 1825 outputs: `dbcan_cgc_overview.pdf` renders as one page and the CAZy overview was visually reviewed.